### PR TITLE
Minor fix to remove a space if the title doesn't contain the team name

### DIFF
--- a/scripts/sql2html.pl
+++ b/scripts/sql2html.pl
@@ -132,11 +132,13 @@ my $link_text = 'columns';
 ##############
 ### Header ###
 ##############
+my $title  = (defined($db_team)) ? "$db_team " : '';
+   $title .= 'Schema Documentation';
 
 my $html_header = qq{
 <html>
 <head>
-<title>$db_team Schema Documentation</title>
+<title>$title</title>
 <meta name="order" content="2" />
 
 <script language="Javascript" type="text/javascript">


### PR DESCRIPTION
This is a minor change for the script sql2html.pl
