### PR TITLE
Extra relationship terms to compute closures over

### DIFF
--- a/scripts/ontology/scripts/compute_closure.pl
+++ b/scripts/ontology/scripts/compute_closure.pl
@@ -106,7 +106,8 @@ SELECT DISTINCT child_term_id, parent_term_id, 1, child_term_id, ontology_id
 FROM    relation r,
         relation_type rt
 WHERE rt.name IN (
-    'is_a', 'part_of' -- in both GO and SO
+    'is_a', 'part_of', -- in both GO and SO
+    'output_of', 'has_output', 'results_in_formation_of' -- Used in FYPO as a relationship
     -- THE FOLLOWING ARE REMOVED FOR NOW
     -- 'has_part', 'derives_from', 'member_of' -- in SO only
   )


### PR DESCRIPTION
I have added 3 new relationship types that should be included when calculating the closures table.

These only affect the FYPO ontology and the terms aren't present in GO or SO.

The terms that have been added are 'output_of', 'has_output' and 'results_in_formation_of'
