### PR TITLE
Update compute_closure.pl to allow cross aspect relationships

### DIFF
--- a/scripts/ontology/scripts/compute_closure.pl
+++ b/scripts/ontology/scripts/compute_closure.pl
@@ -169,9 +169,13 @@ my $select_sth = $dbh->prepare(
      FROM  closure child
      JOIN  closure parent
        ON  (parent.child_term_id = child.parent_term_id)
+     JOIN  ontology co
+       ON  (child.ontology_id=co.ontology_id)
+     JOIN  ontology po
+       ON  (parent.ontology_id=po.ontology_id)
     WHERE  child.distance  = ?
       AND  parent.distance = 1
-      AND  child.ontology_id = parent.ontology_id/
+      AND  co.name = po.name/
 );
 
 my $insert_sth = $dbh->prepare(


### PR DESCRIPTION
This change moves the requirement for the 2 terms to be part of the same ontology rather than the same namespace/aspect. The means that it is able to capture closures where a term in "molecular_function" is "part_of" a "biological process". See the GO terms GO:0061727, GO:0051596, GO:0019243 and GO:0019172