### PR TITLE
Regular expression changes to cater for filename consistency

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/GFF3/DumpFile.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/GFF3/DumpFile.pm
@@ -108,9 +108,9 @@ sub run {
     if ($slice->is_reference) {
       if ($slice->is_chromosome) {
         if ($per_chromosome) {
-          my $slice_name = 'chromosome.' . $slice->seq_region_name;
+          my $slice_name = '.chromosome.' . $slice->seq_region_name;
           my $chr_file = $out_file;
-          $chr_file =~ s/([^\.]+)$/$slice_name.$1/;
+          $chr_file =~ s/\.gff3/$slice_name\.gff3/;
           $self->print_to_file([$slice], $chr_file, $feature_types, \%adaptors, 1);
           push @$out_files, $chr_file;
         }
@@ -118,9 +118,9 @@ sub run {
       }
       else {
         if ($per_chromosome) {
-          my $slice_name = 'nonchromosomal';
+          my $slice_name = '.nonchromosomal';
           my $chr_file = $out_file;
-          $chr_file =~ s/([^\.]+)$/$slice_name.$1/;
+          $chr_file =~ s/\.gff3/$slice_name\.gff3/; 
           $self->print_to_file([$slice], $chr_file, $feature_types, \%adaptors, 1);
           push @$out_files, $chr_file;
         }


### PR DESCRIPTION
Regular expression changes to cater for filename consistency when turning on per_chromosome flag