### PR TITLE
Inter aspect closures to map over is_a and part_of

### DIFF
--- a/scripts/ontology/scripts/compute_closure.pl
+++ b/scripts/ontology/scripts/compute_closure.pl
@@ -107,13 +107,16 @@ $dbh->do(
          WHERE  is_obsolete = 0/ );
 
 print "Importing inter-ontology parent-child relations\n";
+my $rels_join_xaspect = join ',', map { "'$_'" } @$default_relations;
 $dbh->do(
   q/
    INSERT IGNORE INTO  closure
                        (child_term_id, parent_term_id, distance, subparent_term_id, ontology_id)
                SELECT  term_id, term_id, 0, NULL, r.ontology_id
-                 FROM  term t, relation r
+                 FROM  term t, relation r, relation_type rt
                 WHERE  term_id = child_term_id
+                  AND  r.relation_type_id=rt.relation_type_id
+                  AND  rt.name IN ($rels_join_xaspect)
                   AND  t.ontology_id != r.ontology_id
                   AND  is_obsolete = 0/ );
 


### PR DESCRIPTION
Modified the inter ontology import for retrieving parents of a child term to restrict it to is_a and part_of. In cases where there are more relationships that just the basic 2 this causes querying issues in the marts. For example querying with GO:0008233 would get features annotated with GO:0007866 as well