### PR TITLE
Strip colon from slim names

### DIFF
--- a/scripts/ontology/scripts/load_OBO_file.pl
+++ b/scripts/ontology/scripts/load_OBO_file.pl
@@ -141,6 +141,7 @@ sub write_subset {
 
   foreach my $subset_name (sort(keys(%{$subsets}))) {
     my $subset = $subsets->{$subset_name};
+    $subset->{'name'} =~ s/:/_/g;
 
     if (!(defined($subset->{'name'}) && defined($subset->{'definition'}))) {
       print "Null value encountered: subset name " . $subset->{'name'} . " subset definition " . $subset->{'definition'} . "\n";
@@ -218,6 +219,7 @@ sub write_term {
 
     if (exists($term->{'subsets'})) {
       $term_subsets = join(',', map { $subsets->{$_}{'name'} } @{$term->{'subsets'}});
+      $term_subsets =~ s/:/_/g;
     }
 
     if (!defined($term->{'name'})) {


### PR DESCRIPTION
Added in a couple of lines to replace : with _ when loading slim names. This is to prevent aux_<slim>_map tables names including colons.