### PR TITLE
Removed the direct import of a specific ONTO-PERL

### DIFF
--- a/scripts/ontology/scripts/load_OBO_file.pl
+++ b/scripts/ontology/scripts/load_OBO_file.pl
@@ -17,8 +17,8 @@
 use strict;
 use warnings;
 #TODO Do we need this?
-use FindBin;
-use lib "$FindBin::Bin/../../../../ONTO-PERL-1.31/lib";
+#use FindBin;
+#use lib "$FindBin::Bin/../../../../ONTO-PERL-1.31/lib";
 
 use DBI qw( :sql_types );
 use Getopt::Long qw( :config no_ignore_case );

--- a/scripts/ontology/scripts/load_OBO_file.pl
+++ b/scripts/ontology/scripts/load_OBO_file.pl
@@ -16,9 +16,6 @@
 
 use strict;
 use warnings;
-#TODO Do we need this?
-#use FindBin;
-#use lib "$FindBin::Bin/../../../../ONTO-PERL-1.31/lib";
 
 use DBI qw( :sql_types );
 use Getopt::Long qw( :config no_ignore_case );


### PR DESCRIPTION
Term accessions can now include characters other than those represented by the \w regexp. The developer is modifying the ONTO-PERL code and will submit those soon.

This change requires that there is ONTO-PERL in your PERL5LIB. The latest version (1.45) works for me on 5.14.2