### PR TITLE
Adding ability to specify compara division for gene tree highlighting

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/GeneTreeHighlight/HighlightGO.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/GeneTreeHighlight/HighlightGO.pm
@@ -44,15 +44,16 @@ sub param_defaults {
 
 sub fetch_input {
     my ($self) = @_;
+    my $compara_division = $self->param('compara_division');
 
-    my $division = $self->division();
+    my $division = $compara_division || $self->division();
     my $gdba     = Bio::EnsEMBL::Registry->get_adaptor($division, 'compara', 'GenomeDB');
     my $odba     = Bio::EnsEMBL::Registry->get_adaptor('Multi','Ontology','OntologyTerm');
 
     die "Can't get GenomeDB Adaptor for $division - check that database exist in the server specified" if (!$gdba);
     die "Can't get OntologyTerm Adaptor - check that database exist in the server specified" if (!$odba);
     confess('Not a OntologyTermAdaptor object, type error!') unless($odba->isa('Bio::EnsEMBL::DBSQL::OntologyTermAdaptor'));
-    
+
    my $db_name = 'GO';
 
    my $go_sql  = qq/
@@ -63,8 +64,8 @@ sub fetch_input {
 	join translation t on (t.translation_id=ox.ensembl_id and ox.ensembl_object_type='Translation')
 	join transcript tc using (transcript_id)
 	join gene g using (gene_id)
-	join seq_region s on (g.seq_region_id=s.seq_region_id) 
-	join coord_system c using (coord_system_id)  
+	join seq_region s on (g.seq_region_id=s.seq_region_id)
+	join coord_system c using (coord_system_id)
 	where db.db_name='$db_name' and c.species_id=?
 	UNION
 	select distinct g.stable_id,x.dbprimary_acc
@@ -73,11 +74,11 @@ sub fetch_input {
 	join object_xref ox using (xref_id)
 	join transcript tc on (tc.transcript_id=ox.ensembl_id and ox.ensembl_object_type='Transcript')
 	join gene g using (gene_id)
-	join seq_region s on (g.seq_region_id=s.seq_region_id) 
-	join coord_system c using (coord_system_id)  
+	join seq_region s on (g.seq_region_id=s.seq_region_id)
+	join coord_system c using (coord_system_id)
 	where db.db_name='$db_name' and c.species_id=?
 	/;
- 
+
    my $go_parent_sql = qq/
 	SELECT DISTINCT
         parent_term.accession, parent_term.name
@@ -101,28 +102,28 @@ return 0;
 
 sub run {
     my ($self)  = @_;
-    my $species       = $self->param_required('species'); 
+    my $species       = $self->param_required('species');
     my $db_name       = $self->param_required('db_name');
     my $gdba          = $self->param_required('gdba');
     my $odba          = $self->param_required('odba');
     my $go_sql        = $self->param_required('go_sql');
     my $go_parent_sql = $self->param_required('go_parent_sql');
     my $dbc           = $gdba->db()->dbc();
-    my $go_parents    = {};   
+    my $go_parents    = {};
 
     my $xref_adaptor = Bio::EnsEMBL::Compara::DBSQL::XrefAssociationAdaptor->new($dbc);
     my @genome_dbs   = grep { $_->name() ne 'ancestral_sequences' } @{$gdba->fetch_all()};
     @genome_dbs      = grep { $_->name() eq $species } @genome_dbs if(defined $species);
-    
+
     for my $genome_db (@genome_dbs) {
       my $core_dba = $genome_db->db_adaptor();
       $self->info("Processing " . $core_dba->species() . "\n");
       $self->info("Cleaning up member_xref for " . $core_dba->species() . "\n");
 
       $dbc->sql_helper()->execute_update(
-      	-SQL=>q/delete mx.* from member_xref mx 
-      	join external_db e using (external_db_id) 
-   	join gene_member m using (gene_member_id) 
+      	-SQL=>q/delete mx.* from member_xref mx
+      	join external_db e using (external_db_id)
+   	join gene_member m using (gene_member_id)
 	join genome_db g using (genome_db_id) where e.db_name=? and g.name=?/,
 	-PARAMS=>[$db_name, $core_dba->species()]);
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/GeneTreeHighlight/HighlightInterPro.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/GeneTreeHighlight/HighlightInterPro.pm
@@ -43,8 +43,9 @@ sub param_defaults {
 
 sub fetch_input {
     my ($self) = @_;
+    my $compara_division = $self->param('compara_division');
 
-    my $division = $self->division();
+    my $division = $compara_division || $self->division();
     my $gdba     = Bio::EnsEMBL::Registry->get_adaptor($division, 'compara', 'GenomeDB');
     my $odba     = Bio::EnsEMBL::Registry->get_adaptor('Multi','Ontology','OntologyTerm');
 
@@ -59,10 +60,10 @@ sub fetch_input {
 	join protein_feature pf on (pf.hit_name=i.id)
 	join translation t using (translation_id)
 	join transcript tc using (transcript_id)
-	join gene g using (gene_id) 
-	join seq_region s on (g.seq_region_id=s.seq_region_id) 
-	join coord_system c using (coord_system_id)  
-	where c.species_id=?/; 
+	join gene g using (gene_id)
+	join seq_region s on (g.seq_region_id=s.seq_region_id)
+	join coord_system c using (coord_system_id)
+	where c.species_id=?/;
 
    $self->param('db_name', $db_name);
    $self->param('gdba', $gdba);
@@ -74,7 +75,7 @@ return 0;
 
 sub run {
     my ($self)  = @_;
-    my $species       = $self->param_required('species'); 
+    my $species       = $self->param_required('species');
     my $db_name       = $self->param_required('db_name');
     my $gdba          = $self->param_required('gdba');
     my $odba          = $self->param_required('odba');
@@ -84,16 +85,16 @@ sub run {
     my $xref_adaptor = Bio::EnsEMBL::Compara::DBSQL::XrefAssociationAdaptor->new($dbc);
     my @genome_dbs   = grep { $_->name() ne 'ancestral_sequences' } @{$gdba->fetch_all()};
     @genome_dbs      = grep { $_->name() eq $species } @genome_dbs if(defined $species);
-    
+
     for my $genome_db (@genome_dbs) {
       my $core_dba = $genome_db->db_adaptor();
       $self->info("Processing " . $core_dba->species() . "\n");
       $self->info("Cleaning up member_xref for " . $core_dba->species() . "\n");
 
       $dbc->sql_helper()->execute_update(
-      	-SQL=>q/delete mx.* from member_xref mx 
-      	join external_db e using (external_db_id) 
-   	join gene_member m using (gene_member_id) 
+      	-SQL=>q/delete mx.* from member_xref mx
+      	join external_db e using (external_db_id)
+   	join gene_member m using (gene_member_id)
 	join genome_db g using (genome_db_id) where e.db_name=? and g.name=?/,
 	-PARAMS=>[$db_name, $core_dba->species()]);
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GeneTreeHighlighting_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GeneTreeHighlighting_conf.pm
@@ -143,7 +143,7 @@ sub pipeline_analyses {
 
     { -logic_name     => 'highlight_go',
       -module         => 'Bio::EnsEMBL::Production::Pipeline::GeneTreeHighlight::HighlightGO',
-      -hive_capacity  => 10,
+      -hive_capacity   => $self->o('highlighting_capacity'),
       -parameters      => {
                             compara_division => $self->o('compara_division'),
                           },
@@ -152,7 +152,7 @@ sub pipeline_analyses {
 
     { -logic_name     => 'highlight_interpro',
       -module         => 'Bio::EnsEMBL::Production::Pipeline::GeneTreeHighlight::HighlightInterPro',
-      -hive_capacity  => 10,
+      -hive_capacity   => $self->o('highlighting_capacity'),
       -parameters      => {
                             compara_division => $self->o('compara_division'),
                           },

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GeneTreeHighlighting_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GeneTreeHighlighting_conf.pm
@@ -21,9 +21,9 @@ limitations under the License.
 
 =head1 DESCRIPTION
 
-=head1 AUTHOR 
+=head1 AUTHOR
 
- ckong@ebi.ac.uk 
+ ckong@ebi.ac.uk
 
 =cut
 package Bio::EnsEMBL::Production::Pipeline::PipeConfig::GeneTreeHighlighting_conf;
@@ -33,29 +33,32 @@ use warnings;
 use File::Spec;
 use Bio::EnsEMBL::Hive::Version 2.3;
 use Bio::EnsEMBL::ApiVersion qw/software_version/;
-use base ('Bio::EnsEMBL::Hive::PipeConfig::EnsemblGeneric_conf');  
+use base ('Bio::EnsEMBL::Hive::PipeConfig::EnsemblGeneric_conf');
 
 sub default_options {
     my ($self) = @_;
 
     return {
         # inherit other stuff from the base class
-        %{ $self->SUPER::default_options() },      
+        %{ $self->SUPER::default_options() },
 
 	## General parameters
-    'registry'      => $self->o('registry'),   
+    'registry'      => $self->o('registry'),
     'release'       => $self->o('release'),
-    'pipeline_name' => $self->o('hive_db'),       
+    'pipeline_name' => $self->o('hive_db'),
     'email'         => $self->o('ENV', 'USER').'@ebi.ac.uk',
-    'output_dir'    => '/nfs/nobackup/ensemblgenomes/'.$self->o('ENV', 'USER').'/workspace/'.$self->o('pipeline_name'),     
+    'output_dir'    => '/nfs/nobackup/ensemblgenomes/'.$self->o('ENV', 'USER').'/workspace/'.$self->o('pipeline_name'),
 
 	## 'job_factory' parameters
-    'division'      => [], 
+    'division'      => [],
+
+    ## Allow division of compara database to be explicitly specified
+    'compara_division' => undef,
 
     # hive_capacity values for analysis
 	'highlighting_capacity'  => '50',
 
-    'pipeline_db' => {  
+    'pipeline_db' => {
 	   	 -host   => $self->o('hive_host'),
       	 -port   => $self->o('hive_port'),
       	 -user   => $self->o('hive_user'),
@@ -63,7 +66,7 @@ sub default_options {
 	     -dbname => $self->o('hive_db'),
       	 -driver => 'mysql',
      },
-		
+
     };
 }
 
@@ -79,7 +82,7 @@ sub pipeline_create_commands {
 # Ensures output parameters gets propagated implicitly
 sub hive_meta_table {
   my ($self) = @_;
-  
+
   return {
     %{$self->SUPER::hive_meta_table},
     'hive_use_param_stack'  => 1,
@@ -89,14 +92,14 @@ sub hive_meta_table {
 # override the default method, to force an automatic loading of the registry in all workers
 sub beekeeper_extra_cmdline_options {
   my ($self) = @_;
-  return 
+  return
       ' -reg_conf ' . $self->o('registry'),
   ;
 }
 
-# these parameter values are visible to all analyses, 
+# these parameter values are visible to all analyses,
 # can be overridden by parameters{} and input_id{}
-sub pipeline_wide_parameters {  
+sub pipeline_wide_parameters {
     my ($self) = @_;
     return {
             %{$self->SUPER::pipeline_wide_parameters},    # here we inherit anything from the base class
@@ -121,9 +124,9 @@ sub pipeline_analyses {
     return [
     {  -logic_name => 'backbone_fire_GeneTreeHighlighting',
        -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
-       -input_ids  => [ {} ] , 
+       -input_ids  => [ {} ] ,
        -flow_into  => { '1' => ['job_factory'], }
-    },   
+    },
 
     { -logic_name  => 'job_factory',
        -module     => 'Bio::EnsEMBL::Production::Pipeline::BaseSpeciesFactory',
@@ -131,24 +134,30 @@ sub pipeline_analyses {
                         division    => $self->o('division'),
                       },
       -hive_capacity   => -1,
-      -rc_name 	       => 'default',     
+      -rc_name 	       => 'default',
       -max_retry_count => 1,
       -flow_into      => {'2->A' => ['highlight_go'],
                           'A->2' => ['highlight_interpro'],
-                         }		                       
-    },	   
+                         }
+    },
 
     { -logic_name     => 'highlight_go',
       -module         => 'Bio::EnsEMBL::Production::Pipeline::GeneTreeHighlight::HighlightGO',
       -hive_capacity  => 10,
-      -rc_name 	      => 'default',     
-    },   
+      -parameters      => {
+                            compara_division => $self->o('compara_division'),
+                          },
+      -rc_name 	      => 'default',
+    },
 
     { -logic_name     => 'highlight_interpro',
       -module         => 'Bio::EnsEMBL::Production::Pipeline::GeneTreeHighlight::HighlightInterPro',
       -hive_capacity  => 10,
-      -rc_name 	      => 'default',     
-    },       	 	 
+      -parameters      => {
+                            compara_division => $self->o('compara_division'),
+                          },
+      -rc_name 	      => 'default',
+    },
   ];
 }
 


### PR DESCRIPTION
For VectorBase the compara db has 'vb' instead of a division; the modules were deriving the division from the core dbs, which have 'metazoa' set instead. So I added the ability to specify it as a parameter. (It seems like this functionality would also be required to run the pipeline on the 'pan_homology' db too, but I didn't test that.)

Also, I noticed that a capacity parameter was provided in the config, but never applied, so I added that.

Unfortunately my editor has removed trailing whitespace without me realising; so that's muddied the waters of the commit. Let me know if you want a fresh commit without those changes.