### PR TITLE
bugfix: allow "INDEX (column_name)" indices

### DIFF
--- a/scripts/sql2html.pl
+++ b/scripts/sql2html.pl
@@ -361,7 +361,7 @@ while (<SQLFILE>) {
         add_column_index("$1",$3,$2);
         next;
       }
-      elsif ($doc =~ /^\s*(key)\s+\((.+)\)/i) { # Keys
+      elsif ($doc =~ /^\s*(key|index)\s+\((.+)\)/i) { # Keys
         add_column_index("$1",$2);
         next;
       }


### PR DESCRIPTION
Indices of this table were not parsed:
```sql
CREATE TABLE exon_boundaries (
        gene_member_id   INT(10) UNSIGNED NOT NULL,
        seq_member_id    INT(10) UNSIGNED NOT NULL,
        dnafrag_start    INT NOT NULL,
        dnafrag_end      INT NOT NULL,
        sequence_length  INT(10) UNSIGNED NOT NULL,
        left_over        TINYINT(1) DEFAULT 0 NOT NULL,
        INDEX (seq_member_id),
        INDEX (gene_member_id)
) ENGINE=MyISAM;
```