### PR TITLE
Split functionality of SpeciesFactory module into two modules, ...

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Common/DbFactory.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Common/DbFactory.pm
@@ -1,0 +1,324 @@
+
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2017] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+ Bio::EnsEMBL::Production::Pipeline::Common::DbFactory;
+
+=head1 DESCRIPTION
+
+ Given a division or a list of species, dataflow jobs with database names.
+
+=cut
+
+package Bio::EnsEMBL::Production::Pipeline::Common::DbFactory;
+
+use strict;
+use warnings;
+
+use Bio::EnsEMBL::Registry;
+use base qw/Bio::EnsEMBL::Production::Pipeline::Common::Base/;
+
+sub param_defaults {
+  my ($self) = @_;
+
+  return { species      => [],
+           taxons       => [],
+           division     => [],
+           run_all      => 0,
+           antispecies  => [],
+           antitaxons   => [],
+           db_list_flow => 1,
+           db_flow      => 2,
+           compara_flow => 5, # compara_flow moved here from SpeciesFactory; retain former flow #5 here, to avoid bugs
+           div_synonyms => { 'eb'  => 'bacteria',
+                             'ef'  => 'fungi',
+                             'em'  => 'metazoa',
+                             'epl' => 'plants',
+                             'epr' => 'protists',
+                             'e'   => 'ensembl' },
+           meta_filters => {},
+           db_type      => 'core',
+  };
+}
+
+sub run {
+  my ($self) = @_;
+  my @species      = @{ $self->param('species') };
+  my @taxons       = @{ $self->param('taxons') };
+  my @division     = @{ $self->param('division') };
+  my $run_all      = $self->param('run_all');
+  my @antispecies  = @{ $self->param('antispecies') };
+  my @antitaxons   = @{ $self->param('antitaxons') };
+  my %meta_filters = %{ $self->param('meta_filters') };
+  my $db_type      = $self->param_required('db_type');
+
+  my $reg = 'Bio::EnsEMBL::Registry';
+
+  my $taxonomy_dba = $reg->get_DBAdaptor( 'multi', 'taxonomy' );
+
+  my $all_dbas = $reg->get_all_DBAdaptors( -GROUP => $db_type );
+  my %dbs;
+
+  my $all_compara_dbas;
+  if ($self->param('compara_flow')) {
+    $all_compara_dbas = $reg->get_all_DBAdaptors( -GROUP => 'compara' );
+  }
+  my %compara_dbs;
+
+  if ( ! scalar(@$all_dbas) && ! scalar(@$all_compara_dbas) ) {
+    $self->throw("No $db_type or compara databases found in the registry");
+  }
+
+  if ($run_all) {
+    foreach my $dba (@$all_dbas) {
+      $self->add_species($dba, \%dbs);
+    }
+    delete $dbs{'Ancestral sequences'};
+    $self->warning("All species in " . scalar(keys %dbs) . " databases loaded");
+    
+    %compara_dbs = map { $_->dbc->dbname => $_->species } @$all_compara_dbas;
+  }
+  elsif ( scalar(@species) ) {
+    foreach my $species (@species) {
+      $self->process_species( $all_dbas, $species, \%dbs );
+    }
+  }
+  elsif ( scalar(@taxons) ) {
+    foreach my $taxon (@taxons) {
+      $self->process_taxon( $all_dbas , $taxonomy_dba, $taxon, "add", \%dbs );
+    }
+  }
+  elsif ( scalar(@division) ) {
+    foreach my $division (@division) {
+      $self->process_division( $all_dbas, $division, \%dbs );
+      $self->process_division_compara( $all_compara_dbas, $division, \%compara_dbs );
+    }
+  }
+
+  if ( scalar(@antitaxons) ) {
+    foreach my $antitaxon (@antitaxons) {
+      $self->process_taxon( $all_dbas, $taxonomy_dba, $antitaxon, "remove", \%dbs );
+      $self->warning("$antitaxon taxon removed");
+    }
+  }  
+  if ( scalar(@antispecies) ) {
+    foreach my $antispecies (@antispecies) {
+      foreach my $dbname ( keys %dbs ) {
+        if (exists $dbs{$dbname}{$antispecies}) {
+          $self->remove_species($dbname, $antispecies, \%dbs);
+          $self->warning("$antispecies removed");
+        }
+      }
+    }
+  }
+
+  if ( scalar( keys %meta_filters ) ) {
+    foreach my $meta_key ( keys %meta_filters ) {
+      $self->filter_species( $meta_key, $meta_filters{$meta_key}, \%dbs );
+    }
+  }
+
+  $self->param( 'dbs', \%dbs );
+  $self->param( 'compara_dbs', \%compara_dbs );
+} ## end sub run
+
+sub write_output {
+  my ($self) = @_;
+  my $dbs          = $self->param_required('dbs');
+  my $db_flow      = $self->param_required('db_flow');
+  my $db_list_flow = $self->param_required('db_list_flow');
+  my $compara_dbs  = $self->param_required('compara_dbs');
+  my $compara_flow = $self->param_required('compara_flow');
+
+  my @dbnames = keys %$dbs;
+  foreach my $dbname ( @dbnames ) {
+    my @species_list = keys %{ $$dbs{$dbname} };
+    
+    my $dataflow_params = {
+      dbname       => $dbname,
+      species_list => \@species_list,
+      species      => $species_list[0],
+    };
+
+    $self->dataflow_output_id( $dataflow_params, $db_flow );
+  }
+
+  foreach my $dbname ( keys %$compara_dbs ) {
+    my $dataflow_params = {
+      dbname  => $dbname,
+      species => $$compara_dbs{$dbname},
+    };
+
+    $self->dataflow_output_id( $dataflow_params, $compara_flow );
+  }
+
+  $self->dataflow_output_id( {dbname_list => \@dbnames}, $db_list_flow );
+}
+
+sub add_species {
+  my ( $self, $dba, $dbs ) = @_;
+
+  $$dbs{$dba->dbc->dbname}{$dba->species} = $dba;
+  
+  $dba->dbc->disconnect_if_idle();
+}
+
+sub remove_species {
+  my ( $self, $dbname, $species, $dbs ) = @_;
+
+  delete $$dbs{$dbname}{$species};
+  
+  if ( scalar( keys %{ $$dbs{$dbname} } ) == 0 ) {
+    delete $$dbs{$dbname};
+  }
+}
+
+sub process_species {
+  my ( $self, $all_dbas, $species, $dbs ) = @_;
+  my $loaded = 0;
+
+  foreach my $dba ( @$all_dbas ) {
+    if ( $species eq $dba->species() ) {
+      $self->add_species($dba, $dbs);
+      $self->warning("$species loaded");
+      $loaded = 1;
+      last;
+    }
+  }
+
+  if ( ! $loaded ) {
+    $self->throw("Database not found for $species; check registry parameters.");
+  }
+}
+
+sub process_taxon {
+  my ( $self, $all_dbas, $taxonomy_dba, $taxon, $action, $dbs ) = @_;
+  my $species_count = 0;
+
+  my $node_adaptor = $taxonomy_dba->get_TaxonomyNodeAdaptor();
+  my $node = $node_adaptor->fetch_by_name_and_class($taxon,"scientific name");;
+  $self->throw("$taxon not found in the taxonomy database") if (!defined $node);
+  my $taxon_name = $node->names()->{'scientific name'}->[0];
+
+  foreach my $dba (@$all_dbas) {
+    #Next if DB is Compara ancestral sequences
+    next if $dba->species() =~ /ancestral/i;
+    my $dba_ancestors = $self->get_taxon_ancestors_name($dba,$node_adaptor);
+    if (grep(/$taxon_name/, @$dba_ancestors)){
+      if ($action eq "add"){
+        $self->add_species($dba, $dbs);
+        $species_count++;
+      }
+      elsif ($action eq "remove")
+      {
+        $self->remove_species($dba->dbc->dbname, $dba->species, $dbs);
+        $self->warning($dba->species() . " removed");
+        $species_count++;
+      }
+    }
+    $dba->dbc->disconnect_if_idle();
+  }
+
+  if ($species_count == 0) {
+    $self->throw("$taxon was processed but no species was added/removed")
+  }
+  else {
+    if ($action eq "add") {
+      $self->warning("$species_count species loaded for taxon $taxon_name");
+    }
+    if ($action eq "remove") {
+      $self->warning("$species_count species removed for taxon $taxon_name");
+    }
+  }
+}
+
+#Return all the taxon ancestors names for a given dba
+sub get_taxon_ancestors_name {
+  my ($self, $dba, $node_adaptor) = @_;
+  my $dba_node = $node_adaptor->fetch_by_coredbadaptor($dba);
+  my @dba_lineage = @{$node_adaptor->fetch_ancestors($dba_node)};
+  my @dba_ancestors;
+  for my $lineage_node (@dba_lineage) {
+    push @dba_ancestors, $lineage_node->names()->{'scientific name'}->[0];
+  }
+  return \@dba_ancestors;
+}
+
+sub process_division {
+  my ( $self, $all_dbas, $division, $dbs ) = @_;
+  my $species_count = 0;
+
+  my %div_synonyms = %{ $self->param('div_synonyms') };
+  if ( exists $div_synonyms{$division} ) {
+    $division = $div_synonyms{$division};
+  }
+
+  $division = lc($division);
+  $division =~ s/ensembl//;
+  my $div_long = 'Ensembl' . ucfirst($division);
+
+  foreach my $dba (@$all_dbas) {
+    my $dbname = $dba->dbc->dbname();
+
+    if ( $dbname =~ /$division\_.+_collection_/ ) {
+      $self->add_species($dba, $dbs);
+      $species_count++;
+    }
+    elsif ( $dbname !~ /_collection_/ ) {
+      if ( $div_long eq $dba->get_MetaContainer->get_division() ) {
+        $self->add_species($dba, $dbs);
+        $species_count++;
+      }
+      $dba->dbc->disconnect_if_idle();
+    }
+  }
+  $self->warning("$species_count species loaded for $division");
+}
+
+sub process_division_compara {
+  my ( $self, $all_compara_dbas, $division, $compara_dbs ) = @_;
+
+  foreach my $dba (@$all_compara_dbas) {
+    my $compara_div = $dba->species();
+    if ( $compara_div eq 'multi' ) {
+      $compara_div = 'ensembl';
+    }
+    if ( $compara_div eq $division ) {
+      $$compara_dbs{$dba->dbc->dbname} = $compara_div;
+      $self->warning("Added compara for $division");
+    }
+  }
+}
+
+sub filter_species {
+  my ( $self, $meta_key, $meta_value, $dbs ) = @_;
+
+  foreach my $dbname ( keys %$dbs ) {
+    foreach my $species ( keys %{ $$dbs{$dbname} } ) {
+      my $dba = $$dbs{$dbname}{$species};
+      my $meta_values = $dba->get_MetaContainer->list_value_by_key($meta_key);
+      unless ( exists { map { $_ => 1 } @$meta_values }->{$meta_value} ) {
+        $self->remove_species($dbname, $species, $dbs);
+        $self->warning("$species removed by filter '$meta_key = $meta_value'" );
+      }
+    }
+  }
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Common/SpeciesFactory.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Common/SpeciesFactory.pm
@@ -18,20 +18,16 @@ limitations under the License.
 
 =head1 NAME
 
- Bio::EnsEMBL::Production::Pipeline::Common::BaseSpeciesFactory;
+ Bio::EnsEMBL::Production::Pipeline::Common::SpeciesFactory;
 
 =head1 DESCRIPTION
 
- Given a division or a list of species, dataflow jobs with species names. 
+ Given a list of species, dataflow jobs with species names. 
  Optionally send output down different dataflow if a species has chromosomes or variants.
 
  Dataflow of jobs can be made intentions aware by using ensembl production
  database to decide if a species has had an update to its DNA or not. An update
  means any change to the assembly or repeat masking.
-
-=head1 MAINTAINER
-
- ckong@ebi.ac.uk 
 
 =cut
 
@@ -39,307 +35,117 @@ package Bio::EnsEMBL::Production::Pipeline::Common::SpeciesFactory;
 
 use strict;
 use warnings;
-use Data::Dumper;
+
 use Bio::EnsEMBL::Registry;
 use base qw/Bio::EnsEMBL::Production::Pipeline::Common::Base/;
 
 sub param_defaults {
   my ($self) = @_;
 
-  return { species         => [],
-           division        => [],
-           taxons          => [],
-           antitaxons      => [],
-           run_all         => 0,
-           antispecies     => [],
-           core_hash_flow  => 1,
-           core_flow       => 2,
-           chromosome_flow => 3,
-           variation_flow  => 4,
-           compara_flow    => 5,
-           regulation_flow => 6,
+  return { species_list       => [],
+           core_list_flow     => 1,
+           core_flow          => 2,
+           chromosome_flow    => 3,
+           variation_flow     => 4,
+           # compara_flow       => 5, compara_flow moved to DbFactory; but avoid re-using flow #5 here, to avoid bugs
+           regulation_flow    => 6,
            otherfeatures_flow => 7,
-           div_synonyms    => {
-                             'eb'  => 'bacteria',
-                             'ef'  => 'fungi',
-                             'em'  => 'metazoa',
-                             'epl' => 'plants',
-                             'epr' => 'protists',
-                             'e'   => 'ensembl' },
-           meta_filters => {}, };
-}
-
-sub fetch_input {
-  my ($self) = @_;
-  my $species = $self->param('species') || [];
-
-  my @species = ( ref($species) eq 'ARRAY' ) ? @$species : ($species);
-
-  my $division = $self->param('division') || [];
-  my @division =
-    ( ref($division) eq 'ARRAY' ) ? @$division : ($division);
-  my $taxons = $self->param('taxons') || [];
-  my @taxons = ( ref($taxons) eq 'ARRAY' ) ? @$taxons : ($taxons);
-  my $antitaxons = $self->param('antitaxons') || [];
-  my @antitaxons =
-    ( ref($antitaxons) eq 'ARRAY' ) ? @$antitaxons : ($antitaxons);
-  my $run_all     = $self->param('run_all');
-  my $antispecies = $self->param('antispecies') || [];
-  my @antispecies =
-    ( ref($antispecies) eq 'ARRAY' ) ? @$antispecies : ($antispecies);
-  my %meta_filters = %{ $self->param('meta_filters') };
-
-  my $all_dbas =
-    Bio::EnsEMBL::Registry->get_all_DBAdaptors( -GROUP => 'core' );
-  my $all_compara_dbas =
-    Bio::EnsEMBL::Registry->get_all_DBAdaptors( -GROUP => 'compara' );
-  my $taxonomy_dba = Bio::EnsEMBL::Registry->get_DBAdaptor('multi','taxonomy');
-  my %core_dbas;
-  my %compara_dbas;
-
-  if ( !scalar(@$all_dbas) ) {
-    $self->throw(
-"No core databases found in the registry; please check your registry parameters."
-    );
-  }
-
-  if ($run_all) {
-    %core_dbas = map { $_->species => $_ } @$all_dbas;
-    delete $core_dbas{'Ancestral sequences'};
-    %compara_dbas = map { $_->species => $_ } @$all_compara_dbas;
-    $self->warning( scalar( keys %core_dbas ) . " species loaded" );
-  }
-  elsif ( scalar(@species) ) {
-    foreach my $species (@species) {
-      $self->process_species( $all_dbas, $species, \%core_dbas );
-    }
-  }
-  elsif ( scalar(@taxons) ) {
-    foreach my $taxon (@taxons) {
-      $self->process_taxon( $all_dbas, \%core_dbas , $taxonomy_dba, $taxon, "add" );
-    }
-  }
-  elsif ( scalar(@division) ) {
-    foreach my $division (@division) {
-      $self->process_division( $all_dbas, $all_compara_dbas, $division,
-                               \%core_dbas, \%compara_dbas );
-    }
-  }
-  else {
-    $self->warning("Supply one of: -species, -division, -taxons, -run_all OR you can seed jobs later");
-    #$self->throw(
-    #           'You must supply one of: -species, -division, -run_all');
-  }
-  if ( scalar(@antitaxons) ) {
-    foreach my $antitaxon (@antitaxons) {
-      $self->process_taxon( $all_dbas, \%core_dbas , $taxonomy_dba, $antitaxon, "remove" );
-      $self->warning("$antitaxon taxon successfully removed");
-    }
-  }  
-  if ( scalar(@antispecies) ) {
-    foreach my $antispecies (@antispecies) {
-      delete $core_dbas{$antispecies};
-      $self->warning("$antispecies successfully removed");
-    }
-  }
-
-  if ( scalar( keys %meta_filters ) ) {
-    foreach my $meta_key ( keys %meta_filters ) {
-      $self->filter_species( $meta_key, $meta_filters{$meta_key},
-                             \%core_dbas );
-    }
-  }
-
-  $self->param( 'core_dbas',    \%core_dbas );
-  $self->param( 'compara_dbas', \%compara_dbas );
-} ## end sub fetch_input
-
-sub process_division {
-  my ( $self, $all_dbas, $all_compara_dbas, $division, $core_dbas,
-       $compara_dbas )
-    = @_;
-  my $division_count = 0;
-
-  my %div_synonyms = %{ $self->param('div_synonyms') };
-  if ( exists $div_synonyms{$division} ) {
-    $division = $div_synonyms{$division};
-  }
-
-  $division = lc($division);
-  $division =~ s/ensembl//;
-  my $div_long = 'Ensembl' . ucfirst($division);
-
-  foreach my $dba (@$all_dbas) {
-    my $dbname = $dba->dbc->dbname();
-
-    if ( $dbname =~ /$division\_.+_collection_/ ) {
-      $$core_dbas{ $dba->species() } = $dba;
-      $division_count++;
-    }
-    elsif ( $dbname !~ /_collection_/ ) {
-      if ( $div_long eq $dba->get_MetaContainer->get_division() ) {
-        $$core_dbas{ $dba->species() } = $dba;
-        $division_count++;
-      }
-      $dba->dbc->disconnect_if_idle();
-    }
-  }
-  $self->warning("$division_count species loaded for $division");
-
-  foreach my $dba (@$all_compara_dbas) {
-    my $compara_div = $dba->species();
-    if ( $compara_div eq 'multi' ) {
-      $compara_div = 'ensembl';
-    }
-    if ( $compara_div eq $division ) {
-      $$compara_dbas{$compara_div} = $dba;
-      $self->warning("Added compara for $division");
-    }
-  }
-
-  return;
-
-} ## end sub process_division
-
-sub process_taxon {
-  my ( $self, $all_dbas, $core_dbas, $taxonomy_dba, $taxon, $action )
-    = @_;
-
-  my $species_count;
-  my $node_adaptor = $taxonomy_dba->get_TaxonomyNodeAdaptor();
-  my $node = $node_adaptor->fetch_by_name_and_class($taxon,"scientific name");;
-  $self->throw("$taxon not found in the taxonomy database") if (!defined $node);
-  my $taxon_name = $node->names()->{'scientific name'}->[0];
-
-  foreach my $dba (@$all_dbas) {
-    #Next if DB is Compara ancestral sequences
-    next if $dba->species() =~ /ancestral/i;
-    my $dba_ancestors=$self->get_taxon_ancestors_name($dba,$node_adaptor);
-    if (grep(/$taxon_name/, @$dba_ancestors)){
-      if ($action eq "add"){
-        $$core_dbas{ $dba->species() } = $dba;
-        $species_count ++;
-      }
-      elsif ($action eq "remove")
-      {
-        delete $$core_dbas{$dba->species()};
-        $self->warning($dba->species()." successfully removed");
-        $species_count ++;
-      }
-    }
-    $dba->dbc->disconnect_if_idle();
-  }
-  if ($species_count == 0) {
-    $self->throw("$taxon was processed but no species was added/removed")
-  }
-  else {
-    if ($action eq "add") {
-      $self->warning("$species_count species loaded for taxon $taxon_name");
-    }
-    if ($action eq "remove") {
-      $self->warning("$species_count species removed for taxon $taxon_name");
-    }
-  }
-  return;
-
-} ## end sub process_taxon
-
-sub process_species {
-  my ( $self, $all_dbas, $species, $core_dbas ) = @_;
-
-  foreach my $dba (@$all_dbas) {
-    if ( $species eq $dba->species() ) {
-      $$core_dbas{$species} = $dba;
-      last;
-    }
-  }
-
-  if ( exists $$core_dbas{$species} ) {
-    $self->warning("$species successfully found");
-  }
-  else {
-    $self->throw(
-"Core database not found for '$species'; please check your registry parameters."
-    );
-  }
-}
-
-sub filter_species {
-  my ( $self, $meta_key, $meta_value, $core_dbas ) = @_;
-
-  foreach my $species ( keys %$core_dbas ) {
-    my $core_dba = $$core_dbas{$species};
-    my $meta_values =
-      $core_dba->get_MetaContainer->list_value_by_key($meta_key);
-    unless ( exists { map { $_ => 1 } @$meta_values }->{$meta_value} ) {
-      delete $$core_dbas{$species};
-      $self->warning(
-"$species successfully removed by filter '$meta_key = $meta_value'" );
-    }
-  }
+           check_intentions   => 0,
+  };
 }
 
 sub run {
-  my ($self)          = @_;
-  my $chromosome_flow = $self->param('chromosome_flow');
-  my $variation_flow  = $self->param('variation_flow');
+  my ($self) = @_;
+  my $species_list       = $self->param_required('species_list');
+  my $chromosome_flow    = $self->param('chromosome_flow');
+  my $variation_flow     = $self->param('variation_flow');
   my $regulation_flow    = $self->param('regulation_flow');
   my $otherfeatures_flow = $self->param('otherfeatures_flow');
-  my $core_dbas       = $self->param('core_dbas');
-  my ( $chromosome_dbas, $variation_dbas, $regulation_dbas, $otherfeatures_dbas );
 
-  if ( $chromosome_flow || $variation_flow || $regulation_flow || $otherfeatures_flow) {
-    foreach my $species ( keys %$core_dbas ) {
-      my $core_dba = $$core_dbas{$species};
+  my @chromosome_species;
+  my @variation_species;
+  my @regulation_species;
+  my @otherfeatures_species;
 
+  if ($chromosome_flow || $variation_flow || $regulation_flow || $otherfeatures_flow) {
+    foreach my $species (@$species_list) {
       if ($chromosome_flow) {
-        if ( $self->has_chromosome($core_dba) ) {
-          $$chromosome_dbas{$species} = $core_dba;
+        if ( $self->has_chromosome($species) ) {
+          push @chromosome_species, $species;
         }
       }
 
       if ($variation_flow) {
         if ( $self->has_variation($species) ) {
-          $$variation_dbas{$species} = $core_dba;
+          push @variation_species, $species;
         }
       }
       if ($regulation_flow) {
         if ($self->has_regulation($species)) {
-          $$regulation_dbas{$species} = $core_dba;
+          push @regulation_species, $species;
         }
       }
       if ($otherfeatures_flow){
         if ($self->has_otherfeatures($species)) {
-          $$otherfeatures_dbas{$species} = $core_dba;
+          push @otherfeatures_species, $species;
         }
       }
-      $core_dba->dbc()->disconnect_if_idle();
     }
   }
-  $self->param( 'chromosome_dbas', $chromosome_dbas );
-  $self->param( 'variation_dbas',  $variation_dbas );
-  $self->param( 'regulation_dbas', $regulation_dbas );
-  $self->param( 'otherfeatures_dbas', $otherfeatures_dbas);
-} ## end sub run
+
+  my $flow_species = {
+    $chromosome_flow    => \@chromosome_species,
+    $variation_flow     => \@variation_species,
+    $regulation_flow    => \@regulation_species,
+    $otherfeatures_flow => \@otherfeatures_species,
+  };
+
+  $self->param('flow_species', $flow_species);
+}
+
+sub write_output {
+  my ($self) = @_;
+  my $species_list     = $self->param_required('species_list');
+  my $core_list_flow   = $self->param('species_list');
+  my $core_flow        = $self->param('core_flow');
+  my $check_intentions = $self->param('check_intentions');
+  my $flow_species     = $self->param('flow_species');
+
+  foreach my $species ( @$species_list ) {
+    # If check_intention is turned on, then check the production database
+    # and decide if data need to be re-dumped.
+    my $requires_new_dna = 1;
+    if ( $check_intentions == 1 ) {
+      $requires_new_dna = $self->requires_new_dna($species);
+    }
+    my $dataflow_params = {
+      species          => $species,
+      requires_new_dna => $requires_new_dna,
+      check_intentions => $check_intentions,
+    };
+
+    $self->dataflow_output_id( $dataflow_params, $core_flow );
+  }
+
+  foreach my $flow ( keys %$flow_species ) {
+    foreach my $species ( @{ $$flow_species{$flow} } ) {
+      $self->dataflow_output_id( { 'species' => $species }, $flow );
+    }
+  }
+
+  $self->dataflow_output_id( { 'species' => $species_list }, $core_list_flow );
+}
 
 sub has_chromosome {
-  my ( $self, $dba ) = @_;
-  my $cnt = $self->{chr_count}{$dba->dbc()->dbname()};
-  if(!defined $cnt) {
-    $cnt =
-      $dba->dbc()->sql_helper()->execute_into_hash(
-    -SQL => q{
-     SELECT cs.species_id, COUNT(*) FROM
-     coord_system cs INNER JOIN
-     seq_region sr USING (coord_system_id) INNER JOIN
-     seq_region_attrib sa USING (seq_region_id) INNER JOIN
-     attrib_type at USING (attrib_type_id)
-     WHERE at.code = 'karyotype_rank'
-     GROUP BY cs.species_id
-   });
-    $self->{chr_count}{$dba->dbc()->dbname()} = $cnt;
-  }
-  return $cnt->{$dba->species_id()};
+  my ( $self, $species ) = @_;
+  my $gc = 
+    Bio::EnsEMBL::Registry->get_adaptor($species, 'core', 'GenomeContainer');
+  
+  my $has_chromosome = $gc->has_karyotype();
+  
+  $gc && $gc->dbc->disconnect_if_idle();
+
+  return $has_chromosome;
 }
 
 sub has_variation {
@@ -347,107 +153,34 @@ sub has_variation {
   my $dbva =
     Bio::EnsEMBL::Registry->get_DBAdaptor( $species, 'variation' );
 
-  return $dbva ? 1 : 0;
+  my $has_variation = defined $dbva ? 1 : 0;
+  
+  $has_variation && $dbva->dbc->disconnect_if_idle();
+
+  return $has_variation;
 }
 
 sub has_regulation {
   my ($self, $species) = @_;
   my $dbreg = Bio::EnsEMBL::Registry->get_DBAdaptor($species, 'funcgen');
-  return $dbreg ? 1 : 0;
+
+  my $has_regulation = defined $dbreg ? 1 : 0;
+  
+  $has_regulation && $dbreg->dbc->disconnect_if_idle();
+
+  return $has_regulation;
 }
 
 sub has_otherfeatures {
   my ($self, $species) = @_;
   my $dbof = Bio::EnsEMBL::Registry->get_DBAdaptor($species, 'otherfeatures');
-  return $dbof ? 1 : 0;
+
+  my $has_otherfeatures = defined $dbof ? 1 : 0;
+  
+  $has_otherfeatures && $dbof->dbc->disconnect_if_idle();
+
+  return $has_otherfeatures;
 }
-
-#Return all the taxon ancestors names for a given dba
-sub get_taxon_ancestors_name {
-  my ($self, $dba, $node_adaptor) = @_;
-  my $dba_node = $node_adaptor->fetch_by_coredbadaptor($dba);
-  my @dba_lineage = @{$node_adaptor->fetch_ancestors($dba_node)};
-  my @dba_ancestors;
-  for my $lineage_node (@dba_lineage) {
-    push @dba_ancestors, $lineage_node->names()->{'scientific name'}->[0];
-  }
-  return \@dba_ancestors;
-}
-
-sub write_output {
-  my ($self) = @_;
-  my $check_intentions = $self->param('check_intentions') || 0;
-  my $core_dbas        = $self->param('core_dbas');
-  my $compara_dbas     = $self->param('compara_dbas');
-  my $chromosome_dbas  = $self->param('chromosome_dbas');
-  my $variation_dbas   = $self->param('variation_dbas');
-  my $regulation_dbas   = $self->param('regulation_dbas');
-  my $otherfeatures_dbas = $self->param('otherfeatures_dbas');
-  my @all_core_species;
-  foreach my $species ( sort keys %$core_dbas ) {
-    push @all_core_species,$species;
-    # If check_intention is turned on, then check the production database
-    # and decide if data need to be re-dumped.
-    if ( $check_intentions == 1 ) {
-      my $requires_new_dna = $self->requires_new_dna($species);
-      if ($requires_new_dna) {
-        $self->dataflow_output_id( {
-                                 'species'          => $species,
-                                 'requires_new_dna' => '1',
-                                 'check_intentions' => $check_intentions
-                               },
-                               $self->param('core_flow') );
-      }
-      else {
-        $self->dataflow_output_id( {
-                                 'species'          => $species,
-                                 'requires_new_dna' => '0',
-                                 'check_intentions' => $check_intentions
-                               },
-                               $self->param('core_flow') );
-      }
-    }
-    else {
-        $self->dataflow_output_id( {
-                                 'species'          => $species,
-                                 'requires_new_dna' => '1',
-                                 'check_intentions' => $check_intentions
-                               },
-                               $self->param('core_flow') );
-    }
-  }
-
-  foreach my $species ( sort keys %$chromosome_dbas ) {
-    $self->dataflow_output_id( { 'species' => $species },
-                               $self->param('chromosome_flow') );
-  }
-
-  foreach my $species ( sort keys %$variation_dbas ) {
-    $self->dataflow_output_id( { 'species' => $species },
-                               $self->param('variation_flow') );
-  }
-
-  foreach my $species ( sort keys %$compara_dbas ) {
-    $self->dataflow_output_id( { 'species' => $species },
-                               $self->param('compara_flow') );
-  }
-
-  foreach my $species ( sort keys %$regulation_dbas ) {
-    $self->dataflow_output_id( { 'species' => $species },
-                               $self->param('regulation_flow') );
-  }
-
-  foreach my $species ( sort keys %$otherfeatures_dbas ) {
-    $self->dataflow_output_id( { 'species' => $species },
-                               $self->param('otherfeatures_flow') );
-  }
-
-  $self->dataflow_output_id( {'species'          => \@all_core_species,},
-                               $self->param('core_hash_flow') );
-
-  return;
-
-} ## end sub write_output
 
 sub requires_new_dna {
   my ( $self, $species ) = @_;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FactoryTest_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FactoryTest_conf.pm
@@ -1,0 +1,197 @@
+
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2017] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::Production::Pipeline::PipeConfig::FactoryTest_conf;
+
+use strict;
+use warnings;
+
+use base ('Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf');
+
+use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
+use Bio::EnsEMBL::Hive::Version 2.4;
+
+sub default_options {
+  my ($self) = @_;
+  return {
+    %{$self->SUPER::default_options},
+
+    pipeline_name => 'factory_test',
+    
+    species      => [],
+    antispecies  => [],
+    taxons       => [],
+    antitaxons   => [],
+    division     => [],
+    run_all      => 0,
+    meta_filters => {},
+    
+    db_type => 'core',
+    
+    check_intentions => 0,
+  };
+}
+
+# Force an automatic loading of the registry in all workers.
+sub beekeeper_extra_cmdline_options {
+  my ($self) = @_;
+
+  my $options = join(' ',
+    $self->SUPER::beekeeper_extra_cmdline_options,
+    "-reg_conf ".$self->o('registry'),
+  );
+  
+  return $options;
+}
+
+# Ensures that species output parameter gets propagated implicitly.
+sub hive_meta_table {
+  my ($self) = @_;
+
+  return {
+    %{$self->SUPER::hive_meta_table},
+    'hive_use_param_stack'  => 1,
+  };
+}
+
+sub pipeline_analyses {
+  my $self = shift @_;
+  
+  return [
+    {
+      -logic_name        => 'DbFactory',
+      -module            => 'Bio::EnsEMBL::Production::Pipeline::Common::DbFactory',
+      -max_retry_count   => 0,
+      -input_ids         => [ {} ],
+      -parameters        => {
+                              species      => $self->o('species'),
+                              antispecies  => $self->o('antispecies'),
+                              taxons       => $self->o('taxons'),
+                              antitaxons   => $self->o('antitaxons'),
+                              division     => $self->o('division'),
+                              run_all      => $self->o('run_all'),
+                              meta_filters => $self->o('meta_filters'),
+                              db_type      => $self->o('db_type'),
+                            },
+      -flow_into         => {
+                              '2->A' => ['DbFlow'],
+                              'A->2' => ['SpeciesFactory'],
+                              '5'    => ['ComparaFlow'],
+                            },
+      -rc_name           => 'normal',
+    },
+    
+    {
+      -logic_name        => 'DbFlow',
+      -module            => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+      -analysis_capacity => 10,
+      -batch_size        => 100,
+      -max_retry_count   => 0,
+      -rc_name           => 'normal',
+    },
+    
+    {
+      -logic_name        => 'SpeciesFactory',
+      -module            => 'Bio::EnsEMBL::Production::Pipeline::Common::SpeciesFactory',
+      -analysis_capacity => 10,
+      -batch_size        => 100,
+      -max_retry_count   => 0,
+      -parameters        => {
+                              check_intentions => $self->o('check_intentions'),
+                            },
+      -rc_name           => 'normal',
+      -flow_into         => {
+                              '2->A' => ['CoreFlow'],
+                              '3->A' => ['ChromosomeFlow'],
+                              '4->A' => ['VariationFlow'],
+                              '5->A' => ['ComparaFlow'],
+                              '6->A' => ['RegulationFlow'],
+                              '7->A' => ['OtherfeaturesFlow'],
+                              'A->1' => ['SingleFlow'],
+                            },
+    },
+    
+    {
+      -logic_name        => 'CoreFlow',
+      -module            => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+      -analysis_capacity => 10,
+      -batch_size        => 100,
+      -max_retry_count   => 0,
+      -rc_name           => 'normal',
+    },
+    
+    {
+      -logic_name        => 'SingleFlow',
+      -module            => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+      -analysis_capacity => 10,
+      -batch_size        => 100,
+      -max_retry_count   => 0,
+      -rc_name           => 'normal',
+    },
+    
+    {
+      -logic_name        => 'ChromosomeFlow',
+      -module            => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+      -analysis_capacity => 10,
+      -batch_size        => 100,
+      -max_retry_count   => 0,
+      -rc_name           => 'normal',
+    },
+    
+    {
+      -logic_name        => 'VariationFlow',
+      -module            => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+      -analysis_capacity => 10,
+      -batch_size        => 100,
+      -max_retry_count   => 0,
+      -rc_name           => 'normal',
+    },
+    
+    {
+      -logic_name        => 'ComparaFlow',
+      -module            => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+      -analysis_capacity => 10,
+      -batch_size        => 100,
+      -max_retry_count   => 0,
+      -rc_name           => 'normal',
+    },
+    
+    {
+      -logic_name        => 'RegulationFlow',
+      -module            => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+      -analysis_capacity => 10,
+      -batch_size        => 100,
+      -max_retry_count   => 0,
+      -rc_name           => 'normal',
+    },
+    
+    {
+      -logic_name        => 'OtherfeaturesFlow',
+      -module            => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+      -analysis_capacity => 10,
+      -batch_size        => 100,
+      -max_retry_count   => 0,
+      -rc_name           => 'normal',
+    },
+    
+  ];
+}
+
+1;


### PR DESCRIPTION
...one for flowing db information, one for flowing species information. This is designed to make working with collection dbs effective and efficient (but might also be useful in other scenarios).

The DbFactory flows a "species_list" parameter, and the first element of that list as a "species" parameter. I'm not convinced that this is a good idea, but the idea is for downstream modules which rely on a species parameter to work without modification. For example, the function in the Base.pm which gets a core db adaptor requires a "species" parameter; modules like DatabaseDumper use this to get a connection to the database (on which you can then run non-species-specific operations).

Making the SpeciesFactory not backwards-compatible was a deliberate decision. One could leave the existing functionality in that module, and run it in parallel with DbFactory; but I think that'd lead to more confusion in the long-run, and I think it's better to break things and force appropriate changes to the pipelines. (It now occurs to me that maybe a less destructive approach would be to give the new SpeciesFactory module a different name, to allow for a more manageable transition...)

I've also created a PipeConfig file for demonstrating/testing.

Please let me know what you think...