### PR TITLE
add xmllint fake binary

### DIFF
--- a/modules/t/fake_ebeye_binaries/xmllint
+++ b/modules/t/fake_ebeye_binaries/xmllint
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+# Copyright [2016-2017] EMBL-European Bioinformatics Institute
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo '- valid'
+exit


### PR DESCRIPTION
Missing binary was causing Travis to fail
Local runs would work because the actual xmllint binary is usually on the path
With the added fake binary, Travis now passes successfully