### PR TITLE
Making SpeciesFactory 'DB-aware'.

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Common/DbAwareSpeciesFactory.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Common/DbAwareSpeciesFactory.pm
@@ -1,0 +1,54 @@
+
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2017] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+ Bio::EnsEMBL::Production::Pipeline::Common::DbAwareSpeciesFactory;
+
+=head1 DESCRIPTION
+
+ Given a list of species, dataflow jobs with species names. 
+ Optionally send output down different dataflow if a species has chromosomes or variants.
+
+=cut
+
+package Bio::EnsEMBL::Production::Pipeline::Common::DbAwareSpeciesFactory;
+
+use strict;
+use warnings;
+
+use Bio::EnsEMBL::Registry;
+use base qw/Bio::EnsEMBL::Production::Pipeline::Common::SpeciesFactory/;
+
+sub param_defaults {
+  my ($self) = @_;
+
+  return {
+    %{$self->SUPER::param_defaults},
+    compara_flow => 0,
+  };
+}
+
+sub run {
+  my ($self) = @_;
+  my $species_list = $self->param_required('species_list');
+  
+  $self->param( 'all_species', $species_list );
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Common/DbFactory.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Common/DbFactory.pm
@@ -1,0 +1,331 @@
+
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2017] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+ Bio::EnsEMBL::Production::Pipeline::Common::DbFactory;
+
+=head1 DESCRIPTION
+
+ Given a division or a list of species, dataflow jobs with database names.
+
+=cut
+
+package Bio::EnsEMBL::Production::Pipeline::Common::DbFactory;
+
+use strict;
+use warnings;
+
+use Bio::EnsEMBL::Registry;
+use base qw/Bio::EnsEMBL::Production::Pipeline::Common::Base/;
+
+sub param_defaults {
+  my ($self) = @_;
+
+  return {
+    species      => [],
+    taxons       => [],
+    division     => [],
+    run_all      => 0,
+    antispecies  => [],
+    antitaxons   => [],
+    all_dbs_flow => 1,
+    db_flow      => 2,
+    compara_flow => 5, # compara_flow moved here from SpeciesFactory; retain former flow #5 here, to avoid bugs
+    div_synonyms => { 'eb'  => 'bacteria',
+                       'ef'  => 'fungi',
+                       'em'  => 'metazoa',
+                       'epl' => 'plants',
+                       'epr' => 'protists',
+                       'e'   => 'ensembl' },
+    meta_filters => {},
+    db_type      => 'core',
+  };
+}
+
+sub run {
+  my ($self) = @_;
+  my @species      = @{ $self->param('species') };
+  my @taxons       = @{ $self->param('taxons') };
+  my @division     = @{ $self->param('division') };
+  my $run_all      = $self->param('run_all');
+  my @antispecies  = @{ $self->param('antispecies') };
+  my @antitaxons   = @{ $self->param('antitaxons') };
+  my %meta_filters = %{ $self->param('meta_filters') };
+  my $db_type      = $self->param('db_type');
+
+  my $reg = 'Bio::EnsEMBL::Registry';
+
+  my $taxonomy_dba = $reg->get_DBAdaptor( 'multi', 'taxonomy' );
+
+  my $all_dbas = $reg->get_all_DBAdaptors( -GROUP => $db_type );
+  my %dbs;
+
+  my $all_compara_dbas;
+  if ($self->param('compara_flow')) {
+    $all_compara_dbas = $reg->get_all_DBAdaptors( -GROUP => 'compara' );
+  }
+  my %compara_dbs;
+
+  if ( ! scalar(@$all_dbas) && ! scalar(@$all_compara_dbas) ) {
+    $self->throw("No $db_type or compara databases found in the registry");
+  }
+
+  if ($run_all) {
+    foreach my $dba (@$all_dbas) {
+      $self->add_species($dba, \%dbs);
+    }
+    delete $dbs{'Ancestral sequences'};
+    $self->warning("All species in " . scalar(keys %dbs) . " databases loaded");
+    
+    %compara_dbs = map { $_->dbc->dbname => $_->species } @$all_compara_dbas;
+  }
+  elsif ( scalar(@species) ) {
+    foreach my $species (@species) {
+      $self->process_species( $all_dbas, $species, \%dbs );
+    }
+  }
+  elsif ( scalar(@taxons) ) {
+    foreach my $taxon (@taxons) {
+      $self->process_taxon( $all_dbas , $taxonomy_dba, $taxon, "add", \%dbs );
+    }
+  }
+  elsif ( scalar(@division) ) {
+    foreach my $division (@division) {
+      $self->process_division( $all_dbas, $division, \%dbs );
+      $self->process_division_compara( $all_compara_dbas, $division, \%compara_dbs );
+    }
+  }
+
+  if ( scalar(@antitaxons) ) {
+    foreach my $antitaxon (@antitaxons) {
+      $self->process_taxon( $all_dbas, $taxonomy_dba, $antitaxon, "remove", \%dbs );
+      $self->warning("$antitaxon taxon removed");
+    }
+  }  
+  if ( scalar(@antispecies) ) {
+    foreach my $antispecies (@antispecies) {
+      foreach my $dbname ( keys %dbs ) {
+        if (exists $dbs{$dbname}{$antispecies}) {
+          $self->remove_species($dbname, $antispecies, \%dbs);
+          $self->warning("$antispecies removed");
+        }
+      }
+    }
+  }
+
+  if ( scalar( keys %meta_filters ) ) {
+    foreach my $meta_key ( keys %meta_filters ) {
+      $self->filter_species( $meta_key, $meta_filters{$meta_key}, \%dbs );
+    }
+  }
+
+  my @all_species;
+  foreach my $db_name (keys %dbs) {
+    push @all_species, keys %{ $dbs{$db_name} };
+  }
+
+  $self->param( 'dbs', \%dbs );
+  $self->param( 'compara_dbs', \%compara_dbs );
+  $self->param( 'all_species', \@all_species );
+}
+
+sub write_output {
+  my ($self) = @_;
+  my $dbs          = $self->param_required('dbs');
+  my $db_flow      = $self->param_required('db_flow');
+  my $all_dbs_flow = $self->param_required('all_dbs_flow');
+  my $compara_dbs  = $self->param_required('compara_dbs');
+  my $compara_flow = $self->param_required('compara_flow');
+
+  my @dbnames = keys %$dbs;
+  foreach my $dbname ( @dbnames ) {
+    my @species_list = keys %{ $$dbs{$dbname} };
+    
+    my $dataflow_params = {
+      dbname       => $dbname,
+      species_list => \@species_list,
+      species      => $species_list[0],
+    };
+
+    $self->dataflow_output_id( $dataflow_params, $db_flow );
+  }
+
+  foreach my $dbname ( keys %$compara_dbs ) {
+    my $dataflow_params = {
+      dbname  => $dbname,
+      species => $$compara_dbs{$dbname},
+    };
+
+    $self->dataflow_output_id( $dataflow_params, $compara_flow );
+  }
+
+  $self->dataflow_output_id( {all_dbs => \@dbnames}, $all_dbs_flow );
+}
+
+sub add_species {
+  my ( $self, $dba, $dbs ) = @_;
+
+  $$dbs{$dba->dbc->dbname}{$dba->species} = $dba;
+  
+  $dba->dbc->disconnect_if_idle();
+}
+
+sub remove_species {
+  my ( $self, $dbname, $species, $dbs ) = @_;
+
+  delete $$dbs{$dbname}{$species};
+  
+  if ( scalar( keys %{ $$dbs{$dbname} } ) == 0 ) {
+    delete $$dbs{$dbname};
+  }
+}
+
+sub process_species {
+  my ( $self, $all_dbas, $species, $dbs ) = @_;
+  my $loaded = 0;
+
+  foreach my $dba ( @$all_dbas ) {
+    if ( $species eq $dba->species() ) {
+      $self->add_species($dba, $dbs);
+      $self->warning("$species loaded");
+      $loaded = 1;
+      last;
+    }
+  }
+
+  if ( ! $loaded ) {
+    $self->throw("Database not found for $species; check registry parameters.");
+  }
+}
+
+sub process_taxon {
+  my ( $self, $all_dbas, $taxonomy_dba, $taxon, $action, $dbs ) = @_;
+  my $species_count = 0;
+
+  my $node_adaptor = $taxonomy_dba->get_TaxonomyNodeAdaptor();
+  my $node = $node_adaptor->fetch_by_name_and_class($taxon,"scientific name");;
+  $self->throw("$taxon not found in the taxonomy database") if (!defined $node);
+  my $taxon_name = $node->names()->{'scientific name'}->[0];
+
+  foreach my $dba (@$all_dbas) {
+    #Next if DB is Compara ancestral sequences
+    next if $dba->species() =~ /ancestral/i;
+    my $dba_ancestors = $self->get_taxon_ancestors_name($dba,$node_adaptor);
+    if (grep(/$taxon_name/, @$dba_ancestors)){
+      if ($action eq "add"){
+        $self->add_species($dba, $dbs);
+        $species_count++;
+      }
+      elsif ($action eq "remove")
+      {
+        $self->remove_species($dba->dbc->dbname, $dba->species, $dbs);
+        $self->warning($dba->species() . " removed");
+        $species_count++;
+      }
+    }
+    $dba->dbc->disconnect_if_idle();
+  }
+
+  if ($species_count == 0) {
+    $self->throw("$taxon was processed but no species was added/removed")
+  }
+  else {
+    if ($action eq "add") {
+      $self->warning("$species_count species loaded for taxon $taxon_name");
+    }
+    if ($action eq "remove") {
+      $self->warning("$species_count species removed for taxon $taxon_name");
+    }
+  }
+}
+
+# Return all the taxon ancestors names for a given dba
+sub get_taxon_ancestors_name {
+  my ($self, $dba, $node_adaptor) = @_;
+  my $dba_node = $node_adaptor->fetch_by_coredbadaptor($dba);
+  my @dba_lineage = @{$node_adaptor->fetch_ancestors($dba_node)};
+  my @dba_ancestors;
+  for my $lineage_node (@dba_lineage) {
+    push @dba_ancestors, $lineage_node->names()->{'scientific name'}->[0];
+  }
+  return \@dba_ancestors;
+}
+
+sub process_division {
+  my ( $self, $all_dbas, $division, $dbs ) = @_;
+  my $species_count = 0;
+
+  my %div_synonyms = %{ $self->param('div_synonyms') };
+  if ( exists $div_synonyms{$division} ) {
+    $division = $div_synonyms{$division};
+  }
+
+  $division = lc($division);
+  $division =~ s/ensembl//;
+  my $div_long = 'Ensembl' . ucfirst($division);
+
+  foreach my $dba (@$all_dbas) {
+    my $dbname = $dba->dbc->dbname();
+
+    if ( $dbname =~ /$division\_.+_collection_/ ) {
+      $self->add_species($dba, $dbs);
+      $species_count++;
+    }
+    elsif ( $dbname !~ /_collection_/ ) {
+      if ( $div_long eq $dba->get_MetaContainer->get_division() ) {
+        $self->add_species($dba, $dbs);
+        $species_count++;
+      }
+      $dba->dbc->disconnect_if_idle();
+    }
+  }
+  $self->warning("$species_count species loaded for $division");
+}
+
+sub process_division_compara {
+  my ( $self, $all_compara_dbas, $division, $compara_dbs ) = @_;
+
+  foreach my $dba (@$all_compara_dbas) {
+    my $compara_div = $dba->species();
+    if ( $compara_div eq 'multi' ) {
+      $compara_div = 'ensembl';
+    }
+    if ( $compara_div eq $division ) {
+      $$compara_dbs{$dba->dbc->dbname} = $compara_div;
+      $self->warning("Added compara for $division");
+    }
+  }
+}
+
+sub filter_species {
+  my ( $self, $meta_key, $meta_value, $dbs ) = @_;
+
+  foreach my $dbname ( keys %$dbs ) {
+    foreach my $species ( keys %{ $$dbs{$dbname} } ) {
+      my $dba = $$dbs{$dbname}{$species};
+      my $meta_values = $dba->get_MetaContainer->list_value_by_key($meta_key);
+      unless ( exists { map { $_ => 1 } @$meta_values }->{$meta_value} ) {
+        $self->remove_species($dbname, $species, $dbs);
+        $self->warning("$species removed by filter '$meta_key = $meta_value'" );
+      }
+    }
+  }
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FactoryTest_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FactoryTest_conf.pm
@@ -1,0 +1,230 @@
+
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2017] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::Production::Pipeline::PipeConfig::FactoryTest_conf;
+
+use strict;
+use warnings;
+
+use base ('Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf');
+
+use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
+use Bio::EnsEMBL::Hive::Version 2.4;
+
+sub default_options {
+  my ($self) = @_;
+  return {
+    %{$self->SUPER::default_options},
+
+    pipeline_name => 'factory_test',
+    
+    species      => [],
+    antispecies  => [],
+    taxons       => [],
+    antitaxons   => [],
+    division     => [],
+    run_all      => 0,
+    meta_filters => {},
+    
+    db_type => 'core',
+    
+    check_intentions => 0,
+  };
+}
+
+# Force an automatic loading of the registry in all workers.
+sub beekeeper_extra_cmdline_options {
+  my ($self) = @_;
+
+  my $options = join(' ',
+    $self->SUPER::beekeeper_extra_cmdline_options,
+    "-reg_conf ".$self->o('registry'),
+  );
+  
+  return $options;
+}
+
+# Ensures that species output parameter gets propagated implicitly.
+sub hive_meta_table {
+  my ($self) = @_;
+
+  return {
+    %{$self->SUPER::hive_meta_table},
+    'hive_use_param_stack'  => 1,
+  };
+}
+
+sub pipeline_analyses {
+  my $self = shift @_;
+  
+  return [
+    {
+      -logic_name        => 'DbFactory',
+      -module            => 'Bio::EnsEMBL::Production::Pipeline::Common::DbFactory',
+      -max_retry_count   => 0,
+      -input_ids         => [ {} ],
+      -parameters        => {
+                              species      => $self->o('species'),
+                              antispecies  => $self->o('antispecies'),
+                              taxons       => $self->o('taxons'),
+                              antitaxons   => $self->o('antitaxons'),
+                              division     => $self->o('division'),
+                              run_all      => $self->o('run_all'),
+                              meta_filters => $self->o('meta_filters'),
+                              db_type      => $self->o('db_type'),
+                            },
+      -flow_into         => {
+                              '2->A' => ['DbFlow'],
+                              'A->2' => ['DbAwareSpeciesFactory'],
+                              '5'    => ['ComparaFlow'],
+                            },
+      -rc_name           => 'normal',
+    },
+    
+    {
+      -logic_name        => 'SpeciesFactory',
+      -module            => 'Bio::EnsEMBL::Production::Pipeline::Common::SpeciesFactory',
+      -max_retry_count   => 0,
+      -input_ids         => [ {} ],
+      -parameters        => {
+                              species      => $self->o('species'),
+                              antispecies  => $self->o('antispecies'),
+                              taxons       => $self->o('taxons'),
+                              antitaxons   => $self->o('antitaxons'),
+                              division     => $self->o('division'),
+                              run_all      => $self->o('run_all'),
+                              meta_filters => $self->o('meta_filters'),
+                              db_type      => $self->o('db_type'),
+                            },
+      -flow_into         => {
+                              '2->A' => ['CoreFlow'],
+                              '3->A' => ['ChromosomeFlow'],
+                              '4->A' => ['VariationFlow'],
+                              '5->A' => ['ComparaFlow'],
+                              '6->A' => ['RegulationFlow'],
+                              '7->A' => ['OtherfeaturesFlow'],
+                              'A->1' => ['SingleFlow'],
+                            },
+      -rc_name           => 'normal',
+    },
+    
+    {
+      -logic_name        => 'DbFlow',
+      -module            => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+      -analysis_capacity => 10,
+      -batch_size        => 100,
+      -max_retry_count   => 0,
+      -rc_name           => 'normal',
+    },
+    
+    {
+      -logic_name        => 'DbAwareSpeciesFactory',
+      -module            => 'Bio::EnsEMBL::Production::Pipeline::Common::DbAwareSpeciesFactory',
+      -analysis_capacity => 10,
+      -batch_size        => 100,
+      -max_retry_count   => 0,
+      -parameters        => {
+                              check_intentions => $self->o('check_intentions'),
+                            },
+      -rc_name           => 'normal',
+      -flow_into         => {
+                              '2->A' => ['CoreFlow'],
+                              '3->A' => ['ChromosomeFlow'],
+                              '4->A' => ['VariationFlow'],
+                              '6->A' => ['RegulationFlow'],
+                              '7->A' => ['OtherfeaturesFlow'],
+                              'A->1' => ['SingleFlow'],
+                            },
+    },
+    
+    {
+      -logic_name        => 'CoreFlow',
+      -module            => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+      -analysis_capacity => 10,
+      -batch_size        => 100,
+      -max_retry_count   => 0,
+      -rc_name           => 'normal',
+    },
+    
+    {
+      -logic_name        => 'SingleFlow',
+      -module            => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+      -analysis_capacity => 10,
+      -batch_size        => 100,
+      -max_retry_count   => 0,
+      -rc_name           => 'normal',
+    },
+    
+    {
+      -logic_name        => 'ChromosomeFlow',
+      -module            => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+      -analysis_capacity => 10,
+      -batch_size        => 100,
+      -max_retry_count   => 0,
+      -rc_name           => 'normal',
+    },
+    
+    {
+      -logic_name        => 'VariationFlow',
+      -module            => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+      -analysis_capacity => 10,
+      -batch_size        => 100,
+      -max_retry_count   => 0,
+      -rc_name           => 'normal',
+    },
+    
+    {
+      -logic_name        => 'ComparaFlow',
+      -module            => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+      -analysis_capacity => 10,
+      -batch_size        => 100,
+      -max_retry_count   => 0,
+      -rc_name           => 'normal',
+    },
+    
+    {
+      -logic_name        => 'RegulationFlow',
+      -module            => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+      -analysis_capacity => 10,
+      -batch_size        => 100,
+      -max_retry_count   => 0,
+      -rc_name           => 'normal',
+    },
+    
+    {
+      -logic_name        => 'OtherfeaturesFlow',
+      -module            => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+      -analysis_capacity => 10,
+      -batch_size        => 100,
+      -max_retry_count   => 0,
+      -rc_name           => 'normal',
+    },
+    
+  ];
+}
+
+sub resource_classes {
+  my ($self) = @_;
+  return {
+    'normal' => {'LSF' => '-q production-rh7 -M 1000 -R "rusage[mem=1000]"'},
+  }
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProteinFeatures_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProteinFeatures_conf.pm
@@ -312,7 +312,7 @@ sub pipeline_analyses {
                               analyses => $self->o('analyses'),
                             },
       -flow_into 	       => {
-                              '1->A' => ['SpeciesFactory'],
+                              '1->A' => ['DbFactory'],
                               'A->1' => WHEN(
                                           '#interpro_desc_source# eq "file"' =>
                                             ['FetchInterPro'],
@@ -324,8 +324,8 @@ sub pipeline_analyses {
     },
     
     {
-      -logic_name        => 'SpeciesFactory',
-      -module            => 'Bio::EnsEMBL::Production::Pipeline::Common::SpeciesFactory',
+      -logic_name        => 'DbFactory',
+      -module            => 'Bio::EnsEMBL::Production::Pipeline::Common::DbFactory',
       -max_retry_count   => 1,
       -parameters        => {
                               species         => $self->o('species'),
@@ -339,7 +339,7 @@ sub pipeline_analyses {
                             },
       -flow_into         => {
                               '2->A' => ['BackupTables'],
-                              'A->2' => ['StoreGoXrefs'],
+                              'A->2' => ['AnnotateProteinFeatures'],
                             },
       -meadow_type       => 'LOCAL',
     },
@@ -363,10 +363,7 @@ sub pipeline_analyses {
                             },
       -rc_name           => 'normal',
       -analysis_capacity => 20,
-      -flow_into         => {
-                              '1->A' => ['AnalysisFactory'],
-                              'A->1' => ['DumpProteome'],
-                            },
+      -flow_into         => ['AnalysisFactory'],
     },
     
     { -logic_name        => 'AnalysisFactory',
@@ -450,6 +447,35 @@ sub pipeline_analyses {
                               pathway_sources => $self->o('pathway_sources'),
                             },
       -rc_name           => 'normal',
+    },
+    
+    {
+      -logic_name        => 'AnnotateProteinFeatures',
+      -module            => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+      -max_retry_count   => 0,
+      -analysis_capacity => 20,
+      -parameters        => {},
+      -rc_name           => 'normal',
+      -flow_into         => {
+                              '1->A' => ['SpeciesFactory'],
+                              'A->1' => ['StoreGoXrefs'],
+                            },
+    },
+    
+    {
+      -logic_name        => 'SpeciesFactory',
+      -module            => 'Bio::EnsEMBL::Production::Pipeline::Common::DbAwareSpeciesFactory',
+      -max_retry_count   => 1,
+      -parameters        => {
+                              chromosome_flow    => 0,
+                              otherfeatures_flow => 0,
+                              regulation_flow    => 0,
+                              variation_flow     => 0,
+                            },
+      -flow_into         => {
+                              '2' => ['DumpProteome'],
+                            },
+      -meadow_type       => 'LOCAL',
     },
     
     {
@@ -666,14 +692,16 @@ sub pipeline_analyses {
       -logic_name      => 'SpeciesFactoryForDumpingInterPro',
       -module          => 'Bio::EnsEMBL::Production::Pipeline::Common::SpeciesFactory',
       -parameters      => {
-                            species         => $self->o('species'),
-                            antispecies     => $self->o('antispecies'),
-                            division        => $self->o('division'),
-                            run_all         => $self->o('run_all'),
-                            chromosome_flow => 0,
-                            regulation_flow => 0,
-                            variation_flow  => 0,
-                            meta_filters    => $self->o('meta_filters'),
+                            species            => $self->o('species'),
+                            antispecies        => $self->o('antispecies'),
+                            division           => $self->o('division'),
+                            run_all            => $self->o('run_all'),
+                            chromosome_flow    => 0,
+                            compara_flow       => 0,
+                            otherfeatures_flow => 0,
+                            regulation_flow    => 0,
+                            variation_flow     => 0,
+                            meta_filters       => $self->o('meta_filters'),
                           },
       -max_retry_count => 1,
       -flow_into       => {
@@ -714,14 +742,16 @@ sub pipeline_analyses {
       -logic_name      => 'SpeciesFactoryForStoringInterPro',
       -module          => 'Bio::EnsEMBL::Production::Pipeline::Common::SpeciesFactory',
       -parameters      => {
-                            species         => $self->o('species'),
-                            antispecies     => $self->o('antispecies'),
-                            division        => $self->o('division'),
-                            run_all         => $self->o('run_all'),
-                            chromosome_flow => 0,
-                            regulation_flow => 0,
-                            variation_flow  => 0,
-                            meta_filters    => $self->o('meta_filters'),
+                            species            => $self->o('species'),
+                            antispecies        => $self->o('antispecies'),
+                            division           => $self->o('division'),
+                            run_all            => $self->o('run_all'),
+                            chromosome_flow    => 0,
+                            compara_flow       => 0,
+                            otherfeatures_flow => 0,
+                            regulation_flow    => 0,
+                            variation_flow     => 0,
+                            meta_filters       => $self->o('meta_filters'),
                           },
       -max_retry_count => 1,
       -flow_into       => {


### PR DESCRIPTION
Database-level operations have been moved from SpeciesFactory to a new parent module, DBFactory.

SpeciesFactory inherits that code, so functions in exactly the same way as previously. However, if your pipeline needs DB-level operations you can use DBFactory directly, and then flow to DbAwareSpeciesFactory, which has almost* the same behaviour as SpeciesFactory, but does not parse the registry, since DBFactory has done that and passed along the necessary data. (* The 'almost' is because DbAwareSpeciesFactory does not flow compara dbs down pipe #5; that behaviour makes no sense, now that DBFactory flows compara dbs down pipe #5.)

Some of the code has been refactored alongside this development, chiefly: the processing of taxonomic parameters has been simplfied; a couple of simple functions for adding/removing species clarify logic and reduce redundancy; detection of chromosomes is done with an API call rather than SQL.

I've created a toy pipeline to test the flow, and have modified the Protein Features pipeline to work appropriately for collecions: the stuff that only needs to be done once (dumping, analyses, xrefs) is only done once, rather than once per species. In order not to break downstream modules, a "species" parameter is still passed to the db-level modules; this is arbitrarily selected from the list of species. Over time, modules that do db-level operations should be changed to not require a species parameter, using instead the db name that is flowed as an output parameter.

I have left the 'check intentions' functionality in the SpeciesFactory, but I do not believe that it should reside there; it caters for a very specific production use case, and would fit better in a dumping-pipeline-specific module. But I don't think I'm the right person to make that change...

Another change which would be good to make, but which I haven't done for fear of breaking extant pipelines, is the SpeciesFactory #1 flow, which outputs a list of species with a parameter named 'species'. This is potentially confusing, because there's a flow #2 parameter, also named 'species', which has a string value. It'd be better to name the former 'all_species', I reckon.
