### PR TITLE
Switching eHive branch to 2.4 for Travis testing, as that's what is u…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ addons:
 before_install:
 - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-test.git
 - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl.git
-- git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-hive.git
+- git clone --branch version/2.4 --depth 1 https://github.com/Ensembl/ensembl-hive.git
 - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-compara.git
 - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-orm.git
 - git clone --branch 1.3.2 --depth 1 https://github.com/samtools/htslib.git


### PR DESCRIPTION
…sed by Production when running pipelines. This protects against eHive based breakages, as with happened with a recent change on their master branch that made FindBin barf.