### PR TITLE
Remove scalar push

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/JSON/JsonRemodeller.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/JSON/JsonRemodeller.pm
@@ -219,7 +219,7 @@ sub collate_xrefs {
       }
       my $evidence = [];
       for my $lt ( @{ $xref->{linkage_types} } ) {
-        push $evidence, $lt->{evidence};
+        push @$evidence, $lt->{evidence};
       }
       # add associated xrefs
       if ( defined $xref->{associated_xrefs} &&

--- a/modules/t/housekeeping_apache2.t
+++ b/modules/t/housekeeping_apache2.t
@@ -47,7 +47,7 @@ foreach my $f (@source_files) {
     next if $f =~ /\/blib\//;
     next if $f =~ /\/HALXS\.c$/;
     next if $f =~ /\.conf\b/;
-    next if $f =~ /\CLEAN\b/;
+    next if $f =~ /CLEAN\b/;
     next if $f =~ /\.(tmpl|hash|nw|ctl|txt|html|textile)$/;
     has_apache2_licence($f);
 }


### PR DESCRIPTION
Pushing to a scalar is classed as experimental in Perl 5.24 . It was probably an accident in this instance.