### PR TITLE
[ENSCORESW-2475]. Override run method as the transcript and noncoding…

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Production/GeneCount.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Production/GeneCount.pm
@@ -26,6 +26,92 @@ use Bio::EnsEMBL::Utils::Scalar qw(assert_ref assert_integer wrap_array);
 
 use base qw/Bio::EnsEMBL::Production::Pipeline::Production::StatsGenerator/;
 
+sub run {
+  my ($self) = @_;
+  my $species    = $self->param('species');
+
+  $self->dbc()->disconnect_if_idle() if defined $self->dbc();
+
+  my $dba        = Bio::EnsEMBL::Registry->get_DBAdaptor($species, 'core');
+  my $ta         = Bio::EnsEMBL::Registry->get_adaptor($species, 'core', 'transcript');
+  my $aa         = Bio::EnsEMBL::Registry->get_adaptor($species, 'core', 'attribute');
+
+  my $has_readthrough = 0;
+  my @readthroughs = @{ $aa->fetch_all_by_Transcript(undef, 'readthrough_tra') };
+  $has_readthrough = 1 if @readthroughs;
+
+  my %attrib_codes = $self->get_attrib_codes($has_readthrough);
+  $self->delete_old_attrib($dba, %attrib_codes);
+  $self->delete_old_stats($dba, %attrib_codes);
+  
+  my %alt_attrib_codes = $self->get_alt_attrib_codes($has_readthrough);
+  $self->delete_old_attrib($dba, %alt_attrib_codes);
+  $self->delete_old_stats($dba, %alt_attrib_codes);
+  
+  my $count;
+  my $alt_count;
+
+  my %stats_hash;
+  my %stats_attrib;
+
+  my $ref_length = $self->get_ref_length();
+  $stats_hash{ref_length} = $ref_length if $ref_length;
+  
+  my $total_length = $self->get_total_length();
+  $stats_hash{total_length} = $total_length if $total_length;
+
+  my @all_sorted_slices =
+   sort( { $a->coord_system()->rank() <=> $b->coord_system()->rank()
+           || $b->seq_region_length() <=> $a->seq_region_length() } @{$self->get_all_slices($species)}) ;
+  while (my $slice = shift @all_sorted_slices) {
+    next if $slice->seq_region_name =~ /LRG/;
+    
+    if ($slice->is_reference) {
+      $stats_hash{'transcript'} += $ta->count_all_by_Slice($slice);
+      $stats_attrib{'transcript'} = 'transcript_cnt';
+      
+      foreach my $ref_code (keys %attrib_codes) {
+        $count = $self->get_feature_count($slice, $ref_code, $attrib_codes{$ref_code});
+	$self->store_attrib($slice, $count, $ref_code) if $count > 0;
+        $stats_hash{$ref_code} += $count;
+      }
+      
+      $count = $self->get_attrib($slice, 'noncoding_cnt_%');
+      $self->store_attrib($slice, $count, 'noncoding_cnt') if $count > 0;
+      
+      $stats_hash{'noncoding_cnt'} += $count;
+      $stats_attrib{'noncoding_cnt'} = 'noncoding_cnt';
+      
+    } else {
+      my $sa = Bio::EnsEMBL::Registry->get_adaptor($species, 'core', 'slice');
+      my $alt_slices = $sa->fetch_by_region_unique($slice->coord_system->name(), $slice->seq_region_name());
+      
+      foreach my $alt_slice (@$alt_slices) {
+        $stats_hash{'alt_transcript'} += $ta->count_all_by_Slice($alt_slice);
+        $stats_attrib{'alt_transcript'} = 'transcript_acnt';
+	
+        foreach my $alt_code (keys %alt_attrib_codes) {
+          $alt_count = $self->get_feature_count($alt_slice, $alt_code, $alt_attrib_codes{$alt_code});
+	  $self->store_attrib($slice, $alt_count, $alt_code) if $alt_count > 0;
+          $stats_hash{$alt_code} += $alt_count;
+        }
+	
+        $alt_count = $self->get_attrib($slice, 'noncoding_acnt_%');
+	$self->store_attrib($slice, $alt_count, 'noncoding_acnt') if $alt_count > 0;
+	
+        $stats_hash{'noncoding_acnt'} += $alt_count;
+        $stats_attrib{'noncoding_acnt'} = 'noncoding_acnt';
+      }
+    }    
+  }
+  
+  $self->store_statistics($species, \%stats_hash, \%stats_attrib);
+
+  # disconnecting from the registry
+  $dba->dbc->disconnect_if_idle();
+  my $prod_dba    = $self->get_production_DBAdaptor();
+  $prod_dba->dbc()->disconnect_if_idle();
+}
 
 sub get_attrib_codes {
   my ($self, $has_readthrough) = @_;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Production/SnpCount.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Production/SnpCount.pm
@@ -24,7 +24,45 @@ use warnings;
 
 use base qw/Bio::EnsEMBL::Production::Pipeline::Production::StatsGenerator/;
 
+sub run {
+  my ($self) = @_;
+  my $species    = $self->param('species');
 
+  $self->dbc()->disconnect_if_idle() if defined $self->dbc();
+
+  my $dba = Bio::EnsEMBL::Registry->get_DBAdaptor($species, 'core');
+  my $aa  = Bio::EnsEMBL::Registry->get_adaptor($species, 'core', 'attribute');
+
+  my %attrib_codes = $self->get_attrib_codes();
+  $self->delete_old_attrib($dba, %attrib_codes);
+  $self->delete_old_stats($dba, %attrib_codes);
+  
+  my $count;
+  my $alt_count;
+
+  my %stats_hash;
+  my %stats_attrib;
+
+  my @all_sorted_slices =
+   sort( { $a->coord_system()->rank() <=> $b->coord_system()->rank()
+           || $b->seq_region_length() <=> $a->seq_region_length() } @{$self->get_all_slices($species)}) ;
+  while (my $slice = shift @all_sorted_slices) {
+    next unless $slice->is_reference; # no alt attribs ATMO
+    
+    foreach my $ref_code (keys %attrib_codes) {
+      $count = $self->get_feature_count($slice, $ref_code, $attrib_codes{$ref_code});
+      $self->store_attrib($slice, $count, $ref_code) if $count > 0;
+      $stats_hash{$ref_code} += $count;
+    }    
+  }
+  
+  $self->store_statistics($species, \%stats_hash, \%stats_attrib);
+
+  # disconnecting from the registry
+  $dba->dbc->disconnect_if_idle();
+  my $prod_dba    = $self->get_production_DBAdaptor();
+  $prod_dba->dbc()->disconnect_if_idle();
+}
 
 sub get_feature_count {
   my ($self, $slice, $key) = @_;
@@ -77,13 +115,6 @@ sub get_attrib_codes {
   my %attrib_codes = %{ $prod_helper->execute_into_hash(-SQL => $sql) };
   return %attrib_codes;
 }
-
-# Blank as I don't think there are any alt attrib codes for this ATMO
-sub get_alt_attrib_codes {
-  my ($self) = @_;
-  return;
-}
-
 
 1;
 


### PR DESCRIPTION
… parts are not the object of SnpCount processing. This is also preventing the SnpCount (or any other) pipeline to update noncoding global counts while leaving intact the specific ones.

This is in line with the latest findings as it does seem the problem comes from running GeneCount at one stage in the release and later SnpCount at variation handover. For some, yet unknown, reason, SnpCount recomputes global noncoding counts but at that stage that figure is not reflecting the total that comes by summing the individual (i.e. *_[slm]) values.

The changes presented here separates the two concerns entirely: SnpCount does not update and gene nonglobal count.