### PR TITLE
Replace Bioperl 1.2.3 with 1.6.924 in test environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ before_install:
 - make
 - export HTSLIB_DIR=$(pwd -P)
 - cd ..
-- wget https://github.com/bioperl/bioperl-live/archive/bioperl-release-1-2-3.zip
-- unzip bioperl-release-1-2-3.zip
+- wget https://github.com/bioperl/bioperl-live/archive/release-1-6-924.zip
+- unzip release-1-6-924.zip
 
 install:
 - cpanm -v --installdeps --with-recommends --notest --cpanfile ensembl/cpanfile .


### PR DESCRIPTION
In anticipation of standardising on 1.6.924, production can now test on the newest safe version of BioPerl. 1.7.2 currently blocked by a codon issue https://github.com/bioperl/bioperl-live/issues/266