### PR TITLE
- Foreign key statement regex was missing that there could be a space…

### DIFF
--- a/scripts/sql2html.pl
+++ b/scripts/sql2html.pl
@@ -465,7 +465,7 @@ if ($fk_sql_file) {
       chomp $_;
       next if ($_ eq '');
       my $doc = remove_char($_);
-      if ($doc =~ /ALTER\s+TABLE\s+(\S+)\s+ADD.*FOREIGN\s+KEY\s+\((\S+)\)\s+REFERENCES\s+(\S+)\((\S+)\)/i) {
+      if ($doc =~ /ALTER\s+TABLE\s+(\S+)\s+ADD.*FOREIGN\s+KEY\s+\((\S+)\)\s+REFERENCES\s+(\S+)\s*\((\S+)\)/i) {
           push @{$table_documentation{$1}->{foreign_keys}}, [$2,$3,$4];
       } elsif ($doc =~ /ALTER.*FOREIGN/i) {
           die "Unrecognized contruct: $doc";
@@ -499,7 +499,10 @@ sub generate_whole_diagram {
         table_box($graph, $table_name);
     }
     foreach my $table_name (sort keys %table_documentation) {
+	my %seen_fk = ();
         foreach my $fk (@{$table_documentation{$table_name}->{foreign_keys}}) {
+	    next if( defined $seen_fk{ $fk->[1] } );
+	    $seen_fk{ $fk->[1] } = 1;
             $graph->add_edge($table_name => $fk->[1],
                 'style' => 'dashed',
                 $column_links ? (
@@ -577,7 +580,11 @@ sub generate_sub_diagram {
     my %other_table_fields;
     my @drawn_fks;
     foreach my $table_name (sort keys %table_documentation) {
+	my %seen_fk = ();
         foreach my $fk (@{$table_documentation{$table_name}->{foreign_keys}}) {
+	    next if( defined $seen_fk{ $fk->[1] } );
+	    $seen_fk{ $fk->[1] } = 1;
+
             if ($table_documentation{$table_name}->{category} eq $cluster) {
                 $other_table_fields{$fk->[1]}->{$fk->[2]} = 1;
                 $clusters_to_draw{ $table_documentation{$fk->[1]}->{category} } = 1;


### PR DESCRIPTION
… between the table name and column in the key being referenced

- Schemas like Core that have two foreign keys pointing from one table to the same other table caused GraphViz to segfault, add check so the edge isn't added twice