### PR TITLE
enforce null version, no matter what the API tries to do

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/ProteinFeatures/StoreGoXrefs.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/ProteinFeatures/StoreGoXrefs.pm
@@ -139,6 +139,7 @@ sub store_go_xref {
     
         my $go_xref = Bio::EnsEMBL::OntologyXref->new(%go_xref_args);
         $go_xref->add_linkage_type('IEA', $interpro_xref);
+        $go_xref->{version} = undef;
         $dbea->store($go_xref, $transcript_id, 'Transcript', 1);
       }
     }


### PR DESCRIPTION
spurious version=0 set silently by the API causes problems with duplicates.