### PR TITLE
ENSCORESW-2789: early error catching

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/ParseSource.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/ParseSource.pm
@@ -55,11 +55,12 @@ sub run {
   my $module = "XrefParser::$parser";
   eval "require $module";
   my $xref_run = $module->new($xref_dbc);
+  my $failure = 0;
   if (defined $db) {
     my $registry = 'Bio::EnsEMBL::Registry';
     my $dba = $registry->get_DBAdaptor($species, $db);
     $dba->dbc()->disconnect_if_idle();
-    $xref_run->run_script( { source_id  => $source_id,
+    $failure += $xref_run->run_script( { source_id  => $source_id,
                              species_id => $species_id,
                              dba        => $dba,
                              rel_file   => $release_file,
@@ -68,13 +69,14 @@ sub run {
                              file       => $file_name}) ;
     $self->cleanup_DBAdaptor($db);
   } else {
-    $xref_run->run( { source_id  => $source_id,
+    $failure += $xref_run->run( { source_id  => $source_id,
                       species_id => $species_id,
                       species    => $species,
                       rel_file   => $release_file,
                       dbi        => $dbi,
                       files      => [@files] }) ;
   }
+  if ($failure) { die; }
 
 }
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/ScheduleSource.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/ScheduleSource.pm
@@ -23,6 +23,7 @@ use warnings;
 use XrefParser::Database;
 use File::Basename;
 use File::Spec::Functions;
+use Carp;
 
 use parent qw/Bio::EnsEMBL::Production::Pipeline::Xrefs::Base/;
 
@@ -90,7 +91,14 @@ sub run {
     if (defined $db) {
       my $registry = 'Bio::EnsEMBL::Registry';
       $dba = $registry->get_DBAdaptor($species, $db);
-      next unless $dba;
+      if (!$dba) {
+        # Not all species have an otherfeatures database
+        if ($db eq 'otherfeatures') {
+          next;
+        } else {
+          confess("Cannot use $parser for $species, no $db database") unless $dba;
+        }
+      }
     }
 
     if ($file_name eq 'Database') {


### PR DESCRIPTION
If the CCDS database is missing, the pipeline will carry on running but human will not have any HGNC xrefs, which is bad as far as xrefs are concerned.
The proposed change will die at the submission stage if the database to connect to is missing. It will not die if the database is an otherfeatures database, because not all species have it.
Additionally, we now capture the return code from the various xref parsers, so if an error is raised in the parser without killing the process, the runnable will do it for us.
This change is not critical for the release 94 run, but it will probably help in identifying possible issues in setting up the pipeline