### PR TITLE
remove UCSC source

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_sources.json
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_sources.json
@@ -156,20 +156,6 @@
       "priority" : 1
     },
     {
-      "name" : "UCSC_hg38",
-      "parser" : "UCSCParser",
-      "file" : "ftp://hgdownload.cse.ucsc.edu/goldenPath/hg38/database/knownGene.txt.gz",
-      "release" : "ftp://hgdownload.cse.ucsc.edu/goldenPath/hg38/database/README.txt",
-      "priority" : 1
-    },
-    {
-      "name" : "UCSC_mm10",
-      "parser" : "UCSCParser",
-      "file" : "ftp://hgdownload.cse.ucsc.edu/goldenPath/mm10/database/knownGene.txt.gz",
-      "release" : "ftp://hgdownload.cse.ucsc.edu/goldenPath/mm10/database/README.txt",
-      "priority" : 1
-    },
-    {
       "name" : "Uniprot/SWISSPROT",
       "parser" : "UniProtParser",
       "file" : "ftp://ftp.ebi.ac.uk/pub/databases/uniprot/knowledgebase/uniprot_sprot.dat.gz",


### PR DESCRIPTION
Remove UCSC source from xref pipeline
There is currently an issue when mapping UCSC xrefs to Ensembl so it is safer to leave the source out altogether