### PR TITLE
ENSCORESW-2793: reduce memory consumption

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/DownloadSource.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/DownloadSource.pm
@@ -35,10 +35,6 @@ sub run {
   my $version_file     = $self->param('version_file');
 
   $self->dbc()->disconnect_if_idle() if defined $self->dbc();
-  my ($user, $pass, $host, $port, $source_db) = $self->parse_url($db_url);
-  my $dbi = $self->get_dbi($host, $port, $user, $pass, $source_db);
-  my $insert_source_sth = $dbi->prepare("INSERT IGNORE INTO source (name, parser) VALUES (?, ?)");
-  my $insert_version_sth = $dbi->prepare("INSERT ignore INTO version (source_id, uri, index_uri, count_seen, revision) VALUES ((SELECT source_id FROM source WHERE name = ?), ?, ?, ?, ?)");
 
   my $file_name = $self->download_file($file, $base_path, $name, $db);
   my $version;
@@ -46,6 +42,10 @@ sub run {
     $version = $self->download_file($version_file, $base_path, $name, $db, 'version');
   }
 
+  my ($user, $pass, $host, $port, $source_db) = $self->parse_url($db_url);
+  my $dbi = $self->get_dbi($host, $port, $user, $pass, $source_db);
+  my $insert_source_sth = $dbi->prepare("INSERT IGNORE INTO source (name, parser) VALUES (?, ?)");
+  my $insert_version_sth = $dbi->prepare("INSERT ignore INTO version (source_id, uri, index_uri, count_seen, revision) VALUES ((SELECT source_id FROM source WHERE name = ?), ?, ?, ?, ?)");
   $insert_source_sth->execute($name, $parser);
   $insert_version_sth->execute($name, $file_name, $db, $priority, $version);
   $insert_source_sth->finish();


### PR DESCRIPTION
Apologies for yet another change.
I noticed some jobs die with MEMLIMIT when downloading files, but not always. It is usually fine but if the resource is busy, the download takes longer and this exposes a problem with a memory leak in the code.
The memory leak is fixed by preparing the statements once the files have been downloaded rather than before, meaning they do not stay open while waiting for the download.
This should make the pipeline more robust to race conditions and busy resources