### PR TITLE
ignore coordinate_checksum as no UCSC is loaded

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/CoordinateMapping.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/CoordinateMapping.pm
@@ -37,7 +37,7 @@ sub run {
   my $mapper = $self->get_xref_mapper($xref_url, $species, $base_path, $release);
   my $coord = XrefMapper::CoordinateMapper->new($mapper);
   my $species_id = $self->get_taxon_id($species);
-  $coord->run_coordinatemapping(1, $species_id);
+  #$coord->run_coordinatemapping(1, $species_id);
 
 }
 


### PR DESCRIPTION
This patch is to skip the coordinate_mapping stage. This is normally run on the UCSC data loaded at the parsing stage. Because there are some issues with the UCSC data, we have removed it from the list of sources, which means there is no data in the database. The code checks for its existence though, so we skip the coordinate_mapping stage altogether to avoid the problem.
Once we have decided what we want to do with the UCSC data in the future, we will provide a cleaner solution, but this will allow the pipeline to run for release 94