### PR TITLE
Xrefs: Import the versioning schema from VersioningService

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/Xref_update_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/Xref_update_conf.pm
@@ -48,7 +48,7 @@ sub default_options {
            ## Parameters for source download
            'config_file'      => $self->o('ENV', 'HOME')."/work/lib/ensembl-production/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_sources.json",
            'source_url'       => '',
-           'source_dir'       => $self->o('ENV', 'HOME')."/work/lib/VersioningService/sql",
+           'source_dir'       => $self->o('ENV', 'HOME')."/work/lib/ensembl-production/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/sql",
            'source_host'      => '',
            'source_port'      => '',
            'source_user'      => '',

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/sql/table.sql
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/sql/table.sql
@@ -1,0 +1,110 @@
+-- Copyright [1999-2013] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+-- 
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+-- 
+--      http://www.apache.org/licenses/LICENSE-2.0
+-- 
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+# Versioning db table definitions
+#
+
+# Conventions:
+#  - use lower case and underscores
+#  - internal ids are integers named tablename_id
+#  - same name is given in foreign key relations
+
+CREATE TABLE source_group (
+  source_group_id          INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
+  name                     VARCHAR(128),
+  created_date             TIMESTAMP NOT NULL DEFAULT NOW(),
+
+  PRIMARY KEY (source_group_id),
+  unique KEY name_idx (name)
+
+) COLLATE=latin1_swedish_ci ENGINE=InnoDB;
+
+CREATE TABLE checksum_xref (
+  checksum_xref_id  INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  source_id         INT UNSIGNED NOT NULL,
+  accession         CHAR(14) NOT NULL,
+  checksum          CHAR(32) NOT NULL,
+
+  PRIMARY KEY (checksum_xref_id),
+  INDEX checksum_idx(checksum(10))
+) COLLATE=latin1_swedish_ci ENGINE=MyISAM;
+
+
+CREATE TABLE source (
+  source_id                INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
+  name                     VARCHAR(128),
+  source_group_id          INT(10) UNSIGNED,
+  active                   BOOLEAN NOT NULL DEFAULT 1,
+  created_date             TIMESTAMP NOT NULL DEFAULT NOW(),
+  downloader               VARCHAR(128),
+  parser                   VARCHAR(128),
+  current_version          INT(10) UNSIGNED,
+
+  PRIMARY KEY (source_id),
+  UNIQUE KEY name_idx (name),
+  FOREIGN KEY (source_group_id) REFERENCES source_group(source_group_id)
+
+) COLLATE=latin1_swedish_ci ENGINE=InnoDB;
+
+CREATE TABLE run (
+  run_id                   INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
+  start                    TIMESTAMP NOT NULL DEFAULT NOW(),
+  end                      TIMESTAMP,
+
+  PRIMARY KEY (run_id)
+
+) COLLATE=latin1_swedish_ci ENGINE=InnoDB;
+
+CREATE TABLE version (
+  version_id               INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
+  source_id                INT(10) UNSIGNED,
+  revision                 VARCHAR(255),
+  created_date             TIMESTAMP NOT NULL DEFAULT NOW(),
+  count_seen               INT(10) UNSIGNED NOT NULL,
+  record_count             INT(10),
+  uri                      VARCHAR(255),
+  index_uri                VARCHAR(255),
+
+  PRIMARY KEY (version_id),
+  KEY version_idx (source_id, revision),
+  FOREIGN KEY (source_id) REFERENCES source(source_id)
+
+) COLLATE=latin1_swedish_ci ENGINE=InnoDB;
+
+CREATE TABLE process (
+  process_id               INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
+  run_id                   INT(10) UNSIGNED,
+  name                     VARCHAR(128),
+  created_date             TIMESTAMP NOT NULL DEFAULT NOW(),
+
+  PRIMARY KEY (process_id),
+  UNIQUE KEY name_idx (name),
+  FOREIGN KEY (run_id) REFERENCES run(run_id)
+
+) COLLATE=latin1_swedish_ci ENGINE=InnoDB;
+
+CREATE TABLE version_run (
+  version_run_id           INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
+  version_id               INT(10) UNSIGNED,
+  run_id                   INT(10) UNSIGNED,
+
+  PRIMARY KEY (version_run_id),
+  FOREIGN KEY (version_id) REFERENCES version(version_id),
+  FOREIGN KEY (run_id) REFERENCES run(run_id)
+
+) COLLATE=latin1_swedish_ci ENGINE=InnoDB;
+
+
+
+


### PR DESCRIPTION
This is so that the xref pipeline no longer depends on the
VersioningService repository for a single file. See

https://www.ebi.ac.uk/panda/jira/browse/ENSCORESW-2728 .

The imported file is the latest available version as of 2018-08-02:
VersioningService commit 6377671892cf897b70fb1a6603dc4ee398818a58 ,
sha256sum ee6a7335fa3835895b721e4b6a1926b4d7db04f645cec8eed5dd59443191b834 .

For the time being the original is still present in VersioningService
but its use is deprecated, it will be removed at some point in the near
future.

Note: this file needs a copyright update but either leave it until after
the version in VersioningService has been removed or update it in both
repos.