### PR TITLE
Added generation of a new containing all the species without ortholog…

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Ortholog/SourceFactory.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Ortholog/SourceFactory.pm
@@ -82,7 +82,6 @@ sub write_output {
 		if ($cleanup_dir){
 			unlink glob "$dir_name/*";
 		}
-
 		$self->dataflow_output_id( {  'output_dir'     => $dir_name,
 					      'division'       => $division,
 					      'compara'        => $compara,
@@ -93,7 +92,9 @@ sub write_output {
 					      'antitaxons'     => $antitaxons,
  	 				      'homology_types' => $homology_types, },
                        2 );
-	    $self->dataflow_output_id( {  'output_dir'     => $dir_name, },
+			#Flowing all the species to figure out species without orthologs
+	    $self->dataflow_output_id( {  'output_dir'     => $dir_name,
+					      'division'       => $division },
 					   1 );
 	}
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Ortholog/SourceFactory.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Ortholog/SourceFactory.pm
@@ -92,7 +92,7 @@ sub write_output {
 					      'antitaxons'     => $antitaxons,
  	 				      'homology_types' => $homology_types, },
                        2 );
-			#Flowing all the species to figure out species without orthologs
+			#Flowing all the species to figure out species without orthology-based projection
 	    $self->dataflow_output_id( {  'output_dir'     => $dir_name,
 					      'division'       => $division },
 					   1 );

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Ortholog/SpeciesNoOrthologs.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Ortholog/SpeciesNoOrthologs.pm
@@ -20,6 +20,10 @@ Bio::EnsEMBL::Production::Pipeline::Ortholog::SpeciesNoOrthologs;
 
 =head1 DESCRIPTION
 
+This module get a list of all the available species for a given division, then get the list of all the species that we project to
+by parsing all the ortholog files. The module then compare both list to get all the species without orthology-based projection. 
+These species get stored in a file called "genome_no_orthologs.txt" with the date, release number, division and species taxon id.
+
 =head1 AUTHOR
 
 maurel@ebi.ac.uk

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Ortholog/SpeciesNoOrthologs.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Ortholog/SpeciesNoOrthologs.pm
@@ -1,0 +1,85 @@
+=head1 LICENSE
+
+Copyright [2009-2018] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+Bio::EnsEMBL::Production::Pipeline::Ortholog::SpeciesNoOrthologs;
+
+=head1 DESCRIPTION
+
+=head1 AUTHOR
+
+maurel@ebi.ac.uk
+
+=cut
+package Bio::EnsEMBL::Production::Pipeline::Ortholog::SpeciesNoOrthologs;
+
+use strict;
+use warnings;
+use Bio::EnsEMBL::Registry;
+use Bio::EnsEMBL::Utils::SqlHelper;
+use Bio::EnsEMBL::Utils::Exception qw(throw);
+use File::Path qw(make_path);
+use File::Spec::Functions qw(catdir);
+use base('Bio::EnsEMBL::Production::Pipeline::Common::Base');
+
+sub run {
+    my ($self) = @_;
+    #Getting the list of all species, output dir and release
+    my $all_species = $self->param('species');
+    my @all_projected_species=();
+    my $datestring  = localtime();
+    my $output_dir  = $self->param('output_dir');
+    my $release = $self->param('release');
+
+    opendir(DIR, $output_dir) or die $!;     
+    # Get list of species that we project to by parsing all the otholog files
+    while (my $file = readdir(DIR)) {
+	    next unless ($file =~ m/^orthologs-.*tsv$/);
+      my $species = $1 if($file=~/orthologs-.*\-(.+)\.tsv/);
+      push @all_projected_species, $species;
+    }
+
+    if (!-e $output_dir) {
+       $self->warning("Output directory '$output_dir' does not exist. I shall create it.");
+       make_path($output_dir) or $self->throw("Failed to create output directory '$output_dir'");
+    }
+    my $output_file = "/genome_no_orthologs.txt";
+    $output_file    = File::Spec->catdir($output_dir, $output_file);
+    #Store header with date, release and division output directory
+    open FILE , ">$output_file" or die "couldn't open file " . $output_file . " $!";
+    print FILE "## " . $datestring . "\n";
+    print FILE "## release " . $release . "\n";
+    print FILE "## division " . $output_dir . "\n"; 
+    
+    # Figure out species that were not projected
+    my %all_projected_species = map {$_ => 1} @all_projected_species;
+    my @species_without_orthologs  = grep {not $all_projected_species{$_}} @{$all_species};
+    
+    #Get species taxon id and store species without orthologs in the file.
+    for my $species (@species_without_orthologs){
+      my $meta_container = Bio::EnsEMBL::Registry->get_adaptor( $species, 'Core', 'MetaContainer' );
+      my $taxon_id = $meta_container->get_taxonomy_id();
+      print FILE $species . "\t" . $taxon_id ."\n";
+      $meta_container->dbc->disconnect_if_idle()
+    }
+    close FILE;
+	  $self->dataflow_output_id( {  'output_dir'     => $output_dir },
+				   1 );
+return;
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpOrtholog_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpOrtholog_conf.pm
@@ -110,7 +110,8 @@ sub pipeline_analyses {
 						'cleanup_dir'     => $self->o('cleanup_dir')
 		   	 },
 		    -flow_into  => { '2->A'              => ['SpeciesFactory'],
-				    'A->1' => [ 'RunCreateReleaseFile'  ] },
+				    'A->1' => [ 'SpeciesFactoryAll'  ],
+						},
 		    -rc_name    => 'default',
 		 },
 
@@ -122,6 +123,25 @@ sub pipeline_analyses {
                                  },
              -rc_name         => 'default',
           },
+			{  -logic_name      => 'SpeciesFactoryAll',
+             -module          => 'Bio::EnsEMBL::Production::Pipeline::Common::SpeciesFactory',
+             -max_retry_count => 1,
+             -flow_into       => {
+                                  '1' => ['SpeciesNoOrthologs'],
+                                 },
+             -rc_name         => 'default',
+          },
+
+		{  -logic_name => 'SpeciesNoOrthologs',
+		   -module => 'Bio::EnsEMBL::Production::Pipeline::Ortholog::SpeciesNoOrthologs',
+		   -parameters => {
+			      'release' => $self->o('release'),
+       },
+		   -batch_size    => 1,
+			 -flow_into       => {
+				 '1' => ['RunCreateReleaseFile'],
+			 } ,
+		   -rc_name       => 'default',},
 
 		{  -logic_name => 'GetOrthologs',
 		   -module => 'Bio::EnsEMBL::Production::Pipeline::Ortholog::DumpFile',


### PR DESCRIPTION
…s, more details on JIRA ticket: ENSPROD-1482. Pipeline will run as usual generating ortholog files. Once this is done, it will gather a list of all the species for a given division, gather the list of species that we have projected to, compare both list and store species without orthologs into a new file called genome_no_orthologs.txt