### PR TITLE
Add to output of SpeciesFactory module

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Common/SpeciesFactory.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Common/SpeciesFactory.pm
@@ -56,18 +56,33 @@ sub param_defaults {
 
 sub write_output {
   my ($self) = @_;
-  my $all_species      = $self->param_required('all_species');
-  my $all_species_flow = $self->param('all_species_flow');
-  my $core_flow        = $self->param('core_flow');
+  my $all_species        = $self->param_required('all_species');
+  my $all_species_flow   = $self->param('all_species_flow');
+  my $core_flow          = $self->param('core_flow');
+  my $chromosome_flow    = $self->param('chromosome_flow');
+  my $variation_flow     = $self->param('variation_flow');
+  my $compara_flow       = $self->param('compara_flow');
+  my $regulation_flow    = $self->param('regulation_flow');
+  my $otherfeatures_flow = $self->param('otherfeatures_flow');
 
   foreach my $species ( @{$all_species} ) {
-    $self->dataflow_output_id( {'species' => $species}, $core_flow );
+    $self->dataflow_output_id(
+      {
+        species => $species,
+        group   => 'core',
+      },
+    $core_flow);
   }
 
-  my $flow_species = $self->flow_species($all_species);
-  foreach my $flow ( keys %$flow_species ) {
-    foreach my $species ( @{ $$flow_species{$flow} } ) {
-      $self->dataflow_output_id( {'species' => $species}, $flow );
+  my ($flow, $flow_species) = $self->flow_species($all_species);
+  foreach my $group ( keys %$flow ) {
+    foreach my $species ( @{ $$flow_species{$group} } ) {
+      $self->dataflow_output_id(
+        {
+          species => $species,
+          group   => $group,
+        },
+      $$flow{$group} );
     }
   }
 
@@ -76,12 +91,12 @@ sub write_output {
 
 sub flow_species {
   my ($self, $all_species) = @_;
-  my $compara_dbs        = $self->param('compara_dbs');
   my $chromosome_flow    = $self->param('chromosome_flow');
   my $variation_flow     = $self->param('variation_flow');
   my $compara_flow       = $self->param('compara_flow');
   my $regulation_flow    = $self->param('regulation_flow');
   my $otherfeatures_flow = $self->param('otherfeatures_flow');
+  my $compara_dbs        = $self->param('compara_dbs');
 
   my @chromosome_species;
   my @variation_species;
@@ -121,15 +136,23 @@ sub flow_species {
     };
   }
 
-  my $flow_species = {
-    $chromosome_flow    => \@chromosome_species,
-    $variation_flow     => \@variation_species,
-    $regulation_flow    => \@regulation_species,
-    $otherfeatures_flow => \@otherfeatures_species,
-    $compara_flow       => \@compara_species,
+  my $flow = {
+    'core'          => $chromosome_flow,
+    'variation'     => $variation_flow,
+    'regulation'    => $regulation_flow,
+    'otherfeatures' => $otherfeatures_flow,
+    'compara'       => $compara_flow,
   };
 
-  return $flow_species;
+  my $flow_species = {
+    'core'          => \@chromosome_species,
+    'variation'     => \@variation_species,
+    'regulation'    => \@regulation_species,
+    'otherfeatures' => \@otherfeatures_species,
+    'compara'       => \@compara_species,
+  };
+
+  return ($flow, $flow_species);
 }
 
 sub has_chromosome {

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Common/SpeciesFactory.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Common/SpeciesFactory.pm
@@ -56,9 +56,9 @@ sub param_defaults {
 
 sub write_output {
   my ($self) = @_;
-  my $all_species        = $self->param_required('all_species');
-  my $all_species_flow   = $self->param('all_species_flow');
-  my $core_flow          = $self->param('core_flow');
+  my $all_species      = $self->param_required('all_species');
+  my $all_species_flow = $self->param('all_species_flow');
+  my $core_flow        = $self->param('core_flow');
 
   foreach my $species ( @{$all_species} ) {
     $self->dataflow_output_id(
@@ -88,10 +88,9 @@ sub flow_species {
   my ($self, $all_species) = @_;
   my $chromosome_flow    = $self->param('chromosome_flow');
   my $variation_flow     = $self->param('variation_flow');
-  my $compara_flow       = $self->param('compara_flow');
   my $regulation_flow    = $self->param('regulation_flow');
   my $otherfeatures_flow = $self->param('otherfeatures_flow');
-  my $compara_dbs        = $self->param('compara_dbs');
+  my $compara_flow       = $self->param('compara_flow');
 
   my @chromosome_species;
   my @variation_species;
@@ -126,6 +125,7 @@ sub flow_species {
   }
 
   if ($compara_flow) {
+    my $compara_dbs = $self->param('compara_dbs');
     foreach my $division ( keys %$compara_dbs ) {
       push @compara_species, $division;
     };

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Common/SpeciesFactory.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Common/SpeciesFactory.pm
@@ -59,11 +59,6 @@ sub write_output {
   my $all_species        = $self->param_required('all_species');
   my $all_species_flow   = $self->param('all_species_flow');
   my $core_flow          = $self->param('core_flow');
-  my $chromosome_flow    = $self->param('chromosome_flow');
-  my $variation_flow     = $self->param('variation_flow');
-  my $compara_flow       = $self->param('compara_flow');
-  my $regulation_flow    = $self->param('regulation_flow');
-  my $otherfeatures_flow = $self->param('otherfeatures_flow');
 
   foreach my $species ( @{$all_species} ) {
     $self->dataflow_output_id(


### PR DESCRIPTION
Add the type of database ('group' in the parlance of the Registry) as an output parameter that is flowed to subsequent modules. This is required by embedded datachecks, which need to know not only the species, but the type of database to which they should be applied.