### PR TITLE
Tweaks to xref pipeline config

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/Xref_update_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/Xref_update_conf.pm
@@ -37,13 +37,13 @@ sub default_options {
            'release'          => software_version(),
            'pipeline_name'    => 'xref_update_'.$self->o('release'),
 
-           'work_dir'         => $self->o('ENV', 'HOME')."/work/lib";
+           'work_dir'         => $self->o('ENV', 'HOME')."/work/lib",
            'sql_dir'          => $self->o('work_dir')."/ensembl/misc-scripts/xref_mapping",
  
            ## 'job_factory' parameters
            'species'          => [],
-           'antispecies'      => [qw/mus_musculus_129s1svimj mus_musculus_aj mus_musculus_akrj mus_musculus_balbcj mus_musculus_c3hhej mus_musculus_c57bl6nj mus_musculus_cbaj mus_musculus_dba2j mus_musculus_fvbnj mus_musculus_lpj mus_musculus_nodshiltj mus_musculus_nzohlltj mus_musculus_pwkphj mus_musculus_wsbeij drosophila_melanogaster caenorhabditis_elegans saccharomyces_cerevisiae/],
-           'division'         => 'EnsemblVertebrates',
+           'antispecies'      => [],
+           'division'         => [],
            'run_all'          => 0,
 
            ## Parameters for source download

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/Xref_update_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/Xref_update_conf.pm
@@ -55,7 +55,7 @@ sub default_options {
            'skip_download'    => 0,
 
            ## Parameters for xref database
-           'xref_db'          => '',
+           'xref_url'         => '',
            'xref_user'        => '',
            'xref_pass'        => '',
            'xref_host'        => '',
@@ -126,7 +126,7 @@ sub pipeline_analyses {
                              priority      => 1,
                              base_path     => $self->o('base_path'),
                              source_url    => $self->o('source_url'),
-                             xref_db       => $self->o('xref_db'),
+                             xref_url      => $self->o('xref_url'),
                              xref_host     => $self->o('xref_host'),
                              xref_port     => $self->o('xref_port'),
                              xref_user     => $self->o('xref_user'),
@@ -143,7 +143,7 @@ sub pipeline_analyses {
                              priority      => 2,
                              base_path     => $self->o('base_path'),
                              source_url    => $self->o('source_url'),
-                             xref_db       => $self->o('xref_db'),
+                             xref_url      => $self->o('xref_url'),
                              xref_host     => $self->o('xref_host'),
                              xref_port     => $self->o('xref_port'),
                              xref_user     => $self->o('xref_user'),

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/Xref_update_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/Xref_update_conf.pm
@@ -35,9 +35,11 @@ sub default_options {
            %{ $self->SUPER::default_options() },
            'email'            => $self->o('ENV', 'USER').'@ebi.ac.uk',
            'release'          => software_version(),
-           'sql_dir'          => $self->o('ENV', 'HOME')."/work/lib/ensembl/misc-scripts/xref_mapping",
            'pipeline_name'    => 'xref_update_'.$self->o('release'),
 
+           'work_dir'         => $self->o('ENV', 'HOME')."/work/lib";
+           'sql_dir'          => $self->o('work_dir')."/ensembl/misc-scripts/xref_mapping",
+ 
            ## 'job_factory' parameters
            'species'          => [],
            'antispecies'      => [qw/mus_musculus_129s1svimj mus_musculus_aj mus_musculus_akrj mus_musculus_balbcj mus_musculus_c3hhej mus_musculus_c57bl6nj mus_musculus_cbaj mus_musculus_dba2j mus_musculus_fvbnj mus_musculus_lpj mus_musculus_nodshiltj mus_musculus_nzohlltj mus_musculus_pwkphj mus_musculus_wsbeij drosophila_melanogaster caenorhabditis_elegans saccharomyces_cerevisiae/],
@@ -46,9 +48,9 @@ sub default_options {
            'force'            => 0,
 
            ## Parameters for source download
-           'config_file'      => $self->o('ENV', 'HOME')."/work/lib/ensembl-production/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_sources.json",
+           'config_file'      => $self->o('work_dir')."/ensembl-production/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_sources.json",
            'source_url'       => '',
-           'source_dir'       => $self->o('ENV', 'HOME')."/work/lib/ensembl-production/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/sql",
+           'source_dir'       => $self->o('work_dir')."/ensembl-production/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/sql",
            'reuse_db'         => 0,
            'skip_download'    => 0,
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/Xref_update_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/Xref_update_conf.pm
@@ -89,7 +89,7 @@ sub pipeline_analyses {
             {-logic_name => 'download_source',
              -module     => 'Bio::EnsEMBL::Production::Pipeline::Xrefs::DownloadSource',
              -parameters => { base_path     => $self->o('base_path')},
-             -rc_name    => 'small',
+             -rc_name    => 'normal',
             },
             {-logic_name => 'checksum',
              -module     => 'Bio::EnsEMBL::Production::Pipeline::Xrefs::Checksum',

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/Xref_update_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/Xref_update_conf.pm
@@ -45,7 +45,6 @@ sub default_options {
            'antispecies'      => [qw/mus_musculus_129s1svimj mus_musculus_aj mus_musculus_akrj mus_musculus_balbcj mus_musculus_c3hhej mus_musculus_c57bl6nj mus_musculus_cbaj mus_musculus_dba2j mus_musculus_fvbnj mus_musculus_lpj mus_musculus_nodshiltj mus_musculus_nzohlltj mus_musculus_pwkphj mus_musculus_wsbeij drosophila_melanogaster caenorhabditis_elegans saccharomyces_cerevisiae/],
            'division'         => 'EnsemblVertebrates',
            'run_all'          => 0,
-           'force'            => 0,
 
            ## Parameters for source download
            'config_file'      => $self->o('work_dir')."/ensembl-production/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_sources.json",
@@ -109,7 +108,6 @@ sub pipeline_analyses {
                              antispecies => $self->o('antispecies'),
                              division    => $self->o('division'),
                              run_all     => $self->o('run_all'),
-                             force       => $self->o('force'),
                             },
              -flow_into  => { '2->A' => 'schedule_source',
                               'A->2' => 'schedule_dependent_source'},

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/Xref_update_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/Xref_update_conf.pm
@@ -22,6 +22,7 @@ package Bio::EnsEMBL::Production::Pipeline::PipeConfig::Xref_update_conf;
 use strict;
 use warnings;
 
+use Bio::EnsEMBL::Hive::Version 2.5;
 use base ('Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf');
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
 
@@ -59,6 +60,9 @@ sub default_options {
            'xref_pass'        => '',
            'xref_host'        => '',
            'xref_port'        => '',
+
+           # Don't need lots of retries for most analyses
+           'hive_default_max_retry_count' => 1,
         };
 }
 
@@ -90,6 +94,7 @@ sub pipeline_analyses {
              -module     => 'Bio::EnsEMBL::Production::Pipeline::Xrefs::DownloadSource',
              -parameters => { base_path     => $self->o('base_path')},
              -rc_name    => 'normal',
+             -max_retry_count => 3,
             },
             {-logic_name => 'checksum',
              -module     => 'Bio::EnsEMBL::Production::Pipeline::Xrefs::Checksum',

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/Xref_update_vertebrates_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/Xref_update_vertebrates_conf.pm
@@ -1,0 +1,37 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2017] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::Production::Pipeline::PipeConfig::Xref_update_vertebrates_conf;
+
+use strict;
+use warnings;
+
+use base ('Bio::EnsEMBL::Production::Pipeline::PipeConfig::Xref_update_conf');
+
+sub default_options {
+    my ($self) = @_;
+
+    return {
+           %{ $self->SUPER::default_options() },
+           'division'    => ['EnsemblVertebrates'],
+           'antispecies' => [qw/mus_musculus_129s1svimj mus_musculus_aj mus_musculus_akrj mus_musculus_balbcj mus_musculus_c3hhej mus_musculus_c57bl6nj mus_musculus_cbaj mus_musculus_dba2j mus_musculus_fvbnj mus_musculus_lpj mus_musculus_nodshiltj mus_musculus_nzohlltj mus_musculus_pwkphj mus_musculus_wsbeij drosophila_melanogaster caenorhabditis_elegans saccharomyces_cerevisiae/],
+    };
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/ScheduleSource.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/ScheduleSource.pm
@@ -39,7 +39,7 @@ sub run {
 
   my $source_url       = $self->param_required('source_url');
 
-  my $db_url           = $self->param('xref_db');
+  my $db_url           = $self->param('xref_url');
   my $user             = $self->param('xref_user');
   my $pass             = $self->param('xref_pass');
   my $host             = $self->param('xref_host');


### PR DESCRIPTION
Created a new vertebrate-specific config file, to keep the main one generic and more easily used by other divisions. Sundry minor fixes for issues that arose when I ran the pipeline for release 94.