### PR TITLE
mus_spretus should not be excluded from the xref projection list sinc…

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/XrefProjection_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/XrefProjection_conf.pm
@@ -148,7 +148,7 @@ sub default_options {
                                 # target species to project to
                                 'species'     => [], # ['puccinia graminis', 'aspergillus_nidulans']
                                 # target species to exclude
-                                'antispecies' => ['mus_musculus','mus_musculus_129s1svimj', 'mus_musculus_aj', 'mus_musculus_akrj', 'mus_musculus_balbcj', 'mus_musculus_c3hhej', 'mus_musculus_c57bl6nj', 'mus_musculus_casteij', 'mus_musculus_cbaj', 'mus_musculus_dba2j', 'mus_musculus_fvbnj', 'mus_musculus_lpj', 'mus_musculus_nodshiltj', 'mus_musculus_nzohlltj', 'mus_musculus_pwkphj', 'mus_musculus_wsbeij', 'mus_spretus'],
+                                'antispecies' => ['mus_musculus','mus_musculus_129s1svimj', 'mus_musculus_aj', 'mus_musculus_akrj', 'mus_musculus_balbcj', 'mus_musculus_c3hhej', 'mus_musculus_c57bl6nj', 'mus_musculus_casteij', 'mus_musculus_cbaj', 'mus_musculus_dba2j', 'mus_musculus_fvbnj', 'mus_musculus_lpj', 'mus_musculus_nodshiltj', 'mus_musculus_nzohlltj', 'mus_musculus_pwkphj', 'mus_musculus_wsbeij'],
                                 # target species division to project to
                                 'division'    => [],
                                 # Taxon name of species to project to
@@ -291,7 +291,7 @@ sub default_options {
                                  # target species to project to
                                  'species'     => [], # ['puccinia graminis', 'aspergillus_nidulans']
                                  # target species to exclude
-                                 'antispecies' => ['mus_musculus','mus_musculus_129s1svimj', 'mus_musculus_aj', 'mus_musculus_akrj', 'mus_musculus_balbcj', 'mus_musculus_c3hhej', 'mus_musculus_c57bl6nj', 'mus_musculus_casteij', 'mus_musculus_cbaj', 'mus_musculus_dba2j', 'mus_musculus_fvbnj', 'mus_musculus_lpj', 'mus_musculus_nodshiltj', 'mus_musculus_nzohlltj', 'mus_musculus_pwkphj', 'mus_musculus_wsbeij', 'mus_spretus'],
+                                 'antispecies' => ['mus_musculus','mus_musculus_129s1svimj', 'mus_musculus_aj', 'mus_musculus_akrj', 'mus_musculus_balbcj', 'mus_musculus_c3hhej', 'mus_musculus_c57bl6nj', 'mus_musculus_casteij', 'mus_musculus_cbaj', 'mus_musculus_dba2j', 'mus_musculus_fvbnj', 'mus_musculus_lpj', 'mus_musculus_nodshiltj', 'mus_musculus_nzohlltj', 'mus_musculus_pwkphj', 'mus_musculus_wsbeij'],
                                  # target species division to project to
                                  'division'    => [],
                                  # Taxon name of species to project to


### PR DESCRIPTION
…e it's not a mouse strain and should be treated the same way as mus_pahari and mus_caroli