### PR TITLE
ENSCORESW-2792: re-instate UCSC xrefs

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/CoordinateMapping.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/CoordinateMapping.pm
@@ -37,7 +37,7 @@ sub run {
   my $mapper = $self->get_xref_mapper($xref_url, $species, $base_path, $release);
   my $coord = XrefMapper::CoordinateMapper->new($mapper);
   my $species_id = $self->get_taxon_id($species);
-  #$coord->run_coordinatemapping(1, $species_id);
+  $coord->run_coordinatemapping(1, $species_id);
 
 }
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_sources.json
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_sources.json
@@ -157,14 +157,14 @@
     },
     {
       "name" : "UCSC_hg38",
-      "parser" : "UCSCParser",
+      "parser" : "UCSC_human_parser",
       "file" : "ftp://hgdownload.cse.ucsc.edu/goldenPath/hg38/database/knownGene.txt.gz",
       "release" : "ftp://hgdownload.cse.ucsc.edu/goldenPath/hg38/database/README.txt",
       "priority" : 1
     },
     {
       "name" : "UCSC_mm10",
-      "parser" : "UCSC_mouse_Parser",
+      "parser" : "UCSC_mouse_parser",
       "file" : "ftp://hgdownload.cse.ucsc.edu/goldenPath/mm10/database/knownGene.txt.gz",
       "release" : "ftp://hgdownload.cse.ucsc.edu/goldenPath/mm10/database/README.txt",
       "priority" : 1

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_sources.json
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_sources.json
@@ -156,6 +156,20 @@
       "priority" : 1
     },
     {
+      "name" : "UCSC_hg38",
+      "parser" : "UCSCParser",
+      "file" : "ftp://hgdownload.cse.ucsc.edu/goldenPath/hg38/database/knownGene.txt.gz",
+      "release" : "ftp://hgdownload.cse.ucsc.edu/goldenPath/hg38/database/README.txt",
+      "priority" : 1
+    },
+    {
+      "name" : "UCSC_mm10",
+      "parser" : "UCSC_mouse_Parser",
+      "file" : "ftp://hgdownload.cse.ucsc.edu/goldenPath/mm10/database/knownGene.txt.gz",
+      "release" : "ftp://hgdownload.cse.ucsc.edu/goldenPath/mm10/database/README.txt",
+      "priority" : 1
+    },
+    {
       "name" : "Uniprot/SWISSPROT",
       "parser" : "UniProtParser",
       "file" : "ftp://ftp.ebi.ac.uk/pub/databases/uniprot/knowledgebase/uniprot_sprot.dat.gz",


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

_Using one or more sentences, describe in detail the proposed changes._
UCSC xrefs have been switched back on the the xref pipeline

## Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._
There were some issues with cross-mapping of UCSC xrefs, where some human xrefs were mapped to mouse transcripts and vice-versa. While there were not many cases (it still requires to find an Ensembl transcript in the same location and comparable structure to the other species one), the handful of cases led to some core foreign key failures as two xrefs were mapped to incompatible locations. This has now been resolved in the xref pipeline by setting a separate parser for each species, treating the data as two completely separate sources.

## Benefits

_If applicable, describe the advantages the changes will have._
UCSC xrefs get updated for mouse and human every release. There are no more CoreForeignKey failures caused by this source.

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._
It will not scale well if we wanted UCSC xrefs for more species.

## Testing

_Have you added/modified unit tests to test the changes?_
The pipeline was run on human and mouse in parallel to check for any possible contamination. 

_If so, do the tests pass/fail?_
There are no CoreForeignKey HC failure, the number of xrefs obtained is comparable to previous releases and the data looks sane.

_Have you run the entire test suite and no regression was detected?_
NA
