### PR TITLE
ENSCORESW-2335: say RNAcentral also in source database

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_sources.json
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_sources.json
@@ -21,7 +21,7 @@
       "priority" : 1
     },
     {
-      "name" : "RNACentral",
+      "name" : "RNAcentral",
       "parser" : "ChecksumParser",
       "file" : "ftp://ftp.ebi.ac.uk/pub/databases/RNAcentral/current_release/md5/md5.tsv.gz",
       "db" : "checksum",


### PR DESCRIPTION
I had a run fail because my .ini still said RNACentral, and I went to find out which one it is.