### PR TITLE
sql2html: support generation of schema diagrams as SVGs

### DIFF
--- a/scripts/sql2html.pl
+++ b/scripts/sql2html.pl
@@ -774,8 +774,7 @@ close($html_fh);
 my %dimensions;
 sub fetch_png_dimensions {
     my ($image_id, $filename) = @_;
-    my $ss = `file $filename`;
-    if (`file $filename` =~ /PNG image data, (\d+) x (\d+),/) {
+    if (`identify $filename` =~ / PNG (\d+)x(\d+) /) {
         $dimensions{$image_id} = [$1,$2];
     }
 }

--- a/scripts/sql2html.pl
+++ b/scripts/sql2html.pl
@@ -673,7 +673,7 @@ if ($out_diagram_dir) {
         my $filename = "$full_diagram_dir/$db_team.".clean_name($c);
         my $graph = generate_sub_diagram($c, 'column_links');
         $graph->as_png("$filename.png");
-        fetch_png_dimensions($c, "$filename.png");
+        fetch_diagram_dimensions($c, "$filename.png");
     }
 }
 
@@ -772,9 +772,9 @@ close($html_fh);
 
 
 my %dimensions;
-sub fetch_png_dimensions {
+sub fetch_diagram_dimensions {
     my ($image_id, $filename) = @_;
-    if (`identify $filename` =~ / PNG (\d+)x(\d+) /) {
+    if (`identify $filename` =~ /(?:PNG|SVG) (\d+)x(\d+) /) {
         $dimensions{$image_id} = [$1,$2];
     }
 }


### PR DESCRIPTION
A vector format like SVG is generally more useful for this sort of data because it allows zooming in and out without loss of readability. This is important given how large some of our schema diagrams are. SVG files are also more space-efficient thank PNG ones, at least for the sort of resolutions GraphViz uses to produce the latter to make them readable anyway. On the other hand, the advantage of SVG over _e.g._ PDF is that it is natively supported as an image format by most Web browser _and_ can be directly exported to by GraphViz.

The format of diagram is controlled by a command-line option so it *is* still possible to generate PNGs should one choose to do so.

Please note that this PR introduces a dependency on ImageMagick (or GraphicsMagick with compatibility symlinks) because it uses the command 'identify' to extract dimensions from newly generated diagram files. Previously 'file' was used for that but it doesn't show dimensions of SVG files, moreover its output syntax varies wildly between formats (compare _e.g._ PNG and JPEG). This shouldn't be a big deal though, ImageMagick is fairly widespread (for one thing we have got it on the EBI farm) and most of its own dependencies are the same as those of GraphViz. Finally, if this PR gets accepted I would like to rewrite dimension extraction to use ImageMagick Perl bindings instead of an external executable - in which case we will be able to add this dependency to cpanfile.