### PR TITLE
Reflect change in hash structure of compara dbs in parent module

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Common/SpeciesFactory.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Common/SpeciesFactory.pm
@@ -130,8 +130,8 @@ sub flow_species {
   }
 
   if ($compara_flow) {
-    foreach my $dbname ( keys %$compara_dbs ) {
-      push @compara_species, $$compara_dbs{$dbname};
+    foreach my $division ( keys %$compara_dbs ) {
+      push @compara_species, $division;
     };
   }
 


### PR DESCRIPTION
@james-monkeyshines changed this in the DbFactory a while ago: https://github.com/Ensembl/ensembl-production/commit/982ae326312297bf4773842945c51ddf8271157a#diff-408bb2c17c2990106fde7c1b32281f60L113
This broke this line here in the speciesFactory: https://github.com/Ensembl/ensembl-production/blob/release/94/modules/Bio/EnsEMBL/Production/Pipeline/Common/SpeciesFactory.pm#L134
James fixed it on master but the change was not replicated to the release/94 branch. As a result the FTP checker pipeline is broken because it's using the compara flow. 
This change fix the broken compara flow by bringing James fix to release/94 branch