### PR TITLE
dump_dna was retired from the config file in commit 6ee3d5f9c8bad0d93…

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_conf.pm
@@ -214,7 +214,7 @@ sub pipeline_analyses {
     {  -logic_name => 'checksum_generator',
        -module     => 'Bio::EnsEMBL::Production::Pipeline::Common::ChksumGenerator',
        -wait_for   => $pipeline_flow,
-#       -wait_for   => [$pipeline_flow,'dump_dna','copy_dna'],
+#       -wait_for   => [$pipeline_flow],
        -hive_capacity => 10,
     },
 
@@ -500,7 +500,6 @@ sub pipeline_analyses {
       -can_be_empty     => 1,
       -max_retry_count  => 5,
       -priority        => 5,
-      -wait_for         => 'dump_dna'
     },
         
 ### ASSEMBLY CHAIN	


### PR DESCRIPTION
…1d4fd451c233e62f258cb1a but these analysis still uses it