### PR TITLE
ENSCORESW-2792: re-instate UCSC xrefs

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/CoordinateMapping.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/CoordinateMapping.pm
@@ -37,7 +37,7 @@ sub run {
   my $mapper = $self->get_xref_mapper($xref_url, $species, $base_path, $release);
   my $coord = XrefMapper::CoordinateMapper->new($mapper);
   my $species_id = $self->get_taxon_id($species);
-  #$coord->run_coordinatemapping(1, $species_id);
+  $coord->run_coordinatemapping(1, $species_id);
 
 }
 


### PR DESCRIPTION
Part of these changes disappeared from GitHub history both on release/95 and master branch. Restoring latest commit for this file allowing the xref pipeline to load UCSC xrefs. 