### PR TITLE
The reformat_variants method does not expect $self argument

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Search/ReformatVariantsEBeye.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Search/ReformatVariantsEBeye.pm
@@ -58,7 +58,7 @@ sub run {
 	my $dba = $self->get_DBAdaptor($type);
 	$self->{logger}->info("Reformatting $dump_file into $dump_file_out");
 	$reformatter->reformat_variants(
-			$self, $genome_file, $dba->dbc()->dbname(), $dump_file,
+			$genome_file, $dba->dbc()->dbname(), $dump_file,
 			$dump_file_out );
 
 	return;


### PR DESCRIPTION
Passing $self instead of the input filename cuases the reformat_variants method to try to load a file on disk that does not exist and in turn causes the ReformatVariantsEBeye runnable to fail.