### PR TITLE
Better handling of non-core dbs with DbFactory

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Common/DbFactory.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Common/DbFactory.pm
@@ -47,12 +47,16 @@ sub param_defaults {
     all_dbs_flow => 1,
     db_flow      => 2,
     compara_flow => 5, # compara_flow moved here from SpeciesFactory; retain former flow #5 here, to avoid bugs
-    div_synonyms => { 'eb'  => 'bacteria',
-                       'ef'  => 'fungi',
-                       'em'  => 'metazoa',
-                       'epl' => 'plants',
-                       'epr' => 'protists',
-                       'e'   => 'ensembl' },
+    div_synonyms => {
+                      'eb'  => 'bacteria',
+                      'ef'  => 'fungi',
+                      'em'  => 'metazoa',
+                      'epl' => 'plants',
+                      'epr' => 'protists',
+                      'e'   => 'vertebrates',
+                      'ev'  => 'vertebrates',
+                      'ensembl' => 'vertebrates',
+                    },
     meta_filters => {},
     group        => 'core',
   };

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Common/DbFactory.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Common/DbFactory.pm
@@ -262,7 +262,7 @@ sub process_taxon {
   }
 
   if ($species_count == 0) {
-    $self->throw("$taxon was processed but no species was added/removed")
+    $self->warning("$taxon was processed but no species was added/removed")
   }
   else {
     if ($action eq "add") {

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Common/SpeciesFactory.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Common/SpeciesFactory.pm
@@ -59,25 +59,28 @@ sub write_output {
   my $all_species      = $self->param_required('all_species');
   my $all_species_flow = $self->param('all_species_flow');
   my $core_flow        = $self->param('core_flow');
+  my $group            = $self->param('group');
 
   foreach my $species ( @{$all_species} ) {
     $self->dataflow_output_id(
       {
         species => $species,
-        group   => 'core',
+        group   => $group,
       },
     $core_flow);
   }
 
-  my ($flow, $flow_species) = $self->flow_species($all_species);
-  foreach my $group ( keys %$flow ) {
-    foreach my $species ( @{ $$flow_species{$group} } ) {
-      $self->dataflow_output_id(
-        {
-          species => $species,
-          group   => $group,
-        },
-      $$flow{$group} );
+  if ($group eq 'core') {
+    my ($flow, $flow_species) = $self->flow_species($all_species);
+    foreach my $group ( keys %$flow ) {
+      foreach my $species ( @{ $$flow_species{$group} } ) {
+        $self->dataflow_output_id(
+          {
+            species => $species,
+            group   => $group,
+          },
+        $$flow{$group} );
+      }
     }
   }
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FactoryTest_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FactoryTest_conf.pm
@@ -43,7 +43,7 @@ sub default_options {
     run_all      => 0,
     meta_filters => {},
     
-    db_type => 'core',
+    group => 'core',
   };
 }
 
@@ -86,7 +86,7 @@ sub pipeline_analyses {
                               division     => $self->o('division'),
                               run_all      => $self->o('run_all'),
                               meta_filters => $self->o('meta_filters'),
-                              db_type      => $self->o('db_type'),
+                              group        => $self->o('group'),
                             },
       -flow_into         => {
                               '2->A' => ['DbFlow'],
@@ -109,7 +109,7 @@ sub pipeline_analyses {
                               division     => $self->o('division'),
                               run_all      => $self->o('run_all'),
                               meta_filters => $self->o('meta_filters'),
-                              db_type      => $self->o('db_type'),
+                              group        => $self->o('group'),
                             },
       -flow_into         => {
                               '2->A' => ['CoreFlow'],


### PR DESCRIPTION
For non-core groups, use the DNA db if it is necessary to do a division filter, and only spawn jobs down flow #2