### PR TITLE
Explicitly disconnect $dbh

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/DatabaseDumping/DbDumpingFactory.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/DatabaseDumping/DbDumpingFactory.pm
@@ -75,6 +75,7 @@ sub run {
       }
     }
   }
+  $dbh->disconnect;
  
 }
 


### PR DESCRIPTION
It produces a warning to not do this. Disconnecting is irrelevant to the results of this script, but the warning confused me when I had a problem.

Issuing rollback() due to DESTROY without explicit disconnect() of DBD::mysql::db handle database=information_schema;host=mysql-ps-staging-2.ebi.ac.uk;port=4467 at /nfs/production/panda/ensemblgenomes/wormbase/software/packages/ensembl/branches/branch-94/ensembl-hive/modules/Bio/EnsEMBL/Hive/Process.pm line 150.