### PR TITLE
Completely re-wrote the DbDumpingFactory to use the ensembl_metadata …

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/DatabaseDumping/DbDumpingFactory.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/DatabaseDumping/DbDumpingFactory.pm
@@ -21,9 +21,10 @@ limitations under the License.
 
 =head1 DESCRIPTION
 
-The factory will find all the databases on a given server. If run_all is set to 1,
-the module will dataflow all the databases. If db_pattern is defined, dataflow the databases
-matching the patterns
+The factory will use the metadata database to find databases for a given division and dataflow
+The database names and dumping location.
+If databases array is defined, the module will flow these databases directly without checks.
+Please note that you can only dump databases directly for one division. The metadata database won't be checked for this.
 
 =cut
 
@@ -33,49 +34,82 @@ use base ('Bio::EnsEMBL::Hive::Process');
 use strict;
 use warnings;
 use DBI;
+use Bio::EnsEMBL::MetaData::DBSQL::MetaDataDBAdaptor;
+use List::MoreUtils qw(uniq);
 
 sub run {
   my ($self) = @_;
-  my $db_pattern      = $self->param_required('db_pattern') || [];
-  my @db_pattern = ( ref($db_pattern) eq 'ARRAY' ) ? @$db_pattern : ($db_pattern);
-  my $run_all = $self->param('run_all');
+  my $division = $self->param('division');
+  my $databases = $self->param('databases');
+  my $vertebrates_release = $self->param('vertebrates_release');
+  my $non_vertebrates_release = $self->param('non_vertebrates_release');
+  my $base_output_dir = $self->param('base_output_dir');
 
-  my $host  = $self->param('host');
-  my $user = $self->param('user');
-  my $password = $self->param('password');
-  my $port = $self->param('port');
-
-#Connect to the MySQL server
-  my $dsn=sprintf( "DBI:mysql:database=%s;host=%s;port=%d", 'information_schema', $host, $port );
-  my $dbh = DBI->connect( $dsn, $user, $password, {'PrintError' => 1,'AutoCommit' => 0 } );
-  if ( !defined($dbh) ) {
-    die "Failed to connect to the server $dsn";
+  #Connect to the metadata database
+  my $dba = Bio::EnsEMBL::MetaData::DBSQL::MetaDataDBAdaptor->new(
+          -USER=>$self->param('meta_user'),
+          -HOST=> $self->param('meta_host'),
+          -PORT=>$self->param('meta_port'),
+          -DBNAME=>$self->param('meta_database'),
+  );
+  #Get metadata adaptors
+  my $gcdba = $dba->get_GenomeComparaInfoAdaptor();
+  my $gdba = $dba->get_GenomeInfoAdaptor();
+  my $dbdba = $dba->get_DatabaseInfoAdaptor();
+  my $rdba = $dba->get_DataReleaseInfoAdaptor();
+  #set release by querying the metadata db
+  my $release;
+  my $release_dir;
+  if ($non_vertebrates_release){
+    $release = $rdba->fetch_by_ensembl_genomes_release($non_vertebrates_release);
+    $release_dir = $non_vertebrates_release;
   }
-# Get the list of databases from the infromation_schema database excluding generic MysQL or system databases
-  my $sth = $dbh->prepare('SELECT schema_name from SCHEMATA where schema_name not in ("performance_schema","mysql","information_schema","PERCONA_SCHEMA")') or die $dbh->errstr;
-  $sth->execute() or die $dbh->errstr;
-  my $server_databases = $sth->fetchall_arrayref;
-  # If run_all is set to 1, dataflow all the databases
-  if ($run_all){
-    foreach my $database (@$server_databases){
+  else{
+    $release = $rdba->fetch_by_ensembl_release($vertebrates_release);
+    $release_dir = $vertebrates_release;
+  }
+  $gdba->data_release($release);
+
+  # Either dump databases from databases array or loop through divisions
+  if (@$databases) {
+    #Dump given databases
+    foreach my $database (@$databases){
+      if (scalar @$division > 1) {
+        die "Please run a separare pipeline for each divisions";
+      }
       $self->dataflow_output_id({
-			       database=>$database->[0]
-			      }, 1);
+                  database=>$database,
+                  output_dir => $base_output_dir.$division->[0].'/release-'.$release_dir.'/mysql/',
+                  }, 1);
     }
   }
-  # If db_pattern is defined, find matching databases and dataflow them.
-  elsif(@db_pattern){
-    foreach my $database (@$server_databases){
-      foreach my $db_pattern (@db_pattern){
-        if ($database->[0] =~/$db_pattern/i){
-          $self->dataflow_output_id({
-			       database=>$database->[0]
-			      }, 1);
+  else{
+    #Foreach divisions, get all the genomes and then databases associated.
+    # Get the compara databases and other databases like mart
+    foreach my $div (@$division){
+      my $division_databases;
+      my $genomes = $gdba->fetch_all_by_division($div);
+      #Genome databases
+      foreach my $genome (@$genomes){
+        foreach my $database (@{$genome->databases()}){
+          push (@$division_databases,$database->dbname);
         }
+      }
+      #mart databases
+      foreach my $mart_database (@{$dbdba->fetch_databases_DataReleaseInfo($release,$div)}){
+        push (@$division_databases,$mart_database->dbname);
+      }
+      #compara databases
+      foreach my $compara_database (@{$gcdba->fetch_division_databases($div,$release)}){
+        push (@$division_databases,$compara_database);
+      }
+      foreach my $division_database (uniq(@$division_databases)){
+          $self->dataflow_output_id({
+          database=>$division_database,
+          output_dir => $base_output_dir.$div.'/release-'.$release_dir.'/mysql/',
+          }, 1);
       }
     }
   }
- 
 }
-
 1;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/MySQLDumping_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/MySQLDumping_conf.pm
@@ -46,13 +46,18 @@ sub default_options {
         'pass'     => $self->o('pass'),
         'host'     => $self->o('host'),
         'port'     => $self->o('port'),
-        'output_dir'     	   => '/nfs/nobackup/dba/sysmysql/ensembl/mysql',
+        'meta_user'     => $self->o('meta_user'),
+        'meta_host'     => $self->o('meta_host'),
+        'meta_port'     => $self->o('meta_port'),
+        'meta_database' => $self->o('meta_database'),
         'base_dir'  => $self->o('ensembl_cvs_root_dir'),
         'pipeline_name'  => 'mysql_dumping',
-
+        'division' => [],
+        'base_output_dir'     	   => '/nfs/nobackup/dba/sysmysql/',
+        'vertebrates_release' => $self->o('vertebrates_release'),
+        'non_vertebrates_release' => $self->o('non_vertebrates_release'),
         ## 'DbDumpingFactory' parameters
-        'run_all'     => 0,
-        'db_pattern'    => [],
+        'databases'    => [],
     }
 }
 
@@ -80,12 +85,15 @@ sub pipeline_analyses {
       -max_retry_count   => 1,
       -input_ids         => [ {} ],
       -parameters        => {
-                              run_all         => $self->o('run_all'),
-                              db_pattern         => $self->o('db_pattern'),
-                              user      => $self->o('user'),
-                              password      => $self->o('pass'),
-                              host      => $self->o('host'),
-                              port      => $self->o('port'),
+                              division        => $self->o('division'),
+                              databases         => $self->o('databases'),
+                              meta_user      => $self->o('meta_user'),
+                              meta_host      => $self->o('meta_host'),
+                              meta_port      => $self->o('meta_port'),
+                              meta_database => $self->o('meta_database'),
+                              base_output_dir => $self->o('base_output_dir'),
+                              vertebrates_release => $self->o('vertebrates_release'),
+                              non_vertebrates_release => $self->o('non_vertebrates_release'),
                             },
       -flow_into         => {
                               1 => 'DatabaseDump',
@@ -102,8 +110,7 @@ sub pipeline_analyses {
         'password'      => $self->o('pass'),
         'host'      => $self->o('host'),
         'port'      => $self->o('port'),
-        'base_dir'  => $self->o('base_dir'),
-        'output_dir' => $self->o('output_dir'),
+        'base_dir'  => $self->o('base_dir')
         },
       -rc_name          => 'default',
       -analysis_capacity => 10


### PR DESCRIPTION
…database and make the pipeline division aware. The pipeline will use the division to fetch the associated list of databases from the metadata database. The pipeline can also redump a list of databases for one given division without using the metadata database. One caveat is that when dumping the EnsemblVertebrate division, EnsemblPan need to be given to the pipeline too to dump databases like ensembl_website, ontology,...

@james-monkeyshines: You can find associated documentation here: https://www.ebi.ac.uk/seqdb/confluence/display/GTI/3.+MySQL+dumping

Please note that the pipeline can dump each division separately. The pipeline can also dump a list of databases for one given division. I made extensive checks to make sure that all the databases that we need are stored in the metadata database. I also fixed a bug in the metadata compara API call and extended list of databases in this PR that Marc is reviewing, the pipeline need this to work: https://github.com/Ensembl/ensembl-metadata/pull/14.