### PR TITLE
Updated pipeline to work with unified release in metadata database fo…

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/DatabaseDumping/DbDumpingFactory.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/DatabaseDumping/DbDumpingFactory.pm
@@ -40,9 +40,8 @@ use List::MoreUtils qw(uniq);
 sub run {
   my ($self) = @_;
   my $division = $self->param('division');
-  my $databases = $self->param('databases');
-  my $vertebrates_release = $self->param('vertebrates_release');
-  my $non_vertebrates_release = $self->param('non_vertebrates_release');
+  my $database = $self->param('database');
+  my $release = $self->param('release');
   my $base_output_dir = $self->param('base_output_dir');
 
   #Connect to the metadata database
@@ -58,28 +57,29 @@ sub run {
   my $dbdba = $dba->get_DatabaseInfoAdaptor();
   my $rdba = $dba->get_DataReleaseInfoAdaptor();
   #set release by querying the metadata db
-  my $release;
+  my $release_info;
   my $release_dir;
-  if ($non_vertebrates_release){
-    $release = $rdba->fetch_by_ensembl_genomes_release($non_vertebrates_release);
-    $release_dir = $non_vertebrates_release;
+  $release_info = $rdba->fetch_by_ensembl_genomes_release($release);
+  if (!$release_info){
+    $release_info = $rdba->fetch_by_ensembl_release($release);
+    $release_dir = $release_info->{ensembl_version};
   }
   else{
-    $release = $rdba->fetch_by_ensembl_release($vertebrates_release);
-    $release_dir = $vertebrates_release;
+    $release_dir = $release_info->{ensembl_genomes_version};
   }
-  $gdba->data_release($release);
+  $gdba->data_release($release_info);
 
   # Either dump databases from databases array or loop through divisions
-  if (@$databases) {
+  if (@$database) {
     #Dump given databases
-    foreach my $database (@$databases){
+    foreach my $db (@$database){
       if (scalar @$division > 1) {
         die "Please run a separare pipeline for each divisions";
       }
+      my ($division_short_name,$division_name)=process_division_names($division->[0]);
       $self->dataflow_output_id({
-                  database=>$database,
-                  output_dir => $base_output_dir.$division->[0].'/release-'.$release_dir.'/mysql/',
+                  database=>$db,
+                  output_dir => $base_output_dir.$division_short_name.'/release-'.$release_dir.'/mysql/',
                   }, 1);
     }
   }
@@ -87,29 +87,69 @@ sub run {
     #Foreach divisions, get all the genomes and then databases associated.
     # Get the compara databases and other databases like mart
     foreach my $div (@$division){
+      my ($division_short_name,$division_name)=process_division_names($div);
       my $division_databases;
-      my $genomes = $gdba->fetch_all_by_division($div);
+      my $genomes = $gdba->fetch_all_by_division($division_name);
       #Genome databases
       foreach my $genome (@$genomes){
         foreach my $database (@{$genome->databases()}){
           push (@$division_databases,$database->dbname);
         }
       }
-      #mart databases
-      foreach my $mart_database (@{$dbdba->fetch_databases_DataReleaseInfo($release,$div)}){
-        push (@$division_databases,$mart_database->dbname);
+      #release and mart databases
+      foreach my $release_database (@{$dbdba->fetch_databases_DataReleaseInfo($release_info,$division_name)}){
+        if ($division_short_name eq "pan"){
+          if (check_if_db_exists($self,$release_database)){
+            push (@$division_databases,$release_database->dbname);
+          }
+          else{
+            $self->warning("Can't find ".$release_database->dbname." on server: ".$self->param('host'));
+          }
+        }
+        else{
+          push (@$division_databases,$release_database->dbname);
+        }
       }
       #compara databases
-      foreach my $compara_database (@{$gcdba->fetch_division_databases($div,$release)}){
+      foreach my $compara_database (@{$gcdba->fetch_division_databases($division_name,$release_info)}){
         push (@$division_databases,$compara_database);
       }
       foreach my $division_database (uniq(@$division_databases)){
           $self->dataflow_output_id({
           database=>$division_database,
-          output_dir => $base_output_dir.$div.'/release-'.$release_dir.'/mysql/',
+          output_dir => $base_output_dir.$division_short_name.'/release-'.$release_dir.'/mysql/',
           }, 1);
       }
     }
   }
+}
+# Check if a database exist on the mysql server
+sub check_if_db_exists {
+  my ($self,$database_name)=@_;
+  my $database=$database_name->dbname;
+  my $host = $self->param('host');
+  my $port = $self->param('port');
+  my $pass = $self->param('password');
+  my $user = $self->param('user');
+  return `mysql -ss -r --host=$host --port=$port --user=$user --password=$pass -e "show databases like '$database'"`;
+}
+
+#Process the division name, and return both division like metazoa and division name like EnsemblMetazoa
+sub process_division_names {
+  my ($div) = @_;
+  my $division;
+  my $division_name;
+  #Creating the Division name EnsemblBla and division bla variables
+  if ($div !~ m/[E|e]nsembl/){
+    $division = $div;
+    $division_name = 'Ensembl'.ucfirst($div) if defined $div;
+  }
+  else{
+    $division_name = $div;
+    $division = $div;
+    $division =~ s/Ensembl//;
+    $division = lc($division);
+  }
+  return ($division,$division_name)
 }
 1;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/MySQLDumping_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/MySQLDumping_conf.pm
@@ -54,10 +54,9 @@ sub default_options {
         'pipeline_name'  => 'mysql_dumping',
         'division' => [],
         'base_output_dir'     	   => '/nfs/nobackup/dba/sysmysql/',
-        'vertebrates_release' => $self->o('vertebrates_release'),
-        'non_vertebrates_release' => $self->o('non_vertebrates_release'),
+        'release' => $self->o('release'),
         ## 'DbDumpingFactory' parameters
-        'databases'    => [],
+        'database'    => [],
     }
 }
 
@@ -86,14 +85,17 @@ sub pipeline_analyses {
       -input_ids         => [ {} ],
       -parameters        => {
                               division        => $self->o('division'),
-                              databases         => $self->o('databases'),
+                              database         => $self->o('database'),
                               meta_user      => $self->o('meta_user'),
                               meta_host      => $self->o('meta_host'),
                               meta_port      => $self->o('meta_port'),
                               meta_database => $self->o('meta_database'),
                               base_output_dir => $self->o('base_output_dir'),
-                              vertebrates_release => $self->o('vertebrates_release'),
-                              non_vertebrates_release => $self->o('non_vertebrates_release'),
+                              release => $self->o('release'),
+                              user      => $self->o('user'),
+                              password      => $self->o('pass'),
+                              host      => $self->o('host'),
+                              port      => $self->o('port'),
                             },
       -flow_into         => {
                               1 => 'DatabaseDump',


### PR DESCRIPTION
…r 96. Now we have all the pan databases linked to the same release so we can't know which one is from the vertebrate staging and which one is from the non-vertebrate staging. Added a new subroutine to check if the pan database exist on the given server before attempting to dump it. Also added division name EnsemblMetazoa and division short name metazoa compatibility, these can be both uses with the pipeline. Dumping directory is now using division short name. Simplified arguments.