### PR TITLE
Use /scratch rather than /tmp space in Protein Features pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProteinFeatures_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProteinFeatures_conf.pm
@@ -897,12 +897,12 @@ sub resource_classes {
   return {
     %{$self->SUPER::resource_classes},
     '4GB' => {'LSF' => '-q production-rh7 -M 4000 -R "rusage[mem=4000]"'},
-    '4GB_4CPU' => {'LSF' => '-q production-rh7 -n 4 -M 4000 -R "rusage[mem=4000,tmp=4000]"'},
-    '8GB_4CPU' => {'LSF' => '-q production-rh7 -n 4 -M 8000 -R "rusage[mem=8000,tmp=4000]"'},
-    '16GB_4CPU' => {'LSF' => '-q production-rh7 -n 4 -M 16000 -R "rusage[mem=16000,tmp=4000]"'},
-    '4Gb_mem_4Gb_tmp' => {'LSF' => '-q production-rh7 -M 4000 -R "rusage[mem=4000,tmp=4000]"'},
-    '8Gb_mem_4Gb_tmp' => {'LSF' => '-q production-rh7 -M 8000 -R "rusage[mem=8000,tmp=4000]"'},
-    '16Gb_mem_4Gb_tmp' => {'LSF' => '-q production-rh7 -M 16000 -R "rusage[mem=16000,tmp=4000]"'},
+    '4GB_4CPU' => {'LSF' => '-q production-rh7 -n 4 -M 4000 -R "rusage[mem=4000,scratch=4000]"'},
+    '8GB_4CPU' => {'LSF' => '-q production-rh7 -n 4 -M 8000 -R "rusage[mem=8000,scratch=4000]"'},
+    '16GB_4CPU' => {'LSF' => '-q production-rh7 -n 4 -M 16000 -R "rusage[mem=16000,scratch=4000]"'},
+    '4Gb_mem_4Gb_tmp' => {'LSF' => '-q production-rh7 -M 4000 -R "rusage[mem=4000,scratch=4000]"'},
+    '8Gb_mem_4Gb_tmp' => {'LSF' => '-q production-rh7 -M 8000 -R "rusage[mem=8000,scratch=4000]"'},
+    '16Gb_mem_4Gb_tmp' => {'LSF' => '-q production-rh7 -M 16000 -R "rusage[mem=16000,scratch=4000]"'},
   }
 }
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/ProteinFeatures/InterProScan.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/ProteinFeatures/InterProScan.pm
@@ -68,16 +68,16 @@ sub run {
     unlink $outfile_xml if -e $outfile_xml;
     unlink $outfile_tsv if -e $outfile_tsv;
     
-    # Must use /tmp for short temporary file names; TMHMM can't cope with longer ones.
-    my $tmp_dir = tempdir(DIR => '/tmp', CLEANUP => 1);
+    # Must use /scratch for short temporary file names; TMHMM can't cope with longer ones.
+    my $scratch_dir = tempdir(DIR => '/scratch', CLEANUP => 1);
     
-    if (! -e $tmp_dir) {
-      $self->warning("Output directory '$tmp_dir' does not exist. I shall create it.");
-      make_path($tmp_dir) or $self->throw("Failed to create output directory '$tmp_dir'");
+    if (! -e $scratch_dir) {
+      $self->warning("Output directory '$scratch_dir' does not exist. I shall create it.");
+      make_path($scratch_dir) or $self->throw("Failed to create output directory '$scratch_dir'");
     }
     
     my $options = "--iprlookup --goterms --pathways ";
-    $options .= "-f TSV, XML -t $seq_type --tempdir $tmp_dir ";
+    $options .= "-f TSV, XML -t $seq_type --tempdir $scratch_dir ";
     $options .= '--applications '.join(',', @$applications).' ';
     my $input_option  = "-i $input_file ";
     my $output_option = "--output-file-base $outfile_base ";  
@@ -95,6 +95,8 @@ sub run {
     $self->dbc and $self->dbc->disconnect_if_idle();
     
     system($interpro_cmd) == 0 or $self->throw("Failed to run ".$interpro_cmd);
+    
+    unlink $scratch_dir if -e $scratch_dir;
   }
   
   if (! -e $outfile_xml) {


### PR DESCRIPTION
Use /scratch rather than /tmp space, as now recommended by TSC, for reasons of stability. This will hopefully fix the small numbers of intermittent and non-repeatable failures we get with every pipeline run (Bug report: ENSPROD-2607).