### PR TITLE
Adding module for datachecks to protein features pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/ProteinFeatures/InterProScan.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/ProteinFeatures/InterProScan.pm
@@ -38,14 +38,6 @@ sub param_defaults {
 sub fetch_input {
   my ($self) = @_;
   
-  if (defined $self->param('escape_branch') and 
-      $self->input_job->retry_count >= $self->input_job->analysis->max_retry_count) 
-  {
-    $self->dataflow_output_id($self->input_id, $self->param('escape_branch'));
-    $self->input_job->autoflow(0);
-    $self->complete_early("Job failed, retrying with higher memory limit.");
-  }
-  
   my $input_file = $self->param_required('input_file');
   $self->throw("File '$input_file' does not exist") if (! -e $input_file);
 }

--- a/modules/Bio/EnsEMBL/Production/Pipeline/ProteinFeatures/StoreProteinFeatures.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/ProteinFeatures/StoreProteinFeatures.pm
@@ -74,10 +74,10 @@ sub parse_match {
   # function in the ProteinFeatureAdaptor, which means that numbers in
   # scientific E-notation will only be recognised if the 'E' is lowercased.
   my $score = $match->{score};
-  $score =~ s/E/e/;
+  $score =~ s/E/e/ if defined $score;
   
   my $evalue = $match->{evalue};
-  $evalue =~ s/E/e/;
+  $evalue =~ s/E/e/ if defined $evalue;
   
   my $feature_common =
   {


### PR DESCRIPTION
## Description
Currently, after running the protein features pipeline, you need to run a set of healthchecks. Equivalent datachecks now exist, and they can be integrated into the pipeline.

The pipeline runs the 'protein_features' group, plus the ForeignKeys datacheck.

(I've also included a couple of minor fixes, for handling jobs that run out of memory, and avoiding spurious warnings.)

## Benefits
Don't have to do checks as a separate step; it tends not to get forgotten, but integrating the datachecks is efficient, alerts you to problems earlier, and should make it a bit easier to re-run a subset of jobs if necessary.

## Possible Drawbacks
Pipeline is a bit less 'fire and forget', perhaps; needs to be monitored for datacheck failures, but while running we're usually keeping an eye on the pipeline anyway.

## Testing
There are no unit tests for the pipeline config, but pipeline was run on a test dataset.

## Dependencies
ensembl-datacheck repository
