### PR TITLE
fix: do not leave temporary dot files around

### DIFF
--- a/scripts/sql2html.pl
+++ b/scripts/sql2html.pl
@@ -694,12 +694,13 @@ if ($out_diagram_dir) {
     my $file_generator = $diagram_format_params{$diagram_format}->{'graphviz_method'};
 
     my $graph = generate_whole_diagram('show_clusters', 'column_links');
-    $graph->dot_input_filename("$full_diagram_dir/$db_team.dot");
+    #$graph->dot_input_filename("$full_diagram_dir/$db_team.dot");
     $graph->$file_generator("$full_diagram_dir/$db_team.$extension");
 
     foreach my $c (@header_names) {
         my $filename = "$full_diagram_dir/$db_team." . clean_name($c) . ".$extension";
         my $graph = generate_sub_diagram($c, 'column_links');
+        #$graph->dot_input_filename("$full_diagram_dir/$db_team." . clean_name($c) . ".dot");
         $graph->$file_generator($filename);
         fetch_diagram_dimensions($c, $filename);
     }


### PR DESCRIPTION
## Description

When doing some tests for the Compara documentation, I found that there was a .dot file around. I believe it shouldn't be there.

## Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._

## Benefits

No leftover .dot file hanging around. Unlikely to go and pollute public-plugins

## Possible Drawbacks

If people want the .dot file they have to go and uncomment the line in the source code

## Testing

- [ no ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ no ] Have you run the entire test suite and no regression was detected?
- [ hopefully ] TravisCI passed on your branch

Dependencies
------------

None