### PR TITLE
Fixing bioperl version to stop problem installing HTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
 - make
 - export HTSLIB_DIR=$(pwd -P)
 - cd ..
-- git clone --branch bioperl-release-1-6-924 --depth 1 https://github.com/bioperl/bioperl-live.git
+- git clone --branch release-1-6-924 --depth 1 https://github.com/bioperl/bioperl-live.git
 
 install:
 - cpanm -v --installdeps --with-recommends --notest --cpanfile ensembl/cpanfile .

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ before_install:
 install:
 - cpanm -v --installdeps --with-recommends --notest --cpanfile ensembl/cpanfile .
 - cpanm -v --installdeps --notest --cpanfile ensembl-hive/cpanfile .
+- export PERL5LIB=$PERL5LIB:$PWD/bioperl-live
 - cpanm -v --installdeps --notest .
 - cpanm -n Devel::Cover::Report::Coveralls
 - cp travisci/MultiTestDB.conf.travisci  modules/t/MultiTestDB.conf

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,7 @@ before_install:
 - make
 - export HTSLIB_DIR=$(pwd -P)
 - cd ..
-- wget https://github.com/bioperl/bioperl-live/archive/release-1-6-924.zip
-- unzip release-1-6-924.zip
+- git clone --branch bioperl-release-1-6-924 --depth 1 https://github.com/bioperl/bioperl-live.git
 
 install:
 - cpanm -v --installdeps --with-recommends --notest --cpanfile ensembl/cpanfile .

--- a/travisci/harness.sh
+++ b/travisci/harness.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export PERL5LIB=$PWD/bioperl-live-bioperl-release-1-2-3:$PWD/ensembl-test/modules:$PWD/ensembl/modules:$PWD/ensembl-compara/modules:$PWD/ensembl-metadata/modules:$PWD/ensembl-datacheck/lib:$PWD/modules:$PWD/ensembl-hive/modules:$PWD/ensembl-orm/modules:$PWD/ensembl-metadata/modules:$PWD/ensembl-funcgen/modules:$PWD/ensembl-variation/modules:$PWD/modules:$PWD/ensembl-taxonomy/modules:$PWD/modules
+export PERL5LIB=$PWD/bioperl-live:$PWD/ensembl-test/modules:$PWD/ensembl/modules:$PWD/ensembl-compara/modules:$PWD/ensembl-metadata/modules:$PWD/ensembl-datacheck/lib:$PWD/modules:$PWD/ensembl-hive/modules:$PWD/ensembl-orm/modules:$PWD/ensembl-metadata/modules:$PWD/ensembl-funcgen/modules:$PWD/ensembl-variation/modules:$PWD/modules:$PWD/ensembl-taxonomy/modules:$PWD/modules
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/htslib
 
 export PATH=$PATH:$PWD/htslib


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Updated Bioperl version and fixing PERL5LIB export

## Use case

Travis is broken on the repo as it can't install Bio::DB::HTS. The Core team advised to look at BioPerl installation. It looks like we have a discrepency between downloaded Bioperl and what is in PERL5LIB

## Benefits

Travis will work again

## Possible Drawbacks

Travis will work again.

## Testing

- [ N] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ N] Have you run the entire test suite and no regression was detected?
- [ ?] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
