### PR TITLE
so_term column to biotype table

### DIFF
--- a/modules/t/test-genome-DBs/homo_sapiens/core/biotype.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/biotype.txt
@@ -1,188 +1,207 @@
-1	name			0	description		\N
-2	IG_C_gene	transcript	core,otherfeatures,presite	0	NULL	coding	SO:0000478
-3	IG_D_gene	gene	core,otherfeatures,presite	100	NULL	coding	SO:0001217
-4	IG_D_gene	transcript	core,otherfeatures,presite	0	NULL	coding	SO:0000458
-5	IG_J_gene	gene	core,otherfeatures,presite	100	NULL	coding	SO:0001217
-6	IG_J_gene	transcript	core,otherfeatures,presite	0	NULL	coding	SO:0000470
-7	IG_J_pseudogene	gene	core,presite	67	NULL	pseudogene	SO:0000336
-8	IG_J_pseudogene	transcript	core,presite	0	NULL	pseudogene	SO:0000516
-9	IG_V_gene	gene	core,otherfeatures,presite	100	NULL	coding	SO:0001217
-10	IG_V_gene	transcript	core,otherfeatures,presite	0	NULL	coding	SO:0000466
-11	IG_V_pseudogene	gene	core,presite	67	NULL	pseudogene	SO:0000336
-12	IG_V_pseudogene	transcript	core,presite	0	NULL	pseudogene	SO:0000516
-13	IG_gene	gene	vega	0	NULL	coding	SO:0001217
-14	IG_gene	transcript	vega	0	NULL	coding	SO:3000000
-15	IG_pseudogene	gene	core,vega,presite	67	NULL	pseudogene	SO:0000336
-16	IG_pseudogene	transcript	core,vega,presite	0	NULL	pseudogene	SO:0000516
-17	LRG_gene	gene	core	0	NULL	LRG	\N
-18	LRG_gene	transcript	core	0	NULL	LRG	\N
-19	Mt_rRNA	gene	core,presite	73	NULL	snoncoding	SO:0001263
-20	Mt_rRNA	transcript	core,presite	0	NULL	snoncoding	SO:0000252
-21	Mt_tRNA	gene	core,presite	74	NULL	snoncoding	SO:0001263
-22	Mt_tRNA	transcript	core,presite	0	NULL	snoncoding	SO:0000253
-23	Mt_tRNA_pseudogene	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336
-24	Mt_tRNA_pseudogene	transcript	core	0	noncoding RNA pseudogene	pseudogene	SO:0000516
-25	RNA-Seq_ge	1	gene	otherfeatures	0	NULL	undefined	\N
-26	RNA-Seq_ge	1	transcript	otherfeatures	0	NULL	undefined	\N
-27	TEC	gene	core,vega,sangervega	0	NULL	undefined	\N
-28	TEC	transcript	core,vega,sangervega	0	NULL	undefined	SO:0002139
-29	TR_gene	gene	vega	0	NULL	coding	SO:0001217
-30	TR_gene	transcript	core,vega	0	NULL	coding	SO:3000000
-31	TR_pseudogene	gene	vega	0	NULL	pseudogene	SO:0000336
-32	TR_pseudogene	transcript	vega	0	NULL	pseudogene	SO:0000516
-33	ambiguous_orf	transcript	core,vega	0	NULL	lnoncoding	SO:0001877
-35	cdna_update	gene	cdna	0	NULL	undefined	\N
-36	cdna_update	transcript	cdna	0	NULL	undefined	\N
-37	cdna	gene	otherfeatures	0	NULL	undefined	SO:0000756
-38	cdna	transcript	otherfeatures	0	NULL	undefined	SO:0000756
-39	disrupted_domain	transcript	core,vega	0	NULL	pseudogene	SO:0000516
-40	est	gene	otherfeatures	0	NULL	undefined	\N
-41	est	transcript	otherfeatures	0	NULL	undefined	SO:0000345
-42	lincRNA	gene	core,vega,presite	190	NULL	lnoncoding	SO:0001263
-43	lincRNA	transcript	core,vega,presite	0	NULL	lnoncoding	SO:0001877
-44	miRNA	gene	core,otherfeatures,vega,presite	70	From RefSeq import.	snoncoding	SO:0001263
-45	miRNA	transcript	core,otherfeatures,presite	0	From RefSeq import.	snoncoding	SO:0000276
-46	miRNA_pseudogene	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336
-47	miRNA_pseudogene	transcript	core	0	noncoding RNA pseudogene	pseudogene	SO:0000516
-48	misc_RNA	gene	core,otherfeatures,presite	0	NULL	mnoncoding	SO:0001263
-49	misc_RNA	transcript	core,otherfeatures,presite	0	NULL	mnoncoding	SO:0000655
-50	misc_RNA_pseudogene	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336
-51	misc_RNA_pseudogene	transcript	core	0	noncoding RNA pseudogene	pseudogene	SO:0000516
-52	ncRNA	gene	core,otherfeatures	99	NULL	snoncoding	SO:0001263
-53	ncRNA	transcript	core,otherfeatures	0	NULL	snoncoding	SO:0000655
-54	non_coding	gene	core,otherfeatures,rnaseq,vega,presite	353	NULL	lnoncoding	SO:0001263
-55	non_coding	transcript	core,otherfeatures,rnaseq,vega,presite	0	NULL	lnoncoding	SO:0001877
-56	nonsense_mediated_decay	transcript	core,vega,presite	0	NULL	coding	SO:0000234
-57	polymorphic	gene	vega	0	NULL	coding	SO:0001217
-58	polymorphic_pseudogene	gene	core,vega,presite	67	NULL	coding	SO:0001217
-59	polymorphic_pseudogene	transcript	core,vega,presite	0	NULL	coding	SO:0000234
-60	processed_pseudogene	gene	core,vega,presite	0	NULL	pseudogene	SO:0000336
-61	processed_pseudogene	transcript	core,vega,presite	0	NULL	pseudogene	SO:0000516
-62	processed_transcript	gene	core,vega,presite	79	NULL	lnoncoding	SO:0001263
-63	processed_transcript	transcript	core,vega,presite	0	NULL	lnoncoding	SO:0001877
-64	protein_coding	gene	core,otherfeatures,rnaseq,vega,presite	0	NULL	coding	SO:0001217
-65	protein_coding	transcript	core,otherfeatures,rnaseq,vega,presite	0	NULL	coding	SO:0000234
-66	pseudogene	gene	core,otherfeatures,vega,presite	67	NULL	pseudogene	SO:0000336
-67	pseudogene	transcript	core,otherfeatures,vega,presite	0	NULL	pseudogene	SO:0000516
-68	rRNA	gene	core,otherfeatures,vega,presite	66	NULL	lnoncoding	SO:0001263
-69	rRNA	transcript	core,otherfeatures,vega,presite	0	NULL	lnoncoding	SO:0000252
-70	rRNA_pseudogene	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336
-71	rRNA_pseudogene	transcript	core	0	noncoding RNA pseudogene	pseudogene	SO:0000516
-72	retained_intron	transcript	core,vega,presite	0	NULL	lnoncoding	SO:0001877
-73	retrotransposed	gene	core	77	NULL	pseudogene	SO:0000569
-74	retrotransposed	transcript	core	0	NULL	pseudogene	SO:0000569
-75	scRNA_pseudogene	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336
-76	scRNA_pseudogene	transcript	core	0	noncoding RNA pseudogene	pseudogene	SO:0000516
-77	snRNA	gene	core,otherfeatures,vega,presite	68	From Havana manual annotation.	snoncoding	SO:0001263
-78	snRNA	transcript	core,otherfeatures,vega,presite	0	From Havana manual annotation.	snoncoding	SO:0000274
-79	snRNA_pseudogene	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336
-80	snRNA_pseudogene	transcript	core	0	noncoding RNA pseudogene	pseudogene	SO:0000516
-81	snlRNA	gene	core	78	NULL	snoncoding	SO:0001263
-82	snlRNA	transcript	core	0	NULL	snoncoding	SO:0000274
-83	snoRNA	gene	core,otherfeatures,vega,presite	69	small nucleolar RNA.	snoncoding	SO:0001263
-84	snoRNA	transcript	core,otherfeatures,vega,presite	0	small nucleolar RNA.	snoncoding	SO:0000275
-85	snoRNA_pseudogene	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336
-86	snoRNA_pseudogene	transcript	core	0	noncoding RNA pseudogene	pseudogene	SO:0000516
-87	tRNA	gene	core,otherfeatures,presite	76	NULL	snoncoding	SO:0001263
-88	tRNA	transcript	core,otherfeatures,presite	76	NULL	snoncoding	SO:0000253
-89	tRNA_pseudogene	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336
-90	tRNA_pseudogene	transcript	core	0	noncoding RNA pseudogene	pseudogene	SO:0000516
-91	transcribed_processed_pseudogene	gene	core,vega,presite	0	NULL	pseudogene	SO:0000336
-92	transcribed_processed_pseudogene	transcript	core,vega,presite	0	NULL	pseudogene	SO:0000516
-93	transcribed_unitary_pseudogene	gene	core,vega	0	NULL	pseudogene	SO:0000336
-94	transcribed_unprocessed_pseudogene	gene	core,vega,presite	0	NULL	pseudogene	SO:0000336
-95	transcribed_unprocessed_pseudogene	transcript	core,vega,presite	0	NULL	pseudogene	SO:0000516
-96	unitary_pseudogene	gene	core,vega,presite	0	NULL	pseudogene	SO:0000336
-97	unitary_pseudogene	transcript	core,vega,presite	0	NULL	pseudogene	SO:0000516
-98	unprocessed_pseudogene	gene	core,vega,presite	0	NULL	pseudogene	SO:0000336
-99	unprocessed_pseudogene	transcript	core,vega,presite	0	NULL	pseudogene	SO:0000516
-100	ccds_gene	gene	otherfeatures	0	Imported CCDS gene models	undefined	\N
-101	protein_coding_in_progress	gene	vega	0	occurs where the ORF is lost when remapping to a different assembly and the gene is awaiting reannotation	undefined	\N
-102	IG_Z_gene	gene	core,vega	100	NULL	coding	SO:0001217
-103	IG_M_gene	gene	core,vega	100	NULL	coding	SO:0001217
-104	ncrna_host	transcript	core,vega	0	NULL	lnoncoding	\N
-105	TR_V_pseudogene	gene	core,presite	67	NULL	pseudogene	SO:0000336
-106	TR_V_gene	gene	core,presite	100	NULL	coding	SO:0001217
-107	IG_C_pseudogene	gene	core,presite	67	NULL	pseudogene	SO:0000336
-108	TR_C_gene	gene	core,presite	100	NULL	coding	SO:0001217
-109	TR_J_gene	gene	core,presite	100	NULL	coding	SO:0001217
-110	TR_V_pseudogene	transcript	core,presite	0	NULL	pseudogene	SO:0000516
-111	TR_V_gene	transcript	core,presite	0	NULL	coding	SO:0000466
-112	IG_C_pseudogene	transcript	core,presite	0	NULL	pseudogene	SO:0000516
-113	TR_C_gene	transcript	core,presite	0	NULL	coding	SO:0000478
-114	TR_J_gene	transcript	core,presite	0	NULL	coding	SO:0000470
-115	protein_coding_in_progress	transcript	vega	0	occurs where the ORF is lost when remapping to a different assembly and the gene is awaiting reannotation	undefined	\N
-116	IG_M_gene	transcript	core	0	NULL	coding	SO:3000000
-117	IG_Z_gene	transcript	core	0	NULL	coding	SO:3000000
-118	3prime_overlapping_ncrna	transcript	core,vega,presite	0	NULL	lnoncoding	SO:0002120
-123	antisense_RNA	gene	otherfeatures,presite	0	From RefSeq import	lnoncoding	SO:0001263
-124	antisense_RNA	transcript	otherfeatures,presite	0	From RefSeq import	lnoncoding	SO:0001877
-125	scRNA	gene	otherfeatures	0	From RefSeq import	snoncoding	SO:0001263
-126	scRNA	transcript	otherfeatures	0	From RefSeq import	snoncoding	SO:0000013
-127	RNase_MRP_RNA	gene	core,otherfeatures,presite	0	From RefSeq import or Rfamscan	snoncoding	SO:0001263
-128	RNase_MRP_RNA	transcript	core,otherfeatures,presite	0	From RefSeq import or Rfamscan	snoncoding	SO:0000385
-129	RNase_P_RNA	gene	core,otherfeatures,presite	0	From RefSeq import or Rfamscan	snoncoding	SO:0001263
-130	RNase_P_RNA	transcript	core,otherfeatures,presite	0	From RefSeq import or Rfamscan	snoncoding	SO:0000386
-131	telomerase_RNA	gene	otherfeatures,presite	0	From RefSeq import or Rfamscan	snoncoding	SO:0001263
-132	telomerase_RNA	transcript	otherfeatures,presite	0	From RefSeq import or Rfamscan	snoncoding	SO:0000390
-133	sense_intronic	transcript	core,vega,presite	0	NULL	lnoncoding	SO:0001877
-135	sense_overlapping	transcript	core,vega,presite	0	NULL	lnoncoding	SO:0001877
-138	sense_intronic	gene	core,vega,presite	350	NULL	lnoncoding	SO:0001263
-139	ambiguous_orf	gene	core,vega	351	NULL	lnoncoding	SO:0001263
-140	retained_intron	gene	core,vega,presite	352	NULL	lnoncoding	SO:0001263
-142	3prime_overlapping_ncrna	gene	core,vega,presite	356	NULL	lnoncoding	\N
-143	ncrna_host	gene	core,vega	354	NULL	lnoncoding	\N
-144	sense_overlapping	gene	core,vega,presite	355	NULL	lnoncoding	SO:0001263
-146	TR_D_gene	transcript	core,presite	0	NULL	coding	SO:0000458
-147	TR_J_pseudogene	transcript	core,presite	0	NULL	pseudogene	SO:0000516
-148	TR_D_gene	gene	core,presite	100	NULL	coding	SO:0001217
-149	TR_J_pseudogene	gene	core,presite	67	NULL	pseudogene	SO:0000336
-150	ncbi_pseudogene	gene	otherfeatures	0	Imported annotation from RefSeq	pseudogene	SO:0000336
-151	ncbi_pseudogene	transcript	otherfeatures	0	Imported annotation from RefSeq	pseudogene	SO:0000516
-152	ncbigene	gene	otherfeatures	0	Imported annotation from RefSeq	undefined	\N
-153	non_stop_decay	transcript	core,vega,presite	0	A new transcript biotype from Havana.	coding	SO:0000234
-154	pre_miRNA	transcript	core	0	This is the pre miRNA information extracted from FlyBase annotations distinctive from the miRNA form for the same gene model.Gautier is happy for this to be in the short noncoding group.	snoncoding	SO:0001244
-155	tmRNA	gene	core	357	One of the classes of ncRNA genes that is only found in bacteria.Hence only required for EnsemblBacteria.	snoncoding	SO:0001263
-156	tmRNA	transcript	core	0	One of the classes of ncRNA genes that is only found in bacteria. Hence only required for EnsemblBacteria.	snoncoding	SO:0000584
-157	SRP_RNA	gene	core	194	The signal recognition particle (SRP) RNA is one of the classes of ncRNA genes.	snoncoding	SO:0001263
-158	SRP_RNA	transcript	core	0	The signal recognition particle (SRP) RNA is one of the classes of ncRNA genes.	snoncoding	SO:0000590
-160	ribozyme	transcript	core,otherfeatures,presite	0	NULL	lnoncoding	SO:0001877
-163	ncRNA_pseudogene	gene	otherfeatures	99	noncoding RNA pseudogene	pseudogene	SO:0000336
-164	ncRNA_pseudogene	transcript	otherfeatures	99	noncoding RNA pseudogene	pseudogene	SO:0000516
-165	IG_LV_gene	gene	core	100	NULL	coding	SO:0001217
-166	IG_LV_gene	transcript	core	0	NULL	coding	SO:3000000
-167	translated_processed_pseudogene	gene	core,vega,presite	0	NULL	pseudogene	SO:0000336
-168	translated_processed_pseudogene	transcript	core,vega,presite	0	NULL	pseudogene	SO:0000516
-169	nontranslating_CDS	gene	core	0	An imported 'protein-coding' gene that does not translate due to one or more unannotated stop codons.	coding	SO:0001217
-170	nontranslating_CDS	transcript	core	0	An imported 'protein-coding' transcript that does not translate due to one or more unannotated stop codons.	coding	SO:0000234
-171	translated_unprocessed_pseudogene	gene	core,vega	0	NULL	pseudogene	SO:0000336
-172	translated_unprocessed_pseudogene	transcript	core,vega	0	NULL	pseudogene	SO:0000516
-173	mRNA	gene	otherfeatures	0	From RefSeq import	coding	SO:0001217
-174	mRNA	transcript	otherfeatures	0	From RefSeq import	coding	SO:0000234
-175	pre_miRNA	gene	core	0	This is the pre miRNA information extracted from FlyBase annotations distinctive from the miRNA form for the same gene model.Gautier is happy for this to be in the short noncoding group.	snoncoding	SO:0001263
-176	artifact	gene	vega	0	Should not see this biotype in core db	undefined	\N
-177	artifact	transcript	vega	0	Should not see this biotype in core db	undefined	\N
-178	lncRNA	gene	core,otherfeatures,vega,presite	190	NULL	lnoncoding	SO:0001263
-179	class_I_RNA	gene	core	0	Small non-coding RNA (55-65 nt long) containing highly conserved 5' and 3' ends (16 and 8 nt, respectively) that are predicted to come together to form a stem structure. Identified in the social amoeba Dictyostelium discoideum and localized in the cytoplasm.	snoncoding	SO:0001263
-180	class_I_RNA	transcript	core	0	Small non-coding RNA (55-65 nt long) containing highly conserved 5' and 3' ends (16 and 8 nt, respectively) that are predicted to come together to form a stem structure. Identified in the social amoeba Dictyostelium discoideum and localized in the cytoplasm.	snoncoding	SO:0000990
-181	class_II_RNA	gene	core	0	Small non-coding RNA (59-60 nt long) containing 5' and 3' ends that are predicted to come together to form a stem structure. Identified in the social amoeba Dictyostelium discoideum and localized in the cytoplasm.	snoncoding	SO:0001263
-182	class_II_RNA	transcript	core	0	Small non-coding RNA (59-60 nt long) containing 5' and 3' ends that are predicted to come together to form a stem structure. Identified in the social amoeba Dictyostelium discoideum and localized in the cytoplasm.	snoncoding	SO:0000989
-183	known_ncrna	gene	core,otherfeatures,vega,sangervega	99	NULL	snoncoding	\N
-184	known_ncrna	transcript	core,otherfeatures,vega,sangervega	0	NULL	snoncoding	SO:0000655
-185	transcribed_unitary_pseudogene	transcript	core,vega	0	NULL	pseudogene	SO:0000516
-186	piRNA	gene	core	0	A small non coding RNA, part of a silencing system that prevents the spreading of selfish genetic elements.	snoncoding	SO:0001263
-187	piRNA	transcript	core	0	A small non coding RNA, part of a silencing system that prevents the spreading of selfish genetic elements.	snoncoding	SO:0001035
-188	IG_D_pseudogene	gene	core,presite	67	NULL	pseudogene	SO:0000336
-189	macro_lncRNA	gene	core,vega	388	Unspliced lncRNAs that are several kb in size	lnoncoding	SO:0001263
-191	vaultRNA	gene	core,vega	388	short non coding RNA genes that form part of the vault ribonucleoprotein complex	snoncoding	SO:0001263
-192	scaRNA	gene	core,otherfeatures,presite	440	NULL	snoncoding	SO:0001263
-193	scaRNA	transcript	core,otherfeatures,presite	0	NULL	snoncoding	SO:0000013
-194	sRNA	transcript	core,otherfeatures,presite	0	NULL	snoncoding	SO:0000274
-195	sRNA	gene	core,otherfeatures,presite	441	NULL	snoncoding	SO:0001263
-196	CRISPR	gene	core,otherfeatures,presite	442	NULL	snoncoding	SO:0001263
-197	CRISPR	transcript	core,otherfeatures,presite	0	NULL	snoncoding	SO:0001459
-198	antitoxin	transcript	core,otherfeatures,presite	0	NULL	lnoncoding	SO:0001877
-199	antitoxin	gene	core,otherfeatures,presite	443	NULL	lnoncoding	SO:0001263
-200	ribozyme	gene	core,otherfeatures,presite	359	NULL	lnoncoding	SO:0001263
-202	vaultRNA	transcript	core,vega	388	short non coding RNA genes that form part of the vault ribonucleoprotein complex	snoncoding	SO:0002040
-203	macro_lncRNA	transcript	core,vega	388	Unspliced lncRNAs that are several kb in size	lnoncoding	SO:0001877
+1	IG_C_gene	gene	core,otherfeatures,presite	100	\N	coding	SO:0001217	protein_coding_gene
+2	IG_C_gene	transcript	core,otherfeatures,presite	\N	\N	coding	SO:0000478	C_gene_segment
+3	IG_D_gene	gene	core,otherfeatures,presite	100	\N	coding	SO:0001217	protein_coding_gene
+4	IG_D_gene	transcript	core,otherfeatures,presite	\N	\N	coding	SO:0000458	D_gene_segment
+5	IG_J_gene	gene	core,otherfeatures,presite	100	\N	coding	SO:0001217	protein_coding_gene
+6	IG_J_gene	transcript	core,otherfeatures,presite	\N	\N	coding	SO:0000470	J_gene_segment
+7	IG_J_pseudogene	gene	core,otherfeatures,presite	67	\N	pseudogene	SO:0000336	pseudogene
+8	IG_J_pseudogene	transcript	core,otherfeatures,presite	\N	\N	pseudogene	SO:0000516	pseudogenic_transcript
+9	IG_V_gene	gene	core,otherfeatures,presite	100	\N	coding	SO:0001217	protein_coding_gene
+10	IG_V_gene	transcript	core,otherfeatures,presite	\N	\N	coding	SO:0000466	V_gene_segment
+11	IG_V_pseudogene	gene	core,otherfeatures,presite	67	\N	pseudogene	SO:0000336	pseudogene
+12	IG_V_pseudogene	transcript	core,otherfeatures,presite	\N	\N	pseudogene	SO:0000516	pseudogenic_transcript
+13	IG_gene	gene	vega	\N	\N	coding	SO:0001217	protein_coding_gene
+14	IG_gene	transcript	vega	\N	\N	coding	SO:3000000	gene_segment
+15	IG_pseudogene	gene	core,vega,presite	67	\N	pseudogene	SO:0000336	pseudogene
+16	IG_pseudogene	transcript	core,vega,presite	\N	\N	pseudogene	SO:0000516	pseudogenic_transcript
+17	LRG_gene	gene	core	\N	\N	LRG	\N	\N
+18	LRG_gene	transcript	core	\N	\N	LRG	\N	\N
+19	Mt_rRNA	gene	core,presite	73	\N	snoncoding	SO:0001263	ncRNA_gene
+20	Mt_rRNA	transcript	core,presite	\N	\N	snoncoding	SO:0000252	rRNA
+21	Mt_tRNA	gene	core,presite	74	\N	snoncoding	SO:0001263	ncRNA_gene
+22	Mt_tRNA	transcript	core,presite	\N	\N	snoncoding	SO:0000253	tRNA
+23	Mt_tRNA_pseudogene	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336	pseudogene
+24	Mt_tRNA_pseudogene	transcript	core	\N	noncoding RNA pseudogene	pseudogene	SO:0000516	pseudogenic_transcript
+25	RNA-Seq_gene	gene	otherfeatures	\N	\N	undefined	\N	\N
+26	RNA-Seq_gene	transcript	otherfeatures	\N	\N	undefined	\N	\N
+27	TEC	gene	core,vega,sangervega	0	\N	undefined	\N	\N
+28	TEC	transcript	core,vega,sangervega	\N	\N	undefined	SO:0002139	unconfirmed_transcript
+29	TR_gene	gene	vega	\N	\N	coding	SO:0001217	protein_coding_gene
+30	TR_gene	transcript	core,vega	\N	\N	coding	SO:3000000	gene_segment
+31	TR_pseudogene	gene	vega	\N	\N	pseudogene	SO:0000336	pseudogene
+32	TR_pseudogene	transcript	vega	0	\N	pseudogene	SO:0000516	pseudogenic_transcript
+33	ambiguous_orf	transcript	core,vega	\N	\N	lnoncoding	SO:0001877	lnc_RNA
+35	cdna_update	gene	cdna	\N	\N	undefined	\N	\N
+36	cdna_update	transcript	cdna	\N	\N	undefined	\N	\N
+37	cdna	gene	otherfeatures	\N	\N	undefined	SO:0000756	cDNA
+38	cdna	transcript	otherfeatures	\N	\N	undefined	SO:0000756	cDNA
+39	disrupted_domain	transcript	core,vega	\N	\N	pseudogene	SO:0000516	pseudogenic_transcript
+40	est	gene	otherfeatures	\N	\N	undefined	\N	\N
+41	est	transcript	otherfeatures	\N	\N	undefined	SO:0000345	EST
+42	lincRNA	gene	core,vega,presite	190	\N	lnoncoding	SO:0001263	ncRNA_gene
+43	lincRNA	transcript	core,vega,presite	\N	\N	lnoncoding	SO:0001877	lnc_RNA
+44	miRNA	gene	core,otherfeatures,vega,presite	70	From RefSeq import.	snoncoding	SO:0001263	ncRNA_gene
+45	miRNA	transcript	core,otherfeatures,presite	\N	From RefSeq import.	snoncoding	SO:0000276	miRNA
+46	miRNA_pseudogene	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336	pseudogene
+47	miRNA_pseudogene	transcript	core	\N	noncoding RNA pseudogene	pseudogene	SO:0000516	pseudogenic_transcript
+48	misc_RNA	gene	core,otherfeatures,presite	\N	\N	mnoncoding	SO:0001263	ncRNA_gene
+49	misc_RNA	transcript	core,otherfeatures,presite	\N	\N	mnoncoding	SO:0000655	ncRNA
+50	misc_RNA_pseudogene	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336	pseudogene
+51	misc_RNA_pseudogene	transcript	core	\N	noncoding RNA pseudogene	pseudogene	SO:0000516	pseudogenic_transcript
+52	ncRNA	gene	core,otherfeatures	99	\N	snoncoding	SO:0001263	ncRNA_gene
+53	ncRNA	transcript	core,otherfeatures	\N	\N	snoncoding	SO:0000655	ncRNA
+54	non_coding	gene	core,otherfeatures,rnaseq,vega,presite	353	\N	lnoncoding	SO:0001263	ncRNA_gene
+55	non_coding	transcript	core,otherfeatures,rnaseq,vega,presite	\N	\N	lnoncoding	SO:0001877	lnc_RNA
+56	nonsense_mediated_decay	transcript	core,vega,presite	\N	\N	coding	SO:0000234	mRNA
+57	polymorphic	gene	vega	\N	\N	coding	SO:0001217	protein_coding_gene
+58	polymorphic_pseudogene	gene	core,vega,presite	67	\N	coding	SO:0001217	protein_coding_gene
+59	polymorphic_pseudogene	transcript	core,vega,presite	\N	\N	coding	SO:0000234	mRNA
+60	processed_pseudogene	gene	core,vega,presite	\N	\N	pseudogene	SO:0000336	pseudogene
+61	processed_pseudogene	transcript	core,vega,presite	\N	\N	pseudogene	SO:0000516	pseudogenic_transcript
+62	processed_transcript	gene	core,vega,presite	79	\N	lnoncoding	SO:0001263	ncRNA_gene
+63	processed_transcript	transcript	core,vega,presite	\N	\N	lnoncoding	SO:0001877	lnc_RNA
+64	protein_coding	gene	core,otherfeatures,rnaseq,vega,presite	\N	\N	coding	SO:0001217	protein_coding_gene
+65	protein_coding	transcript	core,otherfeatures,rnaseq,vega,presite	\N	\N	coding	SO:0000234	mRNA
+66	pseudogene	gene	core,otherfeatures,vega,presite	67	\N	pseudogene	SO:0000336	pseudogene
+67	pseudogene	transcript	core,otherfeatures,vega,presite	\N	\N	pseudogene	SO:0000516	pseudogenic_transcript
+68	rRNA	gene	core,otherfeatures,vega,presite	\N	\N	snoncoding	SO:0001263	ncRNA_gene
+69	rRNA	transcript	core,otherfeatures,vega,presite	\N	\N	snoncoding	SO:0000252	rRNA
+70	rRNA_pseudogene	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336	pseudogene
+71	rRNA_pseudogene	transcript	core	\N	noncoding RNA pseudogene	pseudogene	SO:0000516	pseudogenic_transcript
+72	retained_intron	transcript	core,vega,presite	\N	\N	lnoncoding	SO:0001877	lnc_RNA
+75	scRNA_pseudogene	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336	pseudogene
+76	scRNA_pseudogene	transcript	core	\N	noncoding RNA pseudogene	pseudogene	SO:0000516	pseudogenic_transcript
+77	snRNA	gene	core,otherfeatures,vega,presite	68	From Havana manual annotation.	snoncoding	SO:0001263	ncRNA_gene
+78	snRNA	transcript	core,otherfeatures,vega,presite	\N	From Havana manual annotation.	snoncoding	SO:0000274	snRNA
+79	snRNA_pseudogene	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336	pseudogene
+80	snRNA_pseudogene	transcript	core	\N	noncoding RNA pseudogene	pseudogene	SO:0000516	pseudogenic_transcript
+81	snlRNA	gene	core	78	\N	snoncoding	SO:0001263	ncRNA_gene
+82	snlRNA	transcript	core	\N	\N	snoncoding	SO:0000274	snRNA
+83	snoRNA	gene	core,otherfeatures,vega,presite	69	small nucleolar RNA.	snoncoding	SO:0001263	ncRNA_gene
+84	snoRNA	transcript	core,otherfeatures,vega,presite	\N	small nucleolar RNA.	snoncoding	SO:0000275	snoRNA
+85	snoRNA_pseudogene	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336	pseudogene
+86	snoRNA_pseudogene	transcript	core	\N	noncoding RNA pseudogene	pseudogene	SO:0000516	pseudogenic_transcript
+87	tRNA	gene	core,otherfeatures,presite	76	\N	snoncoding	SO:0001263	ncRNA_gene
+88	tRNA	transcript	core,otherfeatures,presite	76	\N	snoncoding	SO:0000253	tRNA
+89	tRNA_pseudogene	gene	core,otherfeatures	\N	noncoding RNA pseudogene	pseudogene	SO:0000336	pseudogene
+90	tRNA_pseudogene	transcript	core,otherfeatures	\N	noncoding RNA pseudogene	pseudogene	SO:0000516	pseudogenic_transcript
+91	transcribed_processed_pseudogene	gene	core,vega,presite	\N	\N	pseudogene	SO:0000336	pseudogene
+92	transcribed_processed_pseudogene	transcript	core,vega,presite	\N	\N	pseudogene	SO:0000516	pseudogenic_transcript
+93	transcribed_unitary_pseudogene	gene	core,vega	\N	\N	pseudogene	SO:0000336	pseudogene
+94	transcribed_unprocessed_pseudogene	gene	core,vega,presite	\N	\N	pseudogene	SO:0000336	pseudogene
+95	transcribed_unprocessed_pseudogene	transcript	core,vega,presite	\N	\N	pseudogene	SO:0000516	pseudogenic_transcript
+96	unitary_pseudogene	gene	core,vega,presite	\N	\N	pseudogene	SO:0000336	pseudogene
+97	unitary_pseudogene	transcript	core,vega,presite	\N	\N	pseudogene	SO:0000516	pseudogenic_transcript
+98	unprocessed_pseudogene	gene	core,vega,presite	\N	\N	pseudogene	SO:0000336	pseudogene
+99	unprocessed_pseudogene	transcript	core,vega,presite	\N	\N	pseudogene	SO:0000516	pseudogenic_transcript
+100	ccds_gene	gene	otherfeatures	\N	Imported CCDS gene models	undefined	\N	\N
+101	protein_coding_in_progress	gene	vega	\N	occurs where the ORF is lost when remapping to a different assembly and the gene is awaiting reannotation	undefined	\N	\N
+102	IG_Z_gene	gene	core,vega	100	\N	coding	SO:0001217	protein_coding_gene
+103	IG_M_gene	gene	core,vega	100	\N	coding	SO:0001217	protein_coding_gene
+104	ncRNA_host	transcript	core,vega	\N	\N	lnoncoding	\N	\N
+105	TR_V_pseudogene	gene	core,presite	67	\N	pseudogene	SO:0000336	pseudogene
+106	TR_V_gene	gene	core,presite	100	\N	coding	SO:0001217	protein_coding_gene
+107	IG_C_pseudogene	gene	core,otherfeatures,presite	67	\N	pseudogene	SO:0000336	pseudogene
+108	TR_C_gene	gene	core,presite	100	\N	coding	SO:0001217	protein_coding_gene
+109	TR_J_gene	gene	core,presite	100	\N	coding	SO:0001217	protein_coding_gene
+110	TR_V_pseudogene	transcript	core,presite	\N	\N	pseudogene	SO:0000516	pseudogenic_transcript
+111	TR_V_gene	transcript	core,presite	\N	\N	coding	SO:0000466	V_gene_segment
+112	IG_C_pseudogene	transcript	core,otherfeatures,presite	\N	\N	pseudogene	SO:0000516	pseudogenic_transcript
+113	TR_C_gene	transcript	core,presite	\N	\N	coding	SO:0000478	C_gene_segment
+114	TR_J_gene	transcript	core,presite	\N	\N	coding	SO:0000470	J_gene_segment
+115	protein_coding_in_progress	transcript	vega	\N	occurs where the ORF is lost when remapping to a different assembly and the gene is awaiting reannotation	undefined	\N	\N
+116	IG_M_gene	transcript	core	\N	\N	coding	SO:3000000	gene_segment
+117	IG_Z_gene	transcript	core	\N	\N	coding	SO:3000000	gene_segment
+118	3prime_overlapping_ncRNA	transcript	core,vega,presite	\N	\N	lnoncoding	SO:0002120	three_prime_overlapping_ncrna
+123	antisense_RNA	gene	core,otherfeatures	\N	From RefSeq import	lnoncoding	SO:0001263	ncRNA_gene
+124	antisense_RNA	transcript	core,otherfeatures	\N	From RefSeq import	lnoncoding	SO:0001877	lnc_RNA
+125	scRNA	gene	core,otherfeatures,vega	\N	From RefSeq import or Havana manual annotation.	snoncoding	SO:0001263	ncRNA_gene
+126	scRNA	transcript	core,otherfeatures,vega	\N	From RefSeq import or Havana manual annotation.	snoncoding	SO:0000013	scRNA
+127	RNase_MRP_RNA	gene	core,otherfeatures,presite	\N	From RefSeq import or Rfamscan	snoncoding	SO:0001263	ncRNA_gene
+128	RNase_MRP_RNA	transcript	core,otherfeatures,presite	\N	From RefSeq import or Rfamscan	snoncoding	SO:0000385	RNase_MRP_RNA
+129	RNase_P_RNA	gene	core,otherfeatures,presite	\N	From RefSeq import or Rfamscan	snoncoding	SO:0001263	ncRNA_gene
+130	RNase_P_RNA	transcript	core,otherfeatures,presite	\N	From RefSeq import or Rfamscan	snoncoding	SO:0000386	RNase_P_RNA
+131	telomerase_RNA	gene	core,otherfeatures,presite	\N	From RefSeq import or Rfamscan	snoncoding	SO:0001263	ncRNA_gene
+132	telomerase_RNA	transcript	core,otherfeatures,presite	\N	From RefSeq import or Rfamscan	snoncoding	SO:0000390	telomerase_RNA
+133	sense_intronic	transcript	core,vega,presite	0	\N	lnoncoding	SO:0001877	lnc_RNA
+135	sense_overlapping	transcript	core,vega,presite	0	\N	lnoncoding	SO:0001877	lnc_RNA
+138	sense_intronic	gene	core,vega,presite	350	\N	lnoncoding	SO:0001263	ncRNA_gene
+139	ambiguous_orf	gene	core,vega	351	\N	lnoncoding	SO:0001263	ncRNA_gene
+140	retained_intron	gene	core,vega,presite	352	\N	lnoncoding	SO:0001263	ncRNA_gene
+142	3prime_overlapping_ncRNA	gene	core,vega,presite	\N	\N	lnoncoding	\N	\N
+143	ncRNA_host	gene	core,vega	\N	\N	lnoncoding	\N	\N
+144	sense_overlapping	gene	core,vega,presite	355	\N	lnoncoding	SO:0001263	ncRNA_gene
+146	TR_D_gene	transcript	core,presite	\N	\N	coding	SO:0000458	D_gene_segment
+147	TR_J_pseudogene	transcript	core,presite	\N	\N	pseudogene	SO:0000516	pseudogenic_transcript
+148	TR_D_gene	gene	core,presite	100	\N	coding	SO:0001217	protein_coding_gene
+149	TR_J_pseudogene	gene	core,presite	67	\N	pseudogene	SO:0000336	pseudogene
+150	ncbi_pseudogene	gene	otherfeatures	\N	Imported annotation from RefSeq	pseudogene	SO:0000336	pseudogene
+151	ncbi_pseudogene	transcript	otherfeatures	\N	Imported annotation from RefSeq	pseudogene	SO:0000516	pseudogenic_transcript
+152	ncbigene	gene	otherfeatures	\N	Imported annotation from RefSeq	undefined	\N	\N
+153	non_stop_decay	transcript	core,vega,presite	0	A new transcript biotype from Havana.	coding	SO:0000234	mRNA
+154	pre_miRNA	transcript	core	0	This is the pre miRNA information extracted from FlyBase annotations distinctive from the miRNA form for the same gene model.Gautier is happy for this to be in the short noncoding group.	snoncoding	SO:0001244	pre_miRNA
+155	tmRNA	gene	core	\N	One of the classes of ncRNA genes that is only found in bacteria. Hence only required for EnsemblBacteria.	snoncoding	SO:0001263	ncRNA_gene
+156	tmRNA	transcript	core	0	One of the classes of ncRNA genes that is only found in bacteria. Hence only required for EnsemblBacteria.	snoncoding	SO:0000584	tmRNA
+157	SRP_RNA	gene	core,otherfeatures	\N	The signal recognition particle (SRP) RNA is one of the classes of ncRNA genes.	snoncoding	SO:0001263	ncRNA_gene
+158	SRP_RNA	transcript	core,otherfeatures	0	The signal recognition particle (SRP) RNA is one of the classes of ncRNA genes.	snoncoding	SO:0000590	SRP_RNA
+160	ribozyme	transcript	core,otherfeatures,presite	\N	\N	lnoncoding	SO:0001877	lnc_RNA
+163	ncRNA_pseudogene	gene	otherfeatures	99	noncoding RNA pseudogene	pseudogene	SO:0000336	pseudogene
+164	ncRNA_pseudogene	transcript	otherfeatures	99	noncoding RNA pseudogene	pseudogene	SO:0000516	pseudogenic_transcript
+165	IG_LV_gene	gene	core	100	\N	coding	SO:0001217	protein_coding_gene
+166	IG_LV_gene	transcript	core	\N	\N	coding	SO:3000000	gene_segment
+167	translated_processed_pseudogene	gene	core,vega,presite	\N	\N	pseudogene	SO:0000336	pseudogene
+168	translated_processed_pseudogene	transcript	core,vega,presite	\N	\N	pseudogene	SO:0000516	pseudogenic_transcript
+169	nontranslating_CDS	gene	core,otherfeatures	\N	An imported 'protein-coding' gene that does not translate due to one or more unannotated stop codons.	coding	SO:0001217	protein_coding_gene
+170	nontranslating_CDS	transcript	core,otherfeatures	\N	An imported 'protein-coding' transcript that does not translate due to one or more unannotated stop codons.	coding	SO:0000234	mRNA
+171	translated_unprocessed_pseudogene	gene	core,vega	\N	\N	pseudogene	SO:0000336	pseudogene
+172	translated_unprocessed_pseudogene	transcript	core,vega	\N	\N	pseudogene	SO:0000516	pseudogenic_transcript
+173	mRNA	gene	otherfeatures	\N	From RefSeq import	coding	SO:0001217	protein_coding_gene
+174	mRNA	transcript	otherfeatures	\N	From RefSeq import	coding	SO:0000234	mRNA
+175	pre_miRNA	gene	core	\N	This is the pre miRNA information extracted from FlyBase annotations distinctive from the miRNA form for the same gene model.Gautier is happy for this to be in the short noncoding group.	snoncoding	SO:0001263	ncRNA_gene
+176	artifact	gene	vega	\N	Should not see this biotype in core db	undefined	\N	\N
+177	artifact	transcript	vega	\N	Should not see this biotype in core db	undefined	\N	\N
+178	lncRNA	gene	core,otherfeatures,vega,presite	190	\N	lnoncoding	SO:0001263	ncRNA_gene
+179	class_I_RNA	gene	core	\N	Small non-coding RNA (55-65 nt long) containing highly conserved 5' and 3' ends (16 and 8 nt, respectively) that are predicted to come together to form a stem structure. Identified in the social amoeba Dictyostelium discoideum and localized in the cytoplasm.	snoncoding	SO:0001263	ncRNA_gene
+180	class_I_RNA	transcript	core	\N	Small non-coding RNA (55-65 nt long) containing highly conserved 5' and 3' ends (16 and 8 nt, respectively) that are predicted to come together to form a stem structure. Identified in the social amoeba Dictyostelium discoideum and localized in the cytoplasm.	snoncoding	SO:0000990	class_I_RNA
+181	class_II_RNA	gene	core	\N	Small non-coding RNA (59-60 nt long) containing 5' and 3' ends that are predicted to come together to form a stem structure. Identified in the social amoeba Dictyostelium discoideum and localized in the cytoplasm.	snoncoding	SO:0001263	ncRNA_gene
+182	class_II_RNA	transcript	core	\N	Small non-coding RNA (59-60 nt long) containing 5' and 3' ends that are predicted to come together to form a stem structure. Identified in the social amoeba Dictyostelium discoideum and localized in the cytoplasm.	snoncoding	SO:0000989	class_II_RNA
+183	known_ncRNA	gene	core,otherfeatures,vega,sangervega	\N	\N	snoncoding	\N	\N
+184	known_ncRNA	transcript	core,otherfeatures,vega,sangervega	\N	\N	snoncoding	SO:0000655	ncRNA
+185	transcribed_unitary_pseudogene	transcript	core,vega	\N	\N	pseudogene	SO:0000516	pseudogenic_transcript
+186	piRNA	gene	core	\N	A small non coding RNA, part of a silencing system that prevents the spreading of selfish genetic elements.	snoncoding	SO:0001263	ncRNA_gene
+187	piRNA	transcript	core	\N	A small non coding RNA, part of a silencing system that prevents the spreading of selfish genetic elements.	snoncoding	SO:0001035	piRNA
+188	IG_D_pseudogene	gene	core,otherfeatures,presite	67	\N	pseudogene	SO:0000336	pseudogene
+189	macro_lncRNA	gene	core,vega	388	Unspliced lncRNAs that are several kb in size	lnoncoding	SO:0001263	ncRNA_gene
+191	vaultRNA	gene	core,otherfeatures,vega	388	short non coding RNA genes that form part of the vault ribonucleoprotein complex	snoncoding	SO:0001263	ncRNA_gene
+192	scaRNA	gene	core,otherfeatures,presite	440	\N	snoncoding	SO:0001263	ncRNA_gene
+193	scaRNA	transcript	core,otherfeatures,presite	\N	\N	snoncoding	SO:0000013	scRNA
+194	sRNA	transcript	core,otherfeatures,presite	\N	\N	snoncoding	SO:0000274	snRNA
+195	sRNA	gene	core,otherfeatures,presite	441	\N	snoncoding	SO:0001263	ncRNA_gene
+198	antitoxin	transcript	core,otherfeatures,presite	\N	\N	lnoncoding	SO:0001877	lnc_RNA
+199	antitoxin	gene	core,otherfeatures,presite	443	\N	lnoncoding	SO:0001263	ncRNA_gene
+200	ribozyme	gene	core,otherfeatures,presite	359	\N	lnoncoding	SO:0001263	ncRNA_gene
+202	vaultRNA	transcript	core,otherfeatures,vega	388	short non coding RNA genes that form part of the vault ribonucleoprotein complex	snoncoding	SO:0002040	vaultRNA_primary_transcript
+203	macro_lncRNA	transcript	core,vega	388	Unspliced lncRNAs that are several kb in size	lnoncoding	SO:0001877	lnc_RNA
+204	IG_D_pseudogene	transcript	core,otherfeatures,presite	67	\N	pseudogene	SO:0000516	pseudogenic_transcript
+205	guide_RNA	gene	otherfeatures	\N	From RefSeq import	snoncoding	SO:0001263	ncRNA_gene
+206	guide_RNA	transcript	otherfeatures	\N	From RefSeq import	snoncoding	SO:0000602	guide_RNA
+207	Y_RNA	gene	otherfeatures	\N	From RefSeq import	snoncoding	SO:0001263	ncRNA_gene
+208	Y_RNA	transcript	otherfeatures	\N	From RefSeq import	snoncoding	SO:0000405	Y_RNA
+209	transposable_element	transcript	core	\N	\N	no_group	SO:0000101	transposable_element
+210	transposable_element	gene	core	\N	\N	no_group	SO:0000111	transposable_element_gene
+211	bidirectional_promoter_lncRNA	transcript	core,vega,presite	\N	\N	lnoncoding	\N	\N
+212	bidirectional_promoter_lncRNA	gene	core,vega,presite	\N	\N	lnoncoding	SO:0002185	bidirectional_promoter_lncRNA
+215	unknown_likely_coding	gene	core	\N	Biotype introduced by UCSC in the mouse strains, for genes/transcripts that were not in the mouse reference but are likely to be new protein coding models.	coding	\N	\N
+216	unknown_likely_coding	transcript	core	\N	Biotype introduced by UCSC in the mouse strains, for genes/transcripts that were not in the mouse reference but are likely to be new protein coding models.	coding	\N	\N
+217	other	gene	otherfeatures	\N	\N	undefined	\N	\N
+218	lncRNA	transcript	core,otherfeatures,vega,presite	\N	\N	lnoncoding	SO:0001877	lnc_RNA
+219	aligned_transcript	gene	otherfeatures	\N	Capture Long Seq (CLS) on human and mouse	undefined	\N	\N
+220	aligned_transcript	transcript	otherfeatures	\N	Capture Long Seq (CLS) on human and mouse	undefined	\N	\N
+221	antisense	gene	core,presite	\N	\N	lnoncoding	SO:0001263	ncRNA_gene
+222	antisense	transcript	core,presite	\N	\N	lnoncoding	SO:0001877	lnc_RNA
+223	vault_RNA	gene	core,otherfeatures,vega	\N	short non coding RNA genes that form part of the vault ribonucleoprotein complex	snoncoding	SO:0001263	ncRNA_gene
+224	vault_RNA	transcript	core,otherfeatures,vega	\N	short non coding RNA genes that form part of the vault ribonucleoprotein complex	snoncoding	SO:0001877	lnc_RNA
+225	rnaseq_putative_cds	transcript	core	\N	A biotype for gene/transcripts with transcriptomic data and some very weak support for the cds. This currently means that the cds is less than < 1500bp, is composed of less than 3 coding exons and has less than 40 percent coverage from an alignment of a protein existence level 1 or 2 vertebrate protein from UniProt. We believe there is potentially a cds at these positions, but the evidence is not strong enough to include it directly in the protein coding gene set 	coding	\N	\N
+226	rnaseq_putative_cds	gene	core	\N	A biotype for gene/transcripts with transcriptomic data and some very weak support for the cds. This currently means that the cds is less than < 1500bp, is composed of less than 3 coding exons and has less than 40 percent coverage from an alignment of a protein existence level 1 or 2 vertebrate protein from UniProt. We believe there is potentially a cds at these positions, but the evidence is not strong enough to include it directly in the protein coding gene set	coding	\N	\N
+227	transcribed_pseudogene	gene	otherfeatures	\N	This is for the RefSeq GFF3 import	pseudogene	\N	\N
+228	transcribed_pseudogene	transcript	otherfeatures	\N	This is for the RefSeq GFF3 import	pseudogene	\N	\N

--- a/modules/t/test-genome-DBs/homo_sapiens/core/meta.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/meta.txt
@@ -1,5 +1,5 @@
 2124	1	xref.timestamp	2013-07-22 11:20:10
-1	\N	schema_version	95
+1	\N	schema_version	96
 2	\N	patch	patch_52_53_a.sql|schema_version
 3	\N	patch	patch_52_53_b.sql|external_db_type_enum
 4	\N	patch	patch_52_53_c.sql|identity_xref_rename
@@ -238,3 +238,5 @@
 2194	\N	patch	patch_93_94_b.sql|nullable_ox_analysis
 2195	\N	patch	patch_93_94_c.sql|default_aln_type
 2196	\N	patch	patch_94_95_a.sql|schema_version
+2197	\N	patch	patch_95_96_a.sql|schema_version
+2198	\N	patch	patch_95_96_b.sql|biotype_so_term

--- a/modules/t/test-genome-DBs/homo_sapiens/core/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/table.sql
@@ -114,9 +114,10 @@ CREATE TABLE `biotype` (
   `description` text,
   `biotype_group` enum('coding','pseudogene','snoncoding','lnoncoding','mnoncoding','LRG','undefined','no_group') DEFAULT NULL,
   `so_acc` varchar(64) DEFAULT NULL,
+  `so_term` varchar(1023) DEFAULT NULL,
   PRIMARY KEY (`biotype_id`),
   UNIQUE KEY `name_type_idx` (`name`,`object_type`)
-) ENGINE=MyISAM AUTO_INCREMENT=204 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=229 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `coord_system` (
   `coord_system_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -489,7 +490,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=2197 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=2199 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) NOT NULL,

--- a/modules/t/test-genome-DBs/homo_sapiens/empty/meta.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/empty/meta.txt
@@ -102,3 +102,4 @@
 152	\N	patch	patch_94_95_a.sql|schema_version
 153	\N	patch	patch_94_95_b.sql|vertebrate_division_rename
 154	\N	patch	patch_95_96_a.sql|schema_version
+155	\N	patch	patch_95_96_b.sql|biotype_so_term

--- a/modules/t/test-genome-DBs/homo_sapiens/empty/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/empty/table.sql
@@ -114,6 +114,7 @@ CREATE TABLE `biotype` (
   `description` text,
   `biotype_group` enum('coding','pseudogene','snoncoding','lnoncoding','mnoncoding','LRG','undefined','no_group') DEFAULT NULL,
   `so_acc` varchar(64) DEFAULT NULL,
+  `so_term` varchar(1023) DEFAULT NULL,
   PRIMARY KEY (`biotype_id`),
   UNIQUE KEY `name_type_idx` (`name`,`object_type`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
@@ -493,7 +494,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=155 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=156 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) NOT NULL DEFAULT '',

--- a/modules/t/test-genome-DBs/homo_sapiens_dump/core/meta.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens_dump/core/meta.txt
@@ -240,3 +240,4 @@
 2196	\N	patch	patch_94_95_a.sql|schema_version
 2197	\N	patch	patch_94_95_b.sql|vertebrate_division_rename
 2198	\N	patch	patch_95_96_a.sql|schema_version
+2199	\N	patch	patch_95_96_b.sql|biotype_so_term

--- a/modules/t/test-genome-DBs/homo_sapiens_dump/core/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens_dump/core/table.sql
@@ -5,18 +5,18 @@ CREATE TABLE `alt_allele` (
   PRIMARY KEY (`alt_allele_id`),
   UNIQUE KEY `gene_idx` (`gene_id`),
   KEY `gene_id` (`gene_id`,`alt_allele_group_id`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `alt_allele_attrib` (
   `alt_allele_id` int(10) unsigned DEFAULT NULL,
   `attrib` enum('IS_REPRESENTATIVE','IS_MOST_COMMON_ALLELE','IN_CORRECTED_ASSEMBLY','HAS_CODING_POTENTIAL','IN_ARTIFICIALLY_DUPLICATED_ASSEMBLY','IN_SYNTENIC_REGION','HAS_SAME_UNDERLYING_DNA_SEQUENCE','IN_BROKEN_ASSEMBLY_REGION','IS_VALID_ALTERNATE','SAME_AS_REPRESENTATIVE','SAME_AS_ANOTHER_ALLELE','MANUALLY_ASSIGNED','AUTOMATICALLY_ASSIGNED') DEFAULT NULL,
   KEY `aa_idx` (`alt_allele_id`,`attrib`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `alt_allele_group` (
   `alt_allele_group_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   PRIMARY KEY (`alt_allele_group_id`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `analysis` (
   `analysis_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
@@ -35,7 +35,7 @@ CREATE TABLE `analysis` (
   `gff_feature` varchar(40) DEFAULT NULL,
   PRIMARY KEY (`analysis_id`),
   UNIQUE KEY `logic_name_idx` (`logic_name`)
-) ENGINE=MyISAM  ;
+) ENGINE=MyISAM AUTO_INCREMENT=8498 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `analysis_description` (
   `analysis_id` smallint(5) unsigned NOT NULL,
@@ -44,7 +44,7 @@ CREATE TABLE `analysis_description` (
   `displayable` tinyint(1) NOT NULL DEFAULT '1',
   `web_data` text,
   UNIQUE KEY `analysis_idx` (`analysis_id`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `assembly` (
   `asm_seq_region_id` int(10) unsigned NOT NULL,
@@ -57,7 +57,7 @@ CREATE TABLE `assembly` (
   UNIQUE KEY `all_idx` (`asm_seq_region_id`,`cmp_seq_region_id`,`asm_start`,`asm_end`,`cmp_start`,`cmp_end`,`ori`),
   KEY `cmp_seq_region_idx` (`cmp_seq_region_id`),
   KEY `asm_seq_region_idx` (`asm_seq_region_id`,`asm_start`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `assembly_exception` (
   `assembly_exception_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -72,13 +72,13 @@ CREATE TABLE `assembly_exception` (
   PRIMARY KEY (`assembly_exception_id`),
   KEY `sr_idx` (`seq_region_id`,`seq_region_start`),
   KEY `ex_idx` (`exc_seq_region_id`,`exc_seq_region_start`)
-) ENGINE=MyISAM  ;
+) ENGINE=MyISAM AUTO_INCREMENT=119 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `associated_group` (
   `associated_group_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `description` varchar(128) DEFAULT NULL,
   PRIMARY KEY (`associated_group_id`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `associated_xref` (
   `associated_xref_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -94,7 +94,7 @@ CREATE TABLE `associated_xref` (
   KEY `associated_object_idx` (`object_xref_id`),
   KEY `associated_idx` (`xref_id`),
   KEY `associated_group_idx` (`associated_group_id`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `attrib_type` (
   `attrib_type_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
@@ -103,7 +103,7 @@ CREATE TABLE `attrib_type` (
   `description` text,
   PRIMARY KEY (`attrib_type_id`),
   UNIQUE KEY `code_idx` (`code`)
-) ENGINE=MyISAM  ;
+) ENGINE=MyISAM AUTO_INCREMENT=392 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `biotype` (
   `biotype_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -114,9 +114,10 @@ CREATE TABLE `biotype` (
   `description` text,
   `biotype_group` enum('coding','pseudogene','snoncoding','lnoncoding','mnoncoding','LRG','undefined','no_group') DEFAULT NULL,
   `so_acc` varchar(64) DEFAULT NULL,
+  `so_term` varchar(1023) DEFAULT NULL,
   PRIMARY KEY (`biotype_id`),
   UNIQUE KEY `name_type_idx` (`name`,`object_type`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `coord_system` (
   `coord_system_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -129,7 +130,7 @@ CREATE TABLE `coord_system` (
   UNIQUE KEY `rank_idx` (`rank`,`species_id`),
   UNIQUE KEY `name_idx` (`name`,`version`,`species_id`),
   KEY `species_idx` (`species_id`)
-) ENGINE=MyISAM  ;
+) ENGINE=MyISAM AUTO_INCREMENT=1004 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `data_file` (
   `data_file_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -144,7 +145,7 @@ CREATE TABLE `data_file` (
   UNIQUE KEY `df_unq_idx` (`coord_system_id`,`analysis_id`,`name`,`file_type`),
   KEY `df_name_idx` (`name`),
   KEY `df_analysis_idx` (`analysis_id`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `density_feature` (
   `density_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -156,7 +157,7 @@ CREATE TABLE `density_feature` (
   PRIMARY KEY (`density_feature_id`),
   KEY `seq_region_idx` (`density_type_id`,`seq_region_id`,`seq_region_start`),
   KEY `seq_region_id_idx` (`seq_region_id`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `density_type` (
   `density_type_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -166,7 +167,7 @@ CREATE TABLE `density_type` (
   `value_type` enum('sum','ratio') NOT NULL,
   PRIMARY KEY (`density_type_id`),
   UNIQUE KEY `analysis_idx` (`analysis_id`,`block_size`,`region_features`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `dependent_xref` (
   `object_xref_id` int(10) unsigned NOT NULL,
@@ -175,7 +176,7 @@ CREATE TABLE `dependent_xref` (
   PRIMARY KEY (`object_xref_id`),
   KEY `dependent` (`dependent_xref_id`),
   KEY `master_idx` (`master_xref_id`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `ditag` (
   `ditag_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -184,7 +185,7 @@ CREATE TABLE `ditag` (
   `tag_count` smallint(6) unsigned NOT NULL DEFAULT '1',
   `sequence` tinytext NOT NULL,
   PRIMARY KEY (`ditag_id`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `ditag_feature` (
   `ditag_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -204,13 +205,13 @@ CREATE TABLE `ditag_feature` (
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`,`seq_region_end`),
   KEY `ditag_idx` (`ditag_id`),
   KEY `ditag_pair_idx` (`ditag_pair_id`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `dna` (
   `seq_region_id` int(10) unsigned NOT NULL,
   `sequence` longtext NOT NULL,
   PRIMARY KEY (`seq_region_id`)
-) ENGINE=MyISAM  MAX_ROWS=750000 AVG_ROW_LENGTH=19000;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=750000 AVG_ROW_LENGTH=19000;
 
 CREATE TABLE `dna_align_feature` (
   `dna_align_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -236,7 +237,7 @@ CREATE TABLE `dna_align_feature` (
   KEY `hit_idx` (`hit_name`),
   KEY `analysis_idx` (`analysis_id`),
   KEY `external_db_idx` (`external_db_id`)
-) ENGINE=MyISAM   MAX_ROWS=100000000 AVG_ROW_LENGTH=80;
+) ENGINE=MyISAM AUTO_INCREMENT=29415780 DEFAULT CHARSET=latin1 MAX_ROWS=100000000 AVG_ROW_LENGTH=80;
 
 CREATE TABLE `dna_align_feature_attrib` (
   `dna_align_feature_id` int(10) unsigned NOT NULL,
@@ -246,7 +247,7 @@ CREATE TABLE `dna_align_feature_attrib` (
   KEY `dna_align_feature_idx` (`dna_align_feature_id`),
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40))
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `exon` (
   `exon_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -265,7 +266,7 @@ CREATE TABLE `exon` (
   PRIMARY KEY (`exon_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
   KEY `stable_id_idx` (`stable_id`,`version`)
-) ENGINE=MyISAM  ;
+) ENGINE=MyISAM AUTO_INCREMENT=8057106 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `exon_transcript` (
   `exon_id` int(10) unsigned NOT NULL,
@@ -274,7 +275,7 @@ CREATE TABLE `exon_transcript` (
   PRIMARY KEY (`exon_id`,`transcript_id`,`rank`),
   KEY `transcript` (`transcript_id`),
   KEY `exon` (`exon_id`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `external_db` (
   `external_db_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -289,14 +290,14 @@ CREATE TABLE `external_db` (
   `description` text,
   PRIMARY KEY (`external_db_id`),
   UNIQUE KEY `db_name_db_release_idx` (`db_name`,`db_release`)
-) ENGINE=MyISAM  ;
+) ENGINE=MyISAM AUTO_INCREMENT=50748 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `external_synonym` (
   `xref_id` int(10) unsigned NOT NULL,
   `synonym` varchar(100) NOT NULL,
   PRIMARY KEY (`xref_id`,`synonym`),
   KEY `name_index` (`synonym`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `gene` (
   `gene_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -321,7 +322,7 @@ CREATE TABLE `gene` (
   KEY `analysis_idx` (`analysis_id`),
   KEY `stable_id_idx` (`stable_id`,`version`),
   KEY `canonical_transcript_id_idx` (`canonical_transcript_id`)
-) ENGINE=MyISAM  ;
+) ENGINE=MyISAM AUTO_INCREMENT=698246 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `gene_archive` (
   `gene_stable_id` varchar(128) NOT NULL,
@@ -336,7 +337,7 @@ CREATE TABLE `gene_archive` (
   KEY `gene_idx` (`gene_stable_id`,`gene_version`),
   KEY `transcript_idx` (`transcript_stable_id`,`transcript_version`),
   KEY `translation_idx` (`translation_stable_id`,`translation_version`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `gene_attrib` (
   `gene_id` int(10) unsigned NOT NULL DEFAULT '0',
@@ -346,7 +347,7 @@ CREATE TABLE `gene_attrib` (
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
   KEY `gene_idx` (`gene_id`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `genome_statistics` (
   `genome_statistics_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -357,7 +358,7 @@ CREATE TABLE `genome_statistics` (
   `timestamp` datetime DEFAULT NULL,
   PRIMARY KEY (`genome_statistics_id`),
   UNIQUE KEY `stats_uniq` (`statistic`,`attrib_type_id`,`species_id`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `identity_xref` (
   `object_xref_id` int(10) unsigned NOT NULL,
@@ -371,14 +372,14 @@ CREATE TABLE `identity_xref` (
   `score` double DEFAULT NULL,
   `evalue` double DEFAULT NULL,
   PRIMARY KEY (`object_xref_id`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `interpro` (
   `interpro_ac` varchar(40) NOT NULL,
-  `id` varchar(40)   NOT NULL,
+  `id` varchar(40) NOT NULL,
   UNIQUE KEY `accession_idx` (`interpro_ac`,`id`),
   KEY `id_idx` (`id`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `intron_supporting_evidence` (
   `intron_supporting_evidence_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -394,7 +395,7 @@ CREATE TABLE `intron_supporting_evidence` (
   PRIMARY KEY (`intron_supporting_evidence_id`),
   UNIQUE KEY `analysis_id` (`analysis_id`,`seq_region_id`,`seq_region_start`,`seq_region_end`,`seq_region_strand`,`hit_name`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `karyotype` (
   `karyotype_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -405,13 +406,13 @@ CREATE TABLE `karyotype` (
   `stain` varchar(40) DEFAULT NULL,
   PRIMARY KEY (`karyotype_id`),
   KEY `region_band_idx` (`seq_region_id`,`band`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `map` (
   `map_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `map_name` varchar(30) NOT NULL,
   PRIMARY KEY (`map_id`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `mapping_session` (
   `mapping_session_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -423,7 +424,7 @@ CREATE TABLE `mapping_session` (
   `new_assembly` varchar(20) NOT NULL DEFAULT '',
   `created` datetime NOT NULL,
   PRIMARY KEY (`mapping_session_id`)
-) ENGINE=MyISAM  ;
+) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `mapping_set` (
   `mapping_set_id` int(10) unsigned NOT NULL,
@@ -431,7 +432,7 @@ CREATE TABLE `mapping_set` (
   `external_schema_build` varchar(20) NOT NULL,
   PRIMARY KEY (`mapping_set_id`),
   UNIQUE KEY `mapping_idx` (`internal_schema_build`,`external_schema_build`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `marker` (
   `marker_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -445,7 +446,7 @@ CREATE TABLE `marker` (
   PRIMARY KEY (`marker_id`),
   KEY `marker_idx` (`marker_id`,`priority`),
   KEY `display_idx` (`display_marker_synonym_id`)
-) ENGINE=MyISAM  ;
+) ENGINE=MyISAM AUTO_INCREMENT=10 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `marker_feature` (
   `marker_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -458,7 +459,7 @@ CREATE TABLE `marker_feature` (
   PRIMARY KEY (`marker_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
   KEY `analysis_idx` (`analysis_id`)
-) ENGINE=MyISAM  ;
+) ENGINE=MyISAM AUTO_INCREMENT=705364 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `marker_map_location` (
   `marker_id` int(10) unsigned NOT NULL,
@@ -469,7 +470,7 @@ CREATE TABLE `marker_map_location` (
   `lod_score` double DEFAULT NULL,
   PRIMARY KEY (`marker_id`,`map_id`),
   KEY `map_idx` (`map_id`,`chromosome_name`,`position`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `marker_synonym` (
   `marker_synonym_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -479,7 +480,7 @@ CREATE TABLE `marker_synonym` (
   PRIMARY KEY (`marker_synonym_id`),
   KEY `marker_synonym_idx` (`marker_synonym_id`,`name`),
   KEY `marker_idx` (`marker_id`)
-) ENGINE=MyISAM  ;
+) ENGINE=MyISAM AUTO_INCREMENT=723308 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta` (
   `meta_id` int(11) NOT NULL AUTO_INCREMENT,
@@ -489,14 +490,14 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM  ;
+) ENGINE=MyISAM AUTO_INCREMENT=2200 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) NOT NULL,
   `coord_system_id` int(10) unsigned NOT NULL,
   `max_length` int(11) DEFAULT NULL,
   UNIQUE KEY `cs_table_name_idx` (`coord_system_id`,`table_name`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `misc_attrib` (
   `misc_feature_id` int(10) unsigned NOT NULL DEFAULT '0',
@@ -506,7 +507,7 @@ CREATE TABLE `misc_attrib` (
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
   KEY `misc_feature_idx` (`misc_feature_id`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `misc_feature` (
   `misc_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -516,14 +517,14 @@ CREATE TABLE `misc_feature` (
   `seq_region_strand` tinyint(4) NOT NULL DEFAULT '0',
   PRIMARY KEY (`misc_feature_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`)
-) ENGINE=MyISAM  ;
+) ENGINE=MyISAM AUTO_INCREMENT=93029 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `misc_feature_misc_set` (
   `misc_feature_id` int(10) unsigned NOT NULL DEFAULT '0',
   `misc_set_id` smallint(5) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`misc_feature_id`,`misc_set_id`),
   KEY `reverse_idx` (`misc_set_id`,`misc_feature_id`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `misc_set` (
   `misc_set_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
@@ -533,7 +534,7 @@ CREATE TABLE `misc_set` (
   `max_length` int(10) unsigned NOT NULL,
   PRIMARY KEY (`misc_set_id`),
   UNIQUE KEY `code_idx` (`code`)
-) ENGINE=MyISAM  ;
+) ENGINE=MyISAM AUTO_INCREMENT=24 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `object_xref` (
   `object_xref_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -546,7 +547,7 @@ CREATE TABLE `object_xref` (
   UNIQUE KEY `xref_idx` (`xref_id`,`ensembl_object_type`,`ensembl_id`,`analysis_id`),
   KEY `analysis_idx` (`analysis_id`),
   KEY `ensembl_idx` (`ensembl_object_type`,`ensembl_id`)
-) ENGINE=MyISAM  ;
+) ENGINE=MyISAM AUTO_INCREMENT=16826728 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `ontology_xref` (
   `object_xref_id` int(10) unsigned NOT NULL DEFAULT '0',
@@ -555,7 +556,7 @@ CREATE TABLE `ontology_xref` (
   UNIQUE KEY `object_source_type_idx` (`object_xref_id`,`source_xref_id`,`linkage_type`(1)),
   KEY `source_idx` (`source_xref_id`),
   KEY `object_idx` (`object_xref_id`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `operon` (
   `operon_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -573,7 +574,7 @@ CREATE TABLE `operon` (
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
   KEY `name_idx` (`display_label`),
   KEY `stable_id_idx` (`stable_id`,`version`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `operon_transcript` (
   `operon_transcript_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -592,13 +593,13 @@ CREATE TABLE `operon_transcript` (
   KEY `operon_idx` (`operon_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
   KEY `stable_id_idx` (`stable_id`,`version`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `operon_transcript_gene` (
   `operon_transcript_id` int(10) unsigned DEFAULT NULL,
   `gene_id` int(10) unsigned DEFAULT NULL,
   KEY `operon_transcript_gene_idx` (`operon_transcript_id`,`gene_id`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `peptide_archive` (
   `peptide_archive_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -606,7 +607,7 @@ CREATE TABLE `peptide_archive` (
   `peptide_seq` mediumtext NOT NULL,
   PRIMARY KEY (`peptide_archive_id`),
   KEY `checksum` (`md5_checksum`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `prediction_exon` (
   `prediction_exon_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -622,7 +623,7 @@ CREATE TABLE `prediction_exon` (
   PRIMARY KEY (`prediction_exon_id`),
   KEY `transcript_idx` (`prediction_transcript_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `prediction_transcript` (
   `prediction_transcript_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -635,7 +636,7 @@ CREATE TABLE `prediction_transcript` (
   PRIMARY KEY (`prediction_transcript_id`),
   KEY `analysis_idx` (`analysis_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `protein_align_feature` (
   `protein_align_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -660,7 +661,7 @@ CREATE TABLE `protein_align_feature` (
   KEY `hit_idx` (`hit_name`),
   KEY `analysis_idx` (`analysis_id`),
   KEY `external_db_idx` (`external_db_id`)
-) ENGINE=MyISAM   MAX_ROWS=100000000 AVG_ROW_LENGTH=80;
+) ENGINE=MyISAM AUTO_INCREMENT=19587044 DEFAULT CHARSET=latin1 MAX_ROWS=100000000 AVG_ROW_LENGTH=80;
 
 CREATE TABLE `protein_feature` (
   `protein_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -669,7 +670,7 @@ CREATE TABLE `protein_feature` (
   `seq_end` int(10) NOT NULL,
   `hit_start` int(10) NOT NULL,
   `hit_end` int(10) NOT NULL,
-  `hit_name` varchar(40)   NOT NULL,
+  `hit_name` varchar(40) NOT NULL,
   `analysis_id` smallint(5) unsigned NOT NULL,
   `score` double DEFAULT NULL,
   `evalue` double DEFAULT NULL,
@@ -683,7 +684,7 @@ CREATE TABLE `protein_feature` (
   KEY `hitname_idx` (`hit_name`),
   KEY `analysis_idx` (`analysis_id`),
   KEY `translation_idx` (`translation_id`)
-) ENGINE=MyISAM  ;
+) ENGINE=MyISAM AUTO_INCREMENT=8807105 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `repeat_consensus` (
   `repeat_consensus_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -696,7 +697,7 @@ CREATE TABLE `repeat_consensus` (
   KEY `class` (`repeat_class`),
   KEY `consensus` (`repeat_consensus`(10)),
   KEY `type` (`repeat_type`)
-) ENGINE=MyISAM  ;
+) ENGINE=MyISAM AUTO_INCREMENT=596420 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `repeat_feature` (
   `repeat_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -713,7 +714,7 @@ CREATE TABLE `repeat_feature` (
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
   KEY `repeat_idx` (`repeat_consensus_id`),
   KEY `analysis_idx` (`analysis_id`)
-) ENGINE=MyISAM   MAX_ROWS=100000000 AVG_ROW_LENGTH=80;
+) ENGINE=MyISAM AUTO_INCREMENT=31869415 DEFAULT CHARSET=latin1 MAX_ROWS=100000000 AVG_ROW_LENGTH=80;
 
 CREATE TABLE `seq_region` (
   `seq_region_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -723,7 +724,7 @@ CREATE TABLE `seq_region` (
   PRIMARY KEY (`seq_region_id`),
   UNIQUE KEY `name_cs_idx` (`name`,`coord_system_id`),
   KEY `cs_idx` (`coord_system_id`)
-) ENGINE=MyISAM  ;
+) ENGINE=MyISAM AUTO_INCREMENT=1000357973 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `seq_region_attrib` (
   `seq_region_id` int(10) unsigned NOT NULL DEFAULT '0',
@@ -733,14 +734,14 @@ CREATE TABLE `seq_region_attrib` (
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
   KEY `seq_region_idx` (`seq_region_id`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `seq_region_mapping` (
   `external_seq_region_id` int(10) unsigned NOT NULL,
   `internal_seq_region_id` int(10) unsigned NOT NULL,
   `mapping_set_id` int(10) unsigned NOT NULL,
   KEY `mapping_set_idx` (`mapping_set_id`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `seq_region_synonym` (
   `seq_region_synonym_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -750,7 +751,7 @@ CREATE TABLE `seq_region_synonym` (
   PRIMARY KEY (`seq_region_synonym_id`),
   UNIQUE KEY `syn_idx` (`synonym`,`seq_region_id`),
   KEY `seq_region_idx` (`seq_region_id`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `simple_feature` (
   `simple_feature_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -765,7 +766,7 @@ CREATE TABLE `simple_feature` (
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
   KEY `analysis_idx` (`analysis_id`),
   KEY `hit_idx` (`display_label`)
-) ENGINE=MyISAM   MAX_ROWS=100000000 AVG_ROW_LENGTH=80;
+) ENGINE=MyISAM AUTO_INCREMENT=977796 DEFAULT CHARSET=latin1 MAX_ROWS=100000000 AVG_ROW_LENGTH=80;
 
 CREATE TABLE `stable_id_event` (
   `old_stable_id` varchar(128) DEFAULT NULL,
@@ -778,7 +779,7 @@ CREATE TABLE `stable_id_event` (
   UNIQUE KEY `uni_idx` (`mapping_session_id`,`old_stable_id`,`new_stable_id`,`type`),
   KEY `new_idx` (`new_stable_id`),
   KEY `old_idx` (`old_stable_id`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `supporting_feature` (
   `exon_id` int(10) unsigned NOT NULL DEFAULT '0',
@@ -786,7 +787,7 @@ CREATE TABLE `supporting_feature` (
   `feature_id` int(10) unsigned NOT NULL DEFAULT '0',
   UNIQUE KEY `all_idx` (`exon_id`,`feature_type`,`feature_id`),
   KEY `feature_idx` (`feature_type`,`feature_id`)
-) ENGINE=MyISAM  MAX_ROWS=100000000 AVG_ROW_LENGTH=80;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000 AVG_ROW_LENGTH=80;
 
 CREATE TABLE `transcript` (
   `transcript_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -813,7 +814,7 @@ CREATE TABLE `transcript` (
   KEY `xref_id_index` (`display_xref_id`),
   KEY `analysis_idx` (`analysis_id`),
   KEY `stable_id_idx` (`stable_id`,`version`)
-) ENGINE=MyISAM  ;
+) ENGINE=MyISAM AUTO_INCREMENT=2263272 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `transcript_attrib` (
   `transcript_id` int(10) unsigned NOT NULL DEFAULT '0',
@@ -823,7 +824,7 @@ CREATE TABLE `transcript_attrib` (
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
   KEY `transcript_idx` (`transcript_id`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `transcript_intron_supporting_evidence` (
   `transcript_id` int(10) unsigned NOT NULL,
@@ -832,7 +833,7 @@ CREATE TABLE `transcript_intron_supporting_evidence` (
   `next_exon_id` int(10) unsigned NOT NULL,
   PRIMARY KEY (`intron_supporting_evidence_id`,`transcript_id`),
   KEY `transcript_idx` (`transcript_id`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `transcript_supporting_feature` (
   `transcript_id` int(10) unsigned NOT NULL DEFAULT '0',
@@ -840,7 +841,7 @@ CREATE TABLE `transcript_supporting_feature` (
   `feature_id` int(10) unsigned NOT NULL DEFAULT '0',
   UNIQUE KEY `all_idx` (`transcript_id`,`feature_type`,`feature_id`),
   KEY `feature_idx` (`feature_type`,`feature_id`)
-) ENGINE=MyISAM  MAX_ROWS=100000000 AVG_ROW_LENGTH=80;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 MAX_ROWS=100000000 AVG_ROW_LENGTH=80;
 
 CREATE TABLE `translation` (
   `translation_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -856,7 +857,7 @@ CREATE TABLE `translation` (
   PRIMARY KEY (`translation_id`),
   KEY `transcript_idx` (`transcript_id`),
   KEY `stable_id_idx` (`stable_id`,`version`)
-) ENGINE=MyISAM  ;
+) ENGINE=MyISAM AUTO_INCREMENT=1150578 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `translation_attrib` (
   `translation_id` int(10) unsigned NOT NULL DEFAULT '0',
@@ -866,7 +867,7 @@ CREATE TABLE `translation_attrib` (
   KEY `type_val_idx` (`attrib_type_id`,`value`(40)),
   KEY `val_only_idx` (`value`(40)),
   KEY `translation_idx` (`translation_id`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `unmapped_object` (
   `unmapped_object_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -885,14 +886,14 @@ CREATE TABLE `unmapped_object` (
   KEY `anal_exdb_idx` (`analysis_id`,`external_db_id`),
   KEY `id_idx` (`identifier`(50)),
   KEY `ext_db_identifier_idx` (`external_db_id`,`identifier`)
-) ENGINE=MyISAM ;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE `unmapped_reason` (
   `unmapped_reason_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `summary_description` varchar(255) DEFAULT NULL,
   `full_description` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`unmapped_reason_id`)
-) ENGINE=MyISAM  ;
+) ENGINE=MyISAM AUTO_INCREMENT=139 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `xref` (
   `xref_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -907,5 +908,5 @@ CREATE TABLE `xref` (
   UNIQUE KEY `id_index` (`dbprimary_acc`,`external_db_id`,`info_type`,`info_text`,`version`),
   KEY `display_index` (`display_label`),
   KEY `info_type_idx` (`info_type`)
-) ENGINE=MyISAM  ;
+) ENGINE=MyISAM AUTO_INCREMENT=3709981 DEFAULT CHARSET=latin1;
 

--- a/modules/t/test-genome-DBs/multi/production/master_biotype.txt
+++ b/modules/t/test-genome-DBs/multi/production/master_biotype.txt
@@ -1,189 +1,189 @@
-1	name	0	0			0	description		\N	0	0000-00-00 00:00:00	0	0000-00-00 00:00:00
-2	IG_C_gene	1	1	transcript	core,otherfeatures,presite	0	NULL	coding	SO:0000478	0	0000-00-00 00:00:00	101214	2014-11-06 15:43:12
-3	IG_D_gene	1	1	gene	core,otherfeatures,presite	100	NULL	coding	SO:0001217	0	0000-00-00 00:00:00	101214	2014-11-06 15:43:42
-4	IG_D_gene	1	1	transcript	core,otherfeatures,presite	0	NULL	coding	SO:0000458	0	0000-00-00 00:00:00	101214	2014-11-06 15:43:59
-5	IG_J_gene	1	1	gene	core,otherfeatures,presite	100	NULL	coding	SO:0001217	0	0000-00-00 00:00:00	101214	2014-11-06 15:44:21
-6	IG_J_gene	1	1	transcript	core,otherfeatures,presite	0	NULL	coding	SO:0000470	0	0000-00-00 00:00:00	101214	2014-11-06 15:44:35
-7	IG_J_pseudogene	1	1	gene	core,presite	67	NULL	pseudogene	SO:0000336	0	0000-00-00 00:00:00	104957	2014-03-21 15:07:59
-8	IG_J_pseudogene	1	1	transcript	core,presite	0	NULL	pseudogene	SO:0000516	0	0000-00-00 00:00:00	104957	2014-03-21 15:08:05
-9	IG_V_gene	1	1	gene	core,otherfeatures,presite	100	NULL	coding	SO:0001217	0	0000-00-00 00:00:00	101214	2014-11-06 15:45:02
-10	IG_V_gene	1	1	transcript	core,otherfeatures,presite	0	NULL	coding	SO:0000466	0	0000-00-00 00:00:00	101214	2014-11-06 15:45:24
-11	IG_V_pseudogene	1	1	gene	core,presite	67	NULL	pseudogene	SO:0000336	0	0000-00-00 00:00:00	104957	2014-03-21 15:18:20
-12	IG_V_pseudogene	1	1	transcript	core,presite	0	NULL	pseudogene	SO:0000516	0	0000-00-00 00:00:00	104957	2014-03-21 15:18:25
-13	IG_gene	1	1	gene	vega	0	NULL	coding	SO:0001217	0	0000-00-00 00:00:00	0	0000-00-00 00:00:00
-14	IG_gene	1	1	transcript	vega	0	NULL	coding	SO:3000000	0	0000-00-00 00:00:00	0	0000-00-00 00:00:00
-15	IG_pseudogene	1	1	gene	core,vega,presite	67	NULL	pseudogene	SO:0000336	0	0000-00-00 00:00:00	107110	2014-12-11 10:51:12
-16	IG_pseudogene	1	1	transcript	core,vega,presite	0	NULL	pseudogene	SO:0000516	0	0000-00-00 00:00:00	107110	2014-12-11 10:51:29
-17	LRG_gene	1	1	gene	core	0	NULL	LRG	\N	0	0000-00-00 00:00:00	97245	2014-08-27 10:46:00
-18	LRG_gene	1	1	transcript	core	0	NULL	LRG	\N	0	0000-00-00 00:00:00	97245	2014-08-27 10:46:09
-19	Mt_rRNA	1	1	gene	core,presite	73	NULL	snoncoding	SO:0001263	0	0000-00-00 00:00:00	104957	2014-03-21 15:18:04
-20	Mt_rRNA	1	1	transcript	core,presite	0	NULL	snoncoding	SO:0000252	0	0000-00-00 00:00:00	104957	2014-03-21 15:18:10
-21	Mt_tRNA	1	1	gene	core,presite	74	NULL	snoncoding	SO:0001263	0	0000-00-00 00:00:00	104957	2014-03-21 15:15:39
-22	Mt_tRNA	1	1	transcript	core,presite	0	NULL	snoncoding	SO:0000253	0	0000-00-00 00:00:00	104957	2014-03-21 15:15:44
-23	Mt_tRNA_pseudogene	1	1	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336	0	0000-00-00 00:00:00	5132	2014-10-28 12:19:45
-24	Mt_tRNA_pseudogene	1	1	transcript	core	0	noncoding RNA pseudogene	pseudogene	SO:0000516	0	0000-00-00 00:00:00	5132	2014-10-28 12:19:45
-25	RNA-Seq_gene	1	1	gene	otherfeatures	0	NULL	undefined	\N	0	0000-00-00 00:00:00	0	0000-00-00 00:00:00
-26	RNA-Seq_gene	1	1	transcript	otherfeatures	0	NULL	undefined	\N	0	0000-00-00 00:00:00	0	0000-00-00 00:00:00
-27	TEC	1	1	gene	core,vega,sangervega	0	NULL	undefined	\N	0	0000-00-00 00:00:00	104991	2014-08-26 11:44:53
-28	TEC	1	0	transcript	core,vega,sangervega	0	NULL	undefined	SO:0002139	0	0000-00-00 00:00:00	104991	2014-08-26 11:45:14
-29	TR_gene	1	1	gene	vega	0	NULL	coding	SO:0001217	0	0000-00-00 00:00:00	0	0000-00-00 00:00:00
-30	TR_gene	1	1	transcript	core,vega	0	NULL	coding	SO:3000000	0	0000-00-00 00:00:00	0	0000-00-00 00:00:00
-31	TR_pseudogene	1	1	gene	vega	0	NULL	pseudogene	SO:0000336	0	0000-00-00 00:00:00	5132	2013-07-08 12:44:42
-32	TR_pseudogene	1	1	transcript	vega	0	NULL	pseudogene	SO:0000516	0	0000-00-00 00:00:00	5132	2013-07-08 12:44:42
-33	ambiguous_orf	1	1	transcript	core,vega	0	NULL	lnoncoding	SO:0001877	0	0000-00-00 00:00:00	5132	2013-07-08 12:33:27
-35	cdna_update	1	1	gene	cdna	0	NULL	undefined	\N	0	0000-00-00 00:00:00	97245	2011-10-26 08:58:38
-36	cdna_update	1	1	transcript	cdna	0	NULL	undefined	\N	0	0000-00-00 00:00:00	97245	2011-10-26 08:58:49
-37	cdna	1	1	gene	otherfeatures	0	NULL	undefined	SO:0000756	0	0000-00-00 00:00:00	0	0000-00-00 00:00:00
-38	cdna	1	1	transcript	otherfeatures	0	NULL	undefined	SO:0000756	0	0000-00-00 00:00:00	0	0000-00-00 00:00:00
-39	disrupted_domain	1	1	transcript	core,vega	0	NULL	pseudogene	SO:0000516	0	0000-00-00 00:00:00	0	0000-00-00 00:00:00
-40	est	1	1	gene	otherfeatures	0	NULL	undefined	\N	0	0000-00-00 00:00:00	0	0000-00-00 00:00:00
-41	est	1	1	transcript	otherfeatures	0	NULL	undefined	SO:0000345	0	0000-00-00 00:00:00	0	0000-00-00 00:00:00
-42	lincRNA	1	1	gene	core,vega,presite	190	NULL	lnoncoding	SO:0001263	0	0000-00-00 00:00:00	104957	2014-03-21 15:17:05
-43	lincRNA	1	1	transcript	core,vega,presite	0	NULL	lnoncoding	SO:0001877	0	0000-00-00 00:00:00	104957	2014-03-21 15:17:09
-44	miRNA	1	1	gene	core,otherfeatures,vega,presite	70	From RefSeq import.	snoncoding	SO:0001263	0	0000-00-00 00:00:00	104991	2014-11-12 12:04:54
-45	miRNA	1	1	transcript	core,otherfeatures,presite	0	From RefSeq import.	snoncoding	SO:0000276	0	0000-00-00 00:00:00	104957	2014-03-21 15:16:09
-46	miRNA_pseudogene	1	1	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336	0	0000-00-00 00:00:00	5132	2014-10-28 12:19:45
-47	miRNA_pseudogene	1	1	transcript	core	0	noncoding RNA pseudogene	pseudogene	SO:0000516	0	0000-00-00 00:00:00	5132	2014-10-28 12:19:45
-48	misc_RNA	1	1	gene	core,otherfeatures,presite	0	NULL	mnoncoding	SO:0001263	0	0000-00-00 00:00:00	104957	2015-01-15 11:50:46
-49	misc_RNA	1	1	transcript	core,otherfeatures,presite	0	NULL	mnoncoding	SO:0000655	0	0000-00-00 00:00:00	104957	2015-01-15 11:51:00
-50	misc_RNA_pseudogene	1	1	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336	0	0000-00-00 00:00:00	5132	2014-10-28 12:19:45
-51	misc_RNA_pseudogene	1	1	transcript	core	0	noncoding RNA pseudogene	pseudogene	SO:0000516	0	0000-00-00 00:00:00	5132	2014-10-28 12:19:45
-52	ncRNA	1	1	gene	core,otherfeatures	99	NULL	snoncoding	SO:0001263	0	0000-00-00 00:00:00	5132	2013-07-08 13:03:50
-53	ncRNA	1	1	transcript	core,otherfeatures	0	NULL	snoncoding	SO:0000655	0	0000-00-00 00:00:00	5132	2013-07-08 13:03:50
-54	non_coding	1	1	gene	core,otherfeatures,rnaseq,vega,presite	353	NULL	lnoncoding	SO:0001263	0	0000-00-00 00:00:00	5132	2013-07-08 12:33:27
-55	non_coding	1	1	transcript	core,otherfeatures,rnaseq,vega,presite	0	NULL	lnoncoding	SO:0001877	0	0000-00-00 00:00:00	5132	2013-07-08 12:33:27
-56	nonsense_mediated_decay	1	1	transcript	core,vega,presite	0	NULL	coding	SO:0000234	0	0000-00-00 00:00:00	104957	2014-03-21 15:10:43
-57	polymorphic	1	1	gene	vega	0	NULL	coding	SO:0001217	0	0000-00-00 00:00:00	0	0000-00-00 00:00:00
-58	polymorphic_pseudogene	1	1	gene	core,vega,presite	67	NULL	coding	SO:0001217	0	0000-00-00 00:00:00	104957	2014-03-21 15:16:51
-59	polymorphic_pseudogene	1	1	transcript	core,vega,presite	0	NULL	coding	SO:0000234	0	0000-00-00 00:00:00	104957	2014-03-21 15:16:56
-60	processed_pseudogene	1	1	gene	core,vega,presite	0	NULL	pseudogene	SO:0000336	0	0000-00-00 00:00:00	104957	2014-03-21 15:08:54
-61	processed_pseudogene	1	1	transcript	core,vega,presite	0	NULL	pseudogene	SO:0000516	0	0000-00-00 00:00:00	104957	2014-03-21 15:09:02
-62	processed_transcript	1	1	gene	core,vega,presite	79	NULL	lnoncoding	SO:0001263	0	0000-00-00 00:00:00	104957	2014-03-21 15:17:48
-63	processed_transcript	1	1	transcript	core,vega,presite	0	NULL	lnoncoding	SO:0001877	0	0000-00-00 00:00:00	104957	2014-03-21 15:17:53
-64	protein_coding	1	1	gene	core,otherfeatures,rnaseq,vega,presite	0	NULL	coding	SO:0001217	0	0000-00-00 00:00:00	97245	2012-07-11 12:29:28
-65	protein_coding	1	1	transcript	core,otherfeatures,rnaseq,vega,presite	0	NULL	coding	SO:0000234	0	0000-00-00 00:00:00	0	0000-00-00 00:00:00
-66	pseudogene	1	1	gene	core,otherfeatures,vega,presite	67	NULL	pseudogene	SO:0000336	0	0000-00-00 00:00:00	104957	2014-03-21 15:18:57
-67	pseudogene	1	1	transcript	core,otherfeatures,vega,presite	0	NULL	pseudogene	SO:0000516	0	0000-00-00 00:00:00	104957	2014-03-21 15:19:04
-68	rRNA	1	1	gene	core,otherfeatures,vega,presite	66	NULL	lnoncoding	SO:0001263	0	0000-00-00 00:00:00	104957	2014-12-03 15:06:35
-69	rRNA	1	1	transcript	core,otherfeatures,vega,presite	0	NULL	lnoncoding	SO:0000252	0	0000-00-00 00:00:00	106182	2014-12-15 13:51:34
-70	rRNA_pseudogene	1	1	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336	0	0000-00-00 00:00:00	5132	2014-10-28 12:19:45
-71	rRNA_pseudogene	1	1	transcript	core	0	noncoding RNA pseudogene	pseudogene	SO:0000516	0	0000-00-00 00:00:00	5132	2014-10-28 12:19:45
-72	retained_intron	1	1	transcript	core,vega,presite	0	NULL	lnoncoding	SO:0001877	0	0000-00-00 00:00:00	104957	2014-03-21 15:14:10
-73	retrotransposed	0	1	gene	core	77	NULL	pseudogene	SO:0000569	0	0000-00-00 00:00:00	5132	2012-10-30 17:53:09
-74	retrotransposed	0	1	transcript	core	0	NULL	pseudogene	SO:0000569	0	0000-00-00 00:00:00	5132	2012-10-30 17:53:26
-75	scRNA_pseudogene	1	1	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336	0	0000-00-00 00:00:00	5132	2014-10-28 12:19:45
-76	scRNA_pseudogene	1	1	transcript	core	0	noncoding RNA pseudogene	pseudogene	SO:0000516	0	0000-00-00 00:00:00	5132	2014-10-28 12:19:45
-77	snRNA	1	1	gene	core,otherfeatures,vega,presite	68	From Havana manual annotation.	snoncoding	SO:0001263	0	0000-00-00 00:00:00	104957	2014-03-21 15:05:32
-78	snRNA	1	1	transcript	core,otherfeatures,vega,presite	0	From Havana manual annotation.	snoncoding	SO:0000274	0	0000-00-00 00:00:00	104957	2014-03-21 15:05:40
-79	snRNA_pseudogene	1	1	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336	0	0000-00-00 00:00:00	5132	2014-10-28 12:19:45
-80	snRNA_pseudogene	1	1	transcript	core	0	noncoding RNA pseudogene	pseudogene	SO:0000516	0	0000-00-00 00:00:00	5132	2014-10-28 12:19:45
-81	snlRNA	1	1	gene	core	78	NULL	snoncoding	SO:0001263	0	0000-00-00 00:00:00	5132	2013-07-08 13:03:50
-82	snlRNA	1	1	transcript	core	0	NULL	snoncoding	SO:0000274	0	0000-00-00 00:00:00	5132	2013-07-08 13:03:50
-83	snoRNA	1	1	gene	core,otherfeatures,vega,presite	69	small nucleolar RNA.	snoncoding	SO:0001263	0	0000-00-00 00:00:00	104957	2014-03-21 15:16:36
-84	snoRNA	1	1	transcript	core,otherfeatures,vega,presite	0	small nucleolar RNA.	snoncoding	SO:0000275	0	0000-00-00 00:00:00	104957	2014-03-21 15:16:41
-85	snoRNA_pseudogene	1	1	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336	0	0000-00-00 00:00:00	5132	2014-10-28 12:19:45
-86	snoRNA_pseudogene	1	1	transcript	core	0	noncoding RNA pseudogene	pseudogene	SO:0000516	0	0000-00-00 00:00:00	5132	2014-10-28 12:19:45
-87	tRNA	1	1	gene	core,otherfeatures,presite	76	NULL	snoncoding	SO:0001263	0	0000-00-00 00:00:00	104957	2014-03-21 15:08:32
-88	tRNA	1	1	transcript	core,otherfeatures,presite	76	NULL	snoncoding	SO:0000253	0	0000-00-00 00:00:00	104957	2014-03-21 15:08:38
-89	tRNA_pseudogene	1	1	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336	0	0000-00-00 00:00:00	5132	2014-10-28 12:19:45
-90	tRNA_pseudogene	1	1	transcript	core	0	noncoding RNA pseudogene	pseudogene	SO:0000516	0	0000-00-00 00:00:00	5132	2014-10-28 12:19:45
-91	transcribed_processed_pseudogene	1	1	gene	core,vega,presite	0	NULL	pseudogene	SO:0000336	0	0000-00-00 00:00:00	104957	2014-03-21 15:14:43
-92	transcribed_processed_pseudogene	1	1	transcript	core,vega,presite	0	NULL	pseudogene	SO:0000516	0	0000-00-00 00:00:00	104957	2014-03-21 15:14:48
-93	transcribed_unitary_pseudogene	1	1	gene	core,vega	0	NULL	pseudogene	SO:0000336	0	0000-00-00 00:00:00	104957	2014-08-15 13:48:10
-94	transcribed_unprocessed_pseudogene	1	1	gene	core,vega,presite	0	NULL	pseudogene	SO:0000336	0	0000-00-00 00:00:00	104957	2014-03-21 15:12:59
-95	transcribed_unprocessed_pseudogene	1	1	transcript	core,vega,presite	0	NULL	pseudogene	SO:0000516	0	0000-00-00 00:00:00	104957	2014-03-21 15:13:05
-96	unitary_pseudogene	1	1	gene	core,vega,presite	0	NULL	pseudogene	SO:0000336	0	0000-00-00 00:00:00	104957	2014-03-21 15:11:13
-97	unitary_pseudogene	1	1	transcript	core,vega,presite	0	NULL	pseudogene	SO:0000516	0	0000-00-00 00:00:00	104957	2014-03-21 15:11:20
-98	unprocessed_pseudogene	1	1	gene	core,vega,presite	0	NULL	pseudogene	SO:0000336	0	0000-00-00 00:00:00	104957	2014-03-21 15:11:32
-99	unprocessed_pseudogene	1	1	transcript	core,vega,presite	0	NULL	pseudogene	SO:0000516	0	0000-00-00 00:00:00	104957	2014-03-21 15:11:38
-100	ccds_gene	1	0	gene	otherfeatures	0	Imported CCDS gene models	undefined	\N	0	0000-00-00 00:00:00	0	0000-00-00 00:00:00
-101	protein_coding_in_progress	1	1	gene	vega	0	occurs where the ORF is lost when remapping to a different assembly and the gene is awaiting reannotation	undefined	\N	0	0000-00-00 00:00:00	0	0000-00-00 00:00:00
-102	IG_Z_gene	1	1	gene	core,vega	100	NULL	coding	SO:0001217	0	0000-00-00 00:00:00	0	0000-00-00 00:00:00
-103	IG_M_gene	1	1	gene	core,vega	100	NULL	coding	SO:0001217	0	0000-00-00 00:00:00	0	0000-00-00 00:00:00
-104	ncrna_host	1	1	transcript	core,vega	0	NULL	lnoncoding	\N	0	0000-00-00 00:00:00	5132	2013-07-08 12:33:27
-105	TR_V_pseudogene	1	1	gene	core,presite	67	NULL	pseudogene	SO:0000336	0	0000-00-00 00:00:00	104957	2014-03-21 15:15:12
-106	TR_V_gene	1	1	gene	core,presite	100	NULL	coding	SO:0001217	0	0000-00-00 00:00:00	104957	2014-03-21 15:14:59
-107	IG_C_pseudogene	1	1	gene	core,presite	67	NULL	pseudogene	SO:0000336	0	0000-00-00 00:00:00	104957	2014-03-21 15:16:19
-108	TR_C_gene	1	1	gene	core,presite	100	NULL	coding	SO:0001217	0	0000-00-00 00:00:00	104957	2014-03-21 15:14:25
-109	TR_J_gene	1	1	gene	core,presite	100	NULL	coding	SO:0001217	0	0000-00-00 00:00:00	104957	2014-03-21 15:18:37
-110	TR_V_pseudogene	1	1	transcript	core,presite	0	NULL	pseudogene	SO:0000516	0	0000-00-00 00:00:00	104957	2014-03-21 15:15:18
-111	TR_V_gene	1	1	transcript	core,presite	0	NULL	coding	SO:0000466	0	0000-00-00 00:00:00	104957	2014-03-21 15:15:06
-112	IG_C_pseudogene	1	1	transcript	core,presite	0	NULL	pseudogene	SO:0000516	0	0000-00-00 00:00:00	104957	2014-03-21 15:16:25
-113	TR_C_gene	1	1	transcript	core,presite	0	NULL	coding	SO:0000478	0	0000-00-00 00:00:00	104957	2014-03-21 15:14:31
-114	TR_J_gene	1	1	transcript	core,presite	0	NULL	coding	SO:0000470	0	0000-00-00 00:00:00	104957	2014-03-21 15:18:41
-115	protein_coding_in_progress	1	1	transcript	vega	0	occurs where the ORF is lost when remapping to a different assembly and the gene is awaiting reannotation	undefined	\N	0	0000-00-00 00:00:00	0	0000-00-00 00:00:00
-116	IG_M_gene	1	1	transcript	core	0	NULL	coding	SO:3000000	0	0000-00-00 00:00:00	0	0000-00-00 00:00:00
-117	IG_Z_gene	1	1	transcript	core	0	NULL	coding	SO:3000000	0	0000-00-00 00:00:00	0	0000-00-00 00:00:00
-118	3prime_overlapping_ncrna	1	1	transcript	core,vega,presite	0	NULL	lnoncoding	SO:0002120	0	0000-00-00 00:00:00	104957	2014-03-21 15:09:16
-123	antisense_RNA	1	0	gene	otherfeatures,presite	0	From RefSeq import	lnoncoding	SO:0001263	5132	2011-06-02 07:12:32	104957	2014-03-21 15:13:29
-124	antisense_RNA	1	0	transcript	otherfeatures,presite	0	From RefSeq import	lnoncoding	SO:0001877	5132	2011-06-02 07:12:40	104957	2014-03-21 15:13:35
-125	scRNA	1	0	gene	otherfeatures	0	From RefSeq import	snoncoding	SO:0001263	5132	2011-06-02 07:13:08	5132	2013-07-08 13:03:50
-126	scRNA	1	0	transcript	otherfeatures	0	From RefSeq import	snoncoding	SO:0000013	5132	2011-06-02 07:13:15	5132	2013-07-08 13:03:50
-127	RNase_MRP_RNA	1	0	gene	core,otherfeatures,presite	0	From RefSeq import or Rfamscan	snoncoding	SO:0001263	5132	2011-06-02 07:14:03	104957	2014-03-21 15:11:55
-128	RNase_MRP_RNA	1	0	transcript	core,otherfeatures,presite	0	From RefSeq import or Rfamscan	snoncoding	SO:0000385	5132	2011-06-02 07:14:09	104957	2014-03-21 15:12:01
-129	RNase_P_RNA	1	0	gene	core,otherfeatures,presite	0	From RefSeq import or Rfamscan	snoncoding	SO:0001263	5132	2011-06-02 07:14:40	104957	2014-03-21 15:12:06
-130	RNase_P_RNA	1	0	transcript	core,otherfeatures,presite	0	From RefSeq import or Rfamscan	snoncoding	SO:0000386	5132	2011-06-02 07:14:46	104957	2014-03-21 15:12:12
-131	telomerase_RNA	1	0	gene	otherfeatures,presite	0	From RefSeq import or Rfamscan	snoncoding	SO:0001263	5132	2011-06-02 07:15:54	104957	2014-03-21 15:10:07
-132	telomerase_RNA	1	0	transcript	otherfeatures,presite	0	From RefSeq import or Rfamscan	snoncoding	SO:0000390	5132	2011-06-02 07:16:03	104957	2014-03-21 15:10:12
-133	sense_intronic	1	1	transcript	core,vega,presite	0	NULL	lnoncoding	SO:0001877	97245	2011-07-18 10:14:50	104957	2014-03-21 15:10:23
-135	sense_overlapping	1	1	transcript	core,vega,presite	0	NULL	lnoncoding	SO:0001877	97245	2011-07-19 13:29:37	104957	2014-03-21 15:12:37
-138	sense_intronic	1	1	gene	core,vega,presite	350	NULL	lnoncoding	SO:0001263	97245	2011-07-19 13:31:24	104957	2014-03-21 15:10:31
-139	ambiguous_orf	1	1	gene	core,vega	351	NULL	lnoncoding	SO:0001263	97245	2011-07-19 13:31:27	5132	2013-07-08 12:33:27
-140	retained_intron	1	1	gene	core,vega,presite	352	NULL	lnoncoding	SO:0001263	97245	2011-07-19 13:31:31	104957	2014-03-21 15:14:16
-142	3prime_overlapping_ncrna	1	1	gene	core,vega,presite	356	NULL	lnoncoding	\N	97245	2011-07-19 13:31:38	104957	2014-03-21 15:09:21
-143	ncrna_host	1	1	gene	core,vega	354	NULL	lnoncoding	\N	97245	2011-07-19 13:31:42	5132	2013-07-08 12:33:27
-144	sense_overlapping	1	1	gene	core,vega,presite	355	NULL	lnoncoding	SO:0001263	97245	2011-07-19 13:31:47	104957	2014-03-21 15:12:43
-146	TR_D_gene	1	1	transcript	core,presite	0	NULL	coding	SO:0000458	97245	2011-07-20 10:10:01	104957	2014-03-21 15:12:22
-147	TR_J_pseudogene	1	1	transcript	core,presite	0	NULL	pseudogene	SO:0000516	97245	2011-07-20 10:10:01	104957	2014-03-21 15:04:14
-148	TR_D_gene	1	1	gene	core,presite	100	NULL	coding	SO:0001217	97245	2011-07-20 10:10:01	104957	2014-03-21 15:12:27
-149	TR_J_pseudogene	1	1	gene	core,presite	67	NULL	pseudogene	SO:0000336	97245	2011-07-20 10:10:01	104957	2014-03-21 15:04:57
-150	ncbi_pseudogene	1	0	gene	otherfeatures	0	Imported annotation from RefSeq	pseudogene	SO:0000336	5132	2011-08-06 09:03:27	0	0000-00-00 00:00:00
-151	ncbi_pseudogene	1	0	transcript	otherfeatures	0	Imported annotation from RefSeq	pseudogene	SO:0000516	5132	2011-08-06 09:04:11	0	0000-00-00 00:00:00
-152	ncbigene	1	0	gene	otherfeatures	0	Imported annotation from RefSeq	undefined	\N	5132	2011-08-06 09:04:25	0	0000-00-00 00:00:00
-153	non_stop_decay	1	1	transcript	core,vega,presite	0	A new transcript biotype from Havana.	coding	SO:0000234	9335	2011-10-11 12:28:06	104957	2014-03-21 15:08:18
-154	pre_miRNA	1	1	transcript	core	0	This is the pre miRNA information extracted from FlyBase annotations distinctive from the miRNA form for the same gene model.Gautier is happy for this to be in the short noncoding group.	snoncoding	SO:0001244	98587	2011-10-13 13:29:27	5132	2013-07-09 18:42:54
+1	name	0	0			0	description		\N	\N	0	0000-00-00 00:00:00	0	0000-00-00 00:00:00
+2	IG_C_gene	1	1	transcript	core,otherfeatures,presite	0	NULL	coding	SO:0000478	C_gene_segment	0	0000-00-00 00:00:00	101214	2014-11-06 15:43:12
+3	IG_D_gene	1	1	gene	core,otherfeatures,presite	100	NULL	coding	SO:0001217	protein_coding_gene	0	0000-00-00 00:00:00	101214	2014-11-06 15:43:42
+4	IG_D_gene	1	1	transcript	core,otherfeatures,presite	0	NULL	coding	SO:0000458	D_gene_segment	0	0000-00-00 00:00:00	101214	2014-11-06 15:43:59
+5	IG_J_gene	1	1	gene	core,otherfeatures,presite	100	NULL	coding	SO:0001217	protein_coding_gene	0	0000-00-00 00:00:00	101214	2014-11-06 15:44:21
+6	IG_J_gene	1	1	transcript	core,otherfeatures,presite	0	NULL	coding	SO:0000470	J_gene_segment	0	0000-00-00 00:00:00	101214	2014-11-06 15:44:35
+7	IG_J_pseudogene	1	1	gene	core,presite	67	NULL	pseudogene	SO:0000336	pseudogene	0	0000-00-00 00:00:00	104957	2014-03-21 15:07:59
+8	IG_J_pseudogene	1	1	transcript	core,presite	0	NULL	pseudogene	SO:0000516	pseudogenic_transcript	0	0000-00-00 00:00:00	104957	2014-03-21 15:08:05
+9	IG_V_gene	1	1	gene	core,otherfeatures,presite	100	NULL	coding	SO:0001217	protein_coding_gene	0	0000-00-00 00:00:00	101214	2014-11-06 15:45:02
+10	IG_V_gene	1	1	transcript	core,otherfeatures,presite	0	NULL	coding	SO:0000466	V_gene_segment	0	0000-00-00 00:00:00	101214	2014-11-06 15:45:24
+11	IG_V_pseudogene	1	1	gene	core,presite	67	NULL	pseudogene	SO:0000336	pseudogene	0	0000-00-00 00:00:00	104957	2014-03-21 15:18:20
+12	IG_V_pseudogene	1	1	transcript	core,presite	0	NULL	pseudogene	SO:0000516	pseudogenic_transcript	0	0000-00-00 00:00:00	104957	2014-03-21 15:18:25
+13	IG_gene	1	1	gene	vega	0	NULL	coding	SO:0001217	protein_coding_gene	0	0000-00-00 00:00:00	0	0000-00-00 00:00:00
+14	IG_gene	1	1	transcript	vega	0	NULL	coding	SO:3000000	gene_segment	0	0000-00-00 00:00:00	0	0000-00-00 00:00:00
+15	IG_pseudogene	1	1	gene	core,vega,presite	67	NULL	pseudogene	SO:0000336	pseudogene	0	0000-00-00 00:00:00	107110	2014-12-11 10:51:12
+16	IG_pseudogene	1	1	transcript	core,vega,presite	0	NULL	pseudogene	SO:0000516	pseudogenic_transcript	0	0000-00-00 00:00:00	107110	2014-12-11 10:51:29
+17	LRG_gene	1	1	gene	core	0	NULL	LRG	\N	\N	0	0000-00-00 00:00:00	97245	2014-08-27 10:46:00
+18	LRG_gene	1	1	transcript	core	0	NULL	LRG	\N	\N	0	0000-00-00 00:00:00	97245	2014-08-27 10:46:09
+19	Mt_rRNA	1	1	gene	core,presite	73	NULL	snoncoding	SO:0001263	ncRNA_gene	0	0000-00-00 00:00:00	104957	2014-03-21 15:18:04
+20	Mt_rRNA	1	1	transcript	core,presite	0	NULL	snoncoding	SO:0000252	rRNA	0	0000-00-00 00:00:00	104957	2014-03-21 15:18:10
+21	Mt_tRNA	1	1	gene	core,presite	74	NULL	snoncoding	SO:0001263	ncRNA_gene	0	0000-00-00 00:00:00	104957	2014-03-21 15:15:39
+22	Mt_tRNA	1	1	transcript	core,presite	0	NULL	snoncoding	SO:0000253	tRNA	0	0000-00-00 00:00:00	104957	2014-03-21 15:15:44
+23	Mt_tRNA_pseudogene	1	1	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336	pseudogene	0	0000-00-00 00:00:00	5132	2014-10-28 12:19:45
+24	Mt_tRNA_pseudogene	1	1	transcript	core	0	noncoding RNA pseudogene	pseudogene	SO:0000516	pseudogenic_transcript	0	0000-00-00 00:00:00	5132	2014-10-28 12:19:45
+25	RNA-Seq_gene	1	1	gene	otherfeatures	0	NULL	undefined	\N	\N	0	0000-00-00 00:00:00	0	0000-00-00 00:00:00
+26	RNA-Seq_gene	1	1	transcript	otherfeatures	0	NULL	undefined	\N	\N	0	0000-00-00 00:00:00	0	0000-00-00 00:00:00
+27	TEC	1	1	gene	core,vega,sangervega	0	NULL	undefined	\N	\N	0	0000-00-00 00:00:00	104991	2014-08-26 11:44:53
+28	TEC	1	0	transcript	core,vega,sangervega	0	NULL	undefined	SO:0002139	unconfirmed_transcript	0	0000-00-00 00:00:00	104991	2014-08-26 11:45:14
+29	TR_gene	1	1	gene	vega	0	NULL	coding	SO:0001217	protein_coding_gene	0	0000-00-00 00:00:00	0	0000-00-00 00:00:00
+30	TR_gene	1	1	transcript	core,vega	0	NULL	coding	SO:3000000	gene_segment	0	0000-00-00 00:00:00	0	0000-00-00 00:00:00
+31	TR_pseudogene	1	1	gene	vega	0	NULL	pseudogene	SO:0000336	pseudogene	0	0000-00-00 00:00:00	5132	2013-07-08 12:44:42
+32	TR_pseudogene	1	1	transcript	vega	0	NULL	pseudogene	SO:0000516	pseudogenic_transcript	0	0000-00-00 00:00:00	5132	2013-07-08 12:44:42
+33	ambiguous_orf	1	1	transcript	core,vega	0	NULL	lnoncoding	SO:0001877	lnc_RNA	0	0000-00-00 00:00:00	5132	2013-07-08 12:33:27
+35	cdna_update	1	1	gene	cdna	0	NULL	undefined	\N	\N	0	0000-00-00 00:00:00	97245	2011-10-26 08:58:38
+36	cdna_update	1	1	transcript	cdna	0	NULL	undefined	\N	\N	0	0000-00-00 00:00:00	97245	2011-10-26 08:58:49
+37	cdna	1	1	gene	otherfeatures	0	NULL	undefined	SO:0000756	cDNA	0	0000-00-00 00:00:00	0	0000-00-00 00:00:00
+38	cdna	1	1	transcript	otherfeatures	0	NULL	undefined	SO:0000756	cDNA	0	0000-00-00 00:00:00	0	0000-00-00 00:00:00
+39	disrupted_domain	1	1	transcript	core,vega	0	NULL	pseudogene	SO:0000516	pseudogenic_transcript	0	0000-00-00 00:00:00	0	0000-00-00 00:00:00
+40	est	1	1	gene	otherfeatures	0	NULL	undefined	\N	\N	0	0000-00-00 00:00:00	0	0000-00-00 00:00:00
+41	est	1	1	transcript	otherfeatures	0	NULL	undefined	SO:0000345	EST	0	0000-00-00 00:00:00	0	0000-00-00 00:00:00
+42	lincRNA	1	1	gene	core,vega,presite	190	NULL	lnoncoding	SO:0001263	ncRNA_gene	0	0000-00-00 00:00:00	104957	2014-03-21 15:17:05
+43	lincRNA	1	1	transcript	core,vega,presite	0	NULL	lnoncoding	SO:0001877	lnc_RNA	0	0000-00-00 00:00:00	104957	2014-03-21 15:17:09
+44	miRNA	1	1	gene	core,otherfeatures,vega,presite	70	From RefSeq import.	snoncoding	SO:0001263	ncRNA_gene	0	0000-00-00 00:00:00	104991	2014-11-12 12:04:54
+45	miRNA	1	1	transcript	core,otherfeatures,presite	0	From RefSeq import.	snoncoding	SO:0000276	miRNA	0	0000-00-00 00:00:00	104957	2014-03-21 15:16:09
+46	miRNA_pseudogene	1	1	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336	pseudogene	0	0000-00-00 00:00:00	5132	2014-10-28 12:19:45
+47	miRNA_pseudogene	1	1	transcript	core	0	noncoding RNA pseudogene	pseudogene	SO:0000516	pseudogenic_transcript	0	0000-00-00 00:00:00	5132	2014-10-28 12:19:45
+48	misc_RNA	1	1	gene	core,otherfeatures,presite	0	NULL	mnoncoding	SO:0001263	ncRNA_gene	0	0000-00-00 00:00:00	104957	2015-01-15 11:50:46
+49	misc_RNA	1	1	transcript	core,otherfeatures,presite	0	NULL	mnoncoding	SO:0000655	ncRNA	0	0000-00-00 00:00:00	104957	2015-01-15 11:51:00
+50	misc_RNA_pseudogene	1	1	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336	pseudogene	0	0000-00-00 00:00:00	5132	2014-10-28 12:19:45
+51	misc_RNA_pseudogene	1	1	transcript	core	0	noncoding RNA pseudogene	pseudogene	SO:0000516	pseudogenic_transcript	0	0000-00-00 00:00:00	5132	2014-10-28 12:19:45
+52	ncRNA	1	1	gene	core,otherfeatures	99	NULL	snoncoding	SO:0001263	ncRNA_gene	0	0000-00-00 00:00:00	5132	2013-07-08 13:03:50
+53	ncRNA	1	1	transcript	core,otherfeatures	0	NULL	snoncoding	SO:0000655	ncRNA	0	0000-00-00 00:00:00	5132	2013-07-08 13:03:50
+54	non_coding	1	1	gene	core,otherfeatures,rnaseq,vega,presite	353	NULL	lnoncoding	SO:0001263	ncRNA_gene	0	0000-00-00 00:00:00	5132	2013-07-08 12:33:27
+55	non_coding	1	1	transcript	core,otherfeatures,rnaseq,vega,presite	0	NULL	lnoncoding	SO:0001877	lnc_RNA	0	0000-00-00 00:00:00	5132	2013-07-08 12:33:27
+56	nonsense_mediated_decay	1	1	transcript	core,vega,presite	0	NULL	coding	SO:0000234	mRNA	0	0000-00-00 00:00:00	104957	2014-03-21 15:10:43
+57	polymorphic	1	1	gene	vega	0	NULL	coding	SO:0001217	protein_coding_gene	0	0000-00-00 00:00:00	0	0000-00-00 00:00:00
+58	polymorphic_pseudogene	1	1	gene	core,vega,presite	67	NULL	coding	SO:0001217	protein_coding_gene	0	0000-00-00 00:00:00	104957	2014-03-21 15:16:51
+59	polymorphic_pseudogene	1	1	transcript	core,vega,presite	0	NULL	coding	SO:0000234	mRNA	0	0000-00-00 00:00:00	104957	2014-03-21 15:16:56
+60	processed_pseudogene	1	1	gene	core,vega,presite	0	NULL	pseudogene	SO:0000336	pseudogene	0	0000-00-00 00:00:00	104957	2014-03-21 15:08:54
+61	processed_pseudogene	1	1	transcript	core,vega,presite	0	NULL	pseudogene	SO:0000516	pseudogenic_transcript	0	0000-00-00 00:00:00	104957	2014-03-21 15:09:02
+62	processed_transcript	1	1	gene	core,vega,presite	79	NULL	lnoncoding	SO:0001263	ncRNA_gene	0	0000-00-00 00:00:00	104957	2014-03-21 15:17:48
+63	processed_transcript	1	1	transcript	core,vega,presite	0	NULL	lnoncoding	SO:0001877	lnc_RNA	0	0000-00-00 00:00:00	104957	2014-03-21 15:17:53
+64	protein_coding	1	1	gene	core,otherfeatures,rnaseq,vega,presite	0	NULL	coding	SO:0001217	protein_coding_gene	0	0000-00-00 00:00:00	97245	2012-07-11 12:29:28
+65	protein_coding	1	1	transcript	core,otherfeatures,rnaseq,vega,presite	0	NULL	coding	SO:0000234	mRNA	0	0000-00-00 00:00:00	0	0000-00-00 00:00:00
+66	pseudogene	1	1	gene	core,otherfeatures,vega,presite	67	NULL	pseudogene	SO:0000336	pseudogene	0	0000-00-00 00:00:00	104957	2014-03-21 15:18:57
+67	pseudogene	1	1	transcript	core,otherfeatures,vega,presite	0	NULL	pseudogene	SO:0000516	pseudogenic_transcript	0	0000-00-00 00:00:00	104957	2014-03-21 15:19:04
+68	rRNA	1	1	gene	core,otherfeatures,vega,presite	66	NULL	lnoncoding	SO:0001263	ncRNA_gene	0	0000-00-00 00:00:00	104957	2014-12-03 15:06:35
+69	rRNA	1	1	transcript	core,otherfeatures,vega,presite	0	NULL	lnoncoding	SO:0000252	rRNA	0	0000-00-00 00:00:00	106182	2014-12-15 13:51:34
+70	rRNA_pseudogene	1	1	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336	pseudogene	0	0000-00-00 00:00:00	5132	2014-10-28 12:19:45
+71	rRNA_pseudogene	1	1	transcript	core	0	noncoding RNA pseudogene	pseudogene	SO:0000516	pseudogenic_transcript	0	0000-00-00 00:00:00	5132	2014-10-28 12:19:45
+72	retained_intron	1	1	transcript	core,vega,presite	0	NULL	lnoncoding	SO:0001877	lnc_RNA	0	0000-00-00 00:00:00	104957	2014-03-21 15:14:10
+73	retrotransposed	0	1	gene	core	77	NULL	pseudogene	SO:0000569	retrotransposed	0	0000-00-00 00:00:00	5132	2012-10-30 17:53:09
+74	retrotransposed	0	1	transcript	core	0	NULL	pseudogene	SO:0000569	retrotransposed	0	0000-00-00 00:00:00	5132	2012-10-30 17:53:26
+75	scRNA_pseudogene	1	1	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336	pseudogene	0	0000-00-00 00:00:00	5132	2014-10-28 12:19:45
+76	scRNA_pseudogene	1	1	transcript	core	0	noncoding RNA pseudogene	pseudogene	SO:0000516	pseudogenic_transcript	0	0000-00-00 00:00:00	5132	2014-10-28 12:19:45
+77	snRNA	1	1	gene	core,otherfeatures,vega,presite	68	From Havana manual annotation.	snoncoding	SO:0001263	ncRNA_gene	0	0000-00-00 00:00:00	104957	2014-03-21 15:05:32
+78	snRNA	1	1	transcript	core,otherfeatures,vega,presite	0	From Havana manual annotation.	snoncoding	SO:0000274	snRNA	0	0000-00-00 00:00:00	104957	2014-03-21 15:05:40
+79	snRNA_pseudogene	1	1	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336	pseudogene	0	0000-00-00 00:00:00	5132	2014-10-28 12:19:45
+80	snRNA_pseudogene	1	1	transcript	core	0	noncoding RNA pseudogene	pseudogene	SO:0000516	pseudogenic_transcript	0	0000-00-00 00:00:00	5132	2014-10-28 12:19:45
+81	snlRNA	1	1	gene	core	78	NULL	snoncoding	SO:0001263	ncRNA_gene	0	0000-00-00 00:00:00	5132	2013-07-08 13:03:50
+82	snlRNA	1	1	transcript	core	0	NULL	snoncoding	SO:0000274	snRNA	0	0000-00-00 00:00:00	5132	2013-07-08 13:03:50
+83	snoRNA	1	1	gene	core,otherfeatures,vega,presite	69	small nucleolar RNA.	snoncoding	SO:0001263	ncRNA_gene	0	0000-00-00 00:00:00	104957	2014-03-21 15:16:36
+84	snoRNA	1	1	transcript	core,otherfeatures,vega,presite	0	small nucleolar RNA.	snoncoding	SO:0000275	snoRNA	0	0000-00-00 00:00:00	104957	2014-03-21 15:16:41
+85	snoRNA_pseudogene	1	1	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336	pseudogene	0	0000-00-00 00:00:00	5132	2014-10-28 12:19:45
+86	snoRNA_pseudogene	1	1	transcript	core	0	noncoding RNA pseudogene	pseudogene	SO:0000516	pseudogenic_transcript	0	0000-00-00 00:00:00	5132	2014-10-28 12:19:45
+87	tRNA	1	1	gene	core,otherfeatures,presite	76	NULL	snoncoding	SO:0001263	ncRNA_gene	0	0000-00-00 00:00:00	104957	2014-03-21 15:08:32
+88	tRNA	1	1	transcript	core,otherfeatures,presite	76	NULL	snoncoding	SO:0000253	tRNA	0	0000-00-00 00:00:00	104957	2014-03-21 15:08:38
+89	tRNA_pseudogene	1	1	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336	pseudogene	0	0000-00-00 00:00:00	5132	2014-10-28 12:19:45
+90	tRNA_pseudogene	1	1	transcript	core	0	noncoding RNA pseudogene	pseudogene	SO:0000516	pseudogenic_transcript	0	0000-00-00 00:00:00	5132	2014-10-28 12:19:45
+91	transcribed_processed_pseudogene	1	1	gene	core,vega,presite	0	NULL	pseudogene	SO:0000336	pseudogene	0	0000-00-00 00:00:00	104957	2014-03-21 15:14:43
+92	transcribed_processed_pseudogene	1	1	transcript	core,vega,presite	0	NULL	pseudogene	SO:0000516	pseudogenic_transcript	0	0000-00-00 00:00:00	104957	2014-03-21 15:14:48
+93	transcribed_unitary_pseudogene	1	1	gene	core,vega	0	NULL	pseudogene	SO:0000336	pseudogene	0	0000-00-00 00:00:00	104957	2014-08-15 13:48:10
+94	transcribed_unprocessed_pseudogene	1	1	gene	core,vega,presite	0	NULL	pseudogene	SO:0000336	pseudogene	0	0000-00-00 00:00:00	104957	2014-03-21 15:12:59
+95	transcribed_unprocessed_pseudogene	1	1	transcript	core,vega,presite	0	NULL	pseudogene	SO:0000516	pseudogenic_transcript	0	0000-00-00 00:00:00	104957	2014-03-21 15:13:05
+96	unitary_pseudogene	1	1	gene	core,vega,presite	0	NULL	pseudogene	SO:0000336	pseudogene	0	0000-00-00 00:00:00	104957	2014-03-21 15:11:13
+97	unitary_pseudogene	1	1	transcript	core,vega,presite	0	NULL	pseudogene	SO:0000516	pseudogenic_transcript	0	0000-00-00 00:00:00	104957	2014-03-21 15:11:20
+98	unprocessed_pseudogene	1	1	gene	core,vega,presite	0	NULL	pseudogene	SO:0000336	pseudogene	0	0000-00-00 00:00:00	104957	2014-03-21 15:11:32
+99	unprocessed_pseudogene	1	1	transcript	core,vega,presite	0	NULL	pseudogene	SO:0000516	pseudogenic_transcript	0	0000-00-00 00:00:00	104957	2014-03-21 15:11:38
+100	ccds_gene	1	0	gene	otherfeatures	0	Imported CCDS gene models	undefined	\N	\N	0	0000-00-00 00:00:00	0	0000-00-00 00:00:00
+101	protein_coding_in_progress	1	1	gene	vega	0	occurs where the ORF is lost when remapping to a different assembly and the gene is awaiting reannotation	undefined	\N	\N	0	0000-00-00 00:00:00	0	0000-00-00 00:00:00
+102	IG_Z_gene	1	1	gene	core,vega	100	NULL	coding	SO:0001217	protein_coding_gene	0	0000-00-00 00:00:00	0	0000-00-00 00:00:00
+103	IG_M_gene	1	1	gene	core,vega	100	NULL	coding	SO:0001217	protein_coding_gene	0	0000-00-00 00:00:00	0	0000-00-00 00:00:00
+104	ncrna_host	1	1	transcript	core,vega	0	NULL	lnoncoding	\N	\N	0	0000-00-00 00:00:00	5132	2013-07-08 12:33:27
+105	TR_V_pseudogene	1	1	gene	core,presite	67	NULL	pseudogene	SO:0000336	pseudogene	0	0000-00-00 00:00:00	104957	2014-03-21 15:15:12
+106	TR_V_gene	1	1	gene	core,presite	100	NULL	coding	SO:0001217	protein_coding_gene	0	0000-00-00 00:00:00	104957	2014-03-21 15:14:59
+107	IG_C_pseudogene	1	1	gene	core,presite	67	NULL	pseudogene	SO:0000336	pseudogene	0	0000-00-00 00:00:00	104957	2014-03-21 15:16:19
+108	TR_C_gene	1	1	gene	core,presite	100	NULL	coding	SO:0001217	protein_coding_gene	0	0000-00-00 00:00:00	104957	2014-03-21 15:14:25
+109	TR_J_gene	1	1	gene	core,presite	100	NULL	coding	SO:0001217	protein_coding_gene	0	0000-00-00 00:00:00	104957	2014-03-21 15:18:37
+110	TR_V_pseudogene	1	1	transcript	core,presite	0	NULL	pseudogene	SO:0000516	pseudogenic_transcript	0	0000-00-00 00:00:00	104957	2014-03-21 15:15:18
+111	TR_V_gene	1	1	transcript	core,presite	0	NULL	coding	SO:0000466	V_gene_segment	0	0000-00-00 00:00:00	104957	2014-03-21 15:15:06
+112	IG_C_pseudogene	1	1	transcript	core,presite	0	NULL	pseudogene	SO:0000516	pseudogenic_transcript	0	0000-00-00 00:00:00	104957	2014-03-21 15:16:25
+113	TR_C_gene	1	1	transcript	core,presite	0	NULL	coding	SO:0000478	C_gene_segment	0	0000-00-00 00:00:00	104957	2014-03-21 15:14:31
+114	TR_J_gene	1	1	transcript	core,presite	0	NULL	coding	SO:0000470	J_gene_segment	0	0000-00-00 00:00:00	104957	2014-03-21 15:18:41
+115	protein_coding_in_progress	1	1	transcript	vega	0	occurs where the ORF is lost when remapping to a different assembly and the gene is awaiting reannotation	undefined	\N	\N	0	0000-00-00 00:00:00	0	0000-00-00 00:00:00
+116	IG_M_gene	1	1	transcript	core	0	NULL	coding	SO:3000000	gene_segment	0	0000-00-00 00:00:00	0	0000-00-00 00:00:00
+117	IG_Z_gene	1	1	transcript	core	0	NULL	coding	SO:3000000	gene_segment	0	0000-00-00 00:00:00	0	0000-00-00 00:00:00
+118	3prime_overlapping_ncrna	1	1	transcript	core,vega,presite	0	NULL	lnoncoding	SO:0002120	three_prime_overlapping_ncrna	0	0000-00-00 00:00:00	104957	2014-03-21 15:09:16
+123	antisense_RNA	1	0	gene	otherfeatures,presite	0	From RefSeq import	lnoncoding	SO:0001263	ncRNA_gene	5132	2011-06-02 07:12:32	104957	2014-03-21 15:13:29
+124	antisense_RNA	1	0	transcript	otherfeatures,presite	0	From RefSeq import	lnoncoding	SO:0001877	lnc_RNA	5132	2011-06-02 07:12:40	104957	2014-03-21 15:13:35
+125	scRNA	1	0	gene	otherfeatures	0	From RefSeq import	snoncoding	SO:0001263	ncRNA_gene	5132	2011-06-02 07:13:08	5132	2013-07-08 13:03:50
+126	scRNA	1	0	transcript	otherfeatures	0	From RefSeq import	snoncoding	SO:0000013	scRNA	5132	2011-06-02 07:13:15	5132	2013-07-08 13:03:50
+127	RNase_MRP_RNA	1	0	gene	core,otherfeatures,presite	0	From RefSeq import or Rfamscan	snoncoding	SO:0001263	ncRNA_gene	5132	2011-06-02 07:14:03	104957	2014-03-21 15:11:55
+128	RNase_MRP_RNA	1	0	transcript	core,otherfeatures,presite	0	From RefSeq import or Rfamscan	snoncoding	SO:0000385	RNase_MRP_RNA	5132	2011-06-02 07:14:09	104957	2014-03-21 15:12:01
+129	RNase_P_RNA	1	0	gene	core,otherfeatures,presite	0	From RefSeq import or Rfamscan	snoncoding	SO:0001263	ncRNA_gene	5132	2011-06-02 07:14:40	104957	2014-03-21 15:12:06
+130	RNase_P_RNA	1	0	transcript	core,otherfeatures,presite	0	From RefSeq import or Rfamscan	snoncoding	SO:0000386	RNase_P_RNA	5132	2011-06-02 07:14:46	104957	2014-03-21 15:12:12
+131	telomerase_RNA	1	0	gene	otherfeatures,presite	0	From RefSeq import or Rfamscan	snoncoding	SO:0001263	ncRNA_gene	5132	2011-06-02 07:15:54	104957	2014-03-21 15:10:07
+132	telomerase_RNA	1	0	transcript	otherfeatures,presite	0	From RefSeq import or Rfamscan	snoncoding	SO:0000390	telomerase_RNA	5132	2011-06-02 07:16:03	104957	2014-03-21 15:10:12
+133	sense_intronic	1	1	transcript	core,vega,presite	0	NULL	lnoncoding	SO:0001877	lnc_RNA	97245	2011-07-18 10:14:50	104957	2014-03-21 15:10:23
+135	sense_overlapping	1	1	transcript	core,vega,presite	0	NULL	lnoncoding	SO:0001877	lnc_RNA	97245	2011-07-19 13:29:37	104957	2014-03-21 15:12:37
+138	sense_intronic	1	1	gene	core,vega,presite	350	NULL	lnoncoding	SO:0001263	ncRNA_gene	97245	2011-07-19 13:31:24	104957	2014-03-21 15:10:31
+139	ambiguous_orf	1	1	gene	core,vega	351	NULL	lnoncoding	SO:0001263	ncRNA_gene	97245	2011-07-19 13:31:27	5132	2013-07-08 12:33:27
+140	retained_intron	1	1	gene	core,vega,presite	352	NULL	lnoncoding	SO:0001263	ncRNA_gene	97245	2011-07-19 13:31:31	104957	2014-03-21 15:14:16
+142	3prime_overlapping_ncrna	1	1	gene	core,vega,presite	356	NULL	lnoncoding	\N	\N	97245	2011-07-19 13:31:38	104957	2014-03-21 15:09:21
+143	ncrna_host	1	1	gene	core,vega	354	NULL	lnoncoding	\N	\N	97245	2011-07-19 13:31:42	5132	2013-07-08 12:33:27
+144	sense_overlapping	1	1	gene	core,vega,presite	355	NULL	lnoncoding	SO:0001263	ncRNA_gene	97245	2011-07-19 13:31:47	104957	2014-03-21 15:12:43
+146	TR_D_gene	1	1	transcript	core,presite	0	NULL	coding	SO:0000458	D_gene_segment	97245	2011-07-20 10:10:01	104957	2014-03-21 15:12:22
+147	TR_J_pseudogene	1	1	transcript	core,presite	0	NULL	pseudogene	SO:0000516	pseudogenic_transcript	97245	2011-07-20 10:10:01	104957	2014-03-21 15:04:14
+148	TR_D_gene	1	1	gene	core,presite	100	NULL	coding	SO:0001217	protein_coding_gene	97245	2011-07-20 10:10:01	104957	2014-03-21 15:12:27
+149	TR_J_pseudogene	1	1	gene	core,presite	67	NULL	pseudogene	SO:0000336	pseudogene	97245	2011-07-20 10:10:01	104957	2014-03-21 15:04:57
+150	ncbi_pseudogene	1	0	gene	otherfeatures	0	Imported annotation from RefSeq	pseudogene	SO:0000336	pseudogene	5132	2011-08-06 09:03:27	0	0000-00-00 00:00:00
+151	ncbi_pseudogene	1	0	transcript	otherfeatures	0	Imported annotation from RefSeq	pseudogene	SO:0000516	pseudogenic_transcript	5132	2011-08-06 09:04:11	0	0000-00-00 00:00:00
+152	ncbigene	1	0	gene	otherfeatures	0	Imported annotation from RefSeq	undefined	\N	\N	5132	2011-08-06 09:04:25	0	0000-00-00 00:00:00
+153	non_stop_decay	1	1	transcript	core,vega,presite	0	A new transcript biotype from Havana.	coding	SO:0000234	mRNA	9335	2011-10-11 12:28:06	104957	2014-03-21 15:08:18
+154	pre_miRNA	1	1	transcript	core	0	This is the pre miRNA information extracted from FlyBase annotations distinctive from the miRNA form for the same gene model.Gautier is happy for this to be in the short noncoding group.	snoncoding	SO:0001244	pre_miRNA	98587	2011-10-13 13:29:27	5132	2013-07-09 18:42:54
 155	tmRNA	1	1	gene	core	357	One of the classes of ncRNA genes that is only found in bacteria.\
-Hence only required for EnsemblBacteria.	snoncoding	SO:0001263	101255	2011-10-24 16:20:33	105967	2013-10-08 11:25:14
-156	tmRNA	1	1	transcript	core	0	One of the classes of ncRNA genes that is only found in bacteria. Hence only required for EnsemblBacteria.	snoncoding	SO:0000584	101255	2011-10-24 16:21:47	105967	2013-10-08 11:25:26
-157	SRP_RNA	1	1	gene	core	194	The signal recognition particle (SRP) RNA is one of the classes of ncRNA genes.	snoncoding	SO:0001263	101255	2011-10-24 16:25:07	105967	2013-10-08 11:24:01
-158	SRP_RNA	1	1	transcript	core	0	The signal recognition particle (SRP) RNA is one of the classes of ncRNA genes.	snoncoding	SO:0000590	101255	2011-10-24 16:25:22	105967	2013-10-08 11:24:14
-160	ribozyme	1	1	transcript	core,otherfeatures,presite	0	NULL	lnoncoding	SO:0001877	101255	2012-04-04 15:52:41	104957	2015-01-20 14:37:05
-163	ncRNA_pseudogene	1	1	gene	otherfeatures	99	noncoding RNA pseudogene	pseudogene	SO:0000336	5132	2012-09-23 21:23:20	5132	2014-10-28 12:19:45
-164	ncRNA_pseudogene	1	1	transcript	otherfeatures	99	noncoding RNA pseudogene	pseudogene	SO:0000516	5132	2012-09-23 21:23:39	5132	2014-10-28 12:19:45
-165	IG_LV_gene	1	1	gene	core	100	NULL	coding	SO:0001217	5132	2012-11-14 18:01:19	0	0000-00-00 00:00:00
-166	IG_LV_gene	1	1	transcript	core	0	NULL	coding	SO:3000000	5132	2012-11-14 18:01:46	0	0000-00-00 00:00:00
-167	translated_processed_pseudogene	1	1	gene	core,vega,presite	0	NULL	pseudogene	SO:0000336	102717	2013-03-20 13:24:11	104957	2014-03-21 15:06:29
-168	translated_processed_pseudogene	1	1	transcript	core,vega,presite	0	NULL	pseudogene	SO:0000516	102717	2013-03-20 13:24:42	104957	2014-03-21 15:06:36
-169	nontranslating_CDS	1	0	gene	core	0	An imported 'protein-coding' gene that does not translate due to one or more unannotated stop codons.	coding	SO:0001217	105967	2013-04-24 11:44:22	0	0000-00-00 00:00:00
-170	nontranslating_CDS	1	0	transcript	core	0	An imported 'protein-coding' transcript that does not translate due to one or more unannotated stop codons.	coding	SO:0000234	105967	2013-04-24 11:45:31	0	0000-00-00 00:00:00
-171	translated_unprocessed_pseudogene	1	1	gene	core,vega	0	NULL	pseudogene	SO:0000336	104957	2013-08-07 12:42:12	0	0000-00-00 00:00:00
-172	translated_unprocessed_pseudogene	1	1	transcript	core,vega	0	NULL	pseudogene	SO:0000516	104957	2013-08-07 12:42:27	0	0000-00-00 00:00:00
-173	mRNA	1	1	gene	otherfeatures	0	From RefSeq import	coding	SO:0001217	102717	2014-01-06 11:04:29	0	0000-00-00 00:00:00
-174	mRNA	1	1	transcript	otherfeatures	0	From RefSeq import	coding	SO:0000234	102717	2014-01-06 11:48:30	0	0000-00-00 00:00:00
-175	pre_miRNA	1	1	gene	core	0	This is the pre miRNA information extracted from FlyBase annotations distinctive from the miRNA form for the same gene model.Gautier is happy for this to be in the short noncoding group.	snoncoding	SO:0001263	105967	2014-01-14 13:02:47	0	0000-00-00 00:00:00
-176	artifact	1	0	gene	vega	0	Should not see this biotype in core db	undefined	\N	106182	2014-06-02 08:50:01	5132	2014-06-10 06:56:58
-177	artifact	1	0	transcript	vega	0	Should not see this biotype in core db	undefined	\N	106182	2014-06-02 08:50:24	5132	2014-06-10 06:57:13
-178	lncRNA	1	1	gene	core,otherfeatures,vega,presite	190	NULL	lnoncoding	SO:0001263	102717	2014-06-09 13:14:33	102717	2014-08-31 11:51:02
-179	class_I_RNA	1	1	gene	core	0	Small non-coding RNA (55-65 nt long) containing highly conserved 5' and 3' ends (16 and 8 nt, respectively) that are predicted to come together to form a stem structure. Identified in the social amoeba Dictyostelium discoideum and localized in the cytoplasm.	snoncoding	SO:0001263	101216	2014-08-07 13:41:46	0	0000-00-00 00:00:00
-180	class_I_RNA	1	1	transcript	core	0	Small non-coding RNA (55-65 nt long) containing highly conserved 5' and 3' ends (16 and 8 nt, respectively) that are predicted to come together to form a stem structure. Identified in the social amoeba Dictyostelium discoideum and localized in the cytoplasm.	snoncoding	SO:0000990	101216	2014-08-07 13:42:10	0	0000-00-00 00:00:00
-181	class_II_RNA	1	1	gene	core	0	Small non-coding RNA (59-60 nt long) containing 5' and 3' ends that are predicted to come together to form a stem structure. Identified in the social amoeba Dictyostelium discoideum and localized in the cytoplasm.	snoncoding	SO:0001263	101216	2014-08-07 13:42:41	0	0000-00-00 00:00:00
-182	class_II_RNA	1	1	transcript	core	0	Small non-coding RNA (59-60 nt long) containing 5' and 3' ends that are predicted to come together to form a stem structure. Identified in the social amoeba Dictyostelium discoideum and localized in the cytoplasm.	snoncoding	SO:0000989	101216	2014-08-07 13:43:18	0	0000-00-00 00:00:00
-183	known_ncrna	1	1	gene	core,otherfeatures,vega,sangervega	99	NULL	snoncoding	\N	104957	2014-08-15 13:33:26	104991	2014-08-26 12:03:28
-184	known_ncrna	1	1	transcript	core,otherfeatures,vega,sangervega	0	NULL	snoncoding	SO:0000655	104957	2014-08-15 13:33:44	104991	2014-08-26 12:03:41
-185	transcribed_unitary_pseudogene	1	1	transcript	core,vega	0	NULL	pseudogene	SO:0000516	104957	2014-08-15 13:49:12	0	0000-00-00 00:00:00
-186	piRNA	1	1	gene	core	0	A small non coding RNA, part of a silencing system that prevents the spreading of selfish genetic elements.	snoncoding	SO:0001263	104856	2014-10-17 15:51:11	0	0000-00-00 00:00:00
-187	piRNA	1	1	transcript	core	0	A small non coding RNA, part of a silencing system that prevents the spreading of selfish genetic elements.	snoncoding	SO:0001035	104856	2014-10-19 20:08:35	0	0000-00-00 00:00:00
-188	IG_D_pseudogene	1	1	gene	core,presite	67	NULL	pseudogene	SO:0000336	101214	2014-10-22 15:18:32	0	0000-00-00 00:00:00
-189	macro_lncRNA	1	1	gene	core,vega	388	Unspliced lncRNAs that are several kb in size	lnoncoding	SO:0001263	104991	2014-10-28 11:46:17	104957	2015-01-20 09:33:36
-191	vaultRNA	1	1	gene	core,vega	388	short non coding RNA genes that form part of the vault ribonucleoprotein complex	snoncoding	SO:0001263	104991	2014-10-28 11:47:09	104957	2015-01-20 09:34:31
-192	scaRNA	1	1	gene	core,otherfeatures,presite	440	NULL	snoncoding	SO:0001263	104957	2014-12-02 14:02:42	104957	2014-12-03 15:03:54
-193	scaRNA	1	1	transcript	core,otherfeatures,presite	0	NULL	snoncoding	SO:0000013	104957	2014-12-02 14:02:56	0	0000-00-00 00:00:00
-194	sRNA	1	1	transcript	core,otherfeatures,presite	0	NULL	snoncoding	SO:0000274	104957	2014-12-02 14:04:57	104957	2014-12-03 15:05:06
-195	sRNA	1	1	gene	core,otherfeatures,presite	441	NULL	snoncoding	SO:0001263	104957	2014-12-02 14:05:38	104957	2014-12-03 15:05:18
-196	CRISPR	1	1	gene	core,otherfeatures,presite	442	NULL	snoncoding	SO:0001263	104957	2014-12-02 14:06:35	104957	2014-12-03 15:00:56
-197	CRISPR	1	1	transcript	core,otherfeatures,presite	0	NULL	snoncoding	SO:0001459	104957	2014-12-02 14:06:52	0	0000-00-00 00:00:00
-198	antitoxin	1	1	transcript	core,otherfeatures,presite	0	NULL	lnoncoding	SO:0001877	104957	2014-12-02 14:07:48	104957	2014-12-03 14:59:20
-199	antitoxin	1	1	gene	core,otherfeatures,presite	443	NULL	lnoncoding	SO:0001263	104957	2014-12-02 14:08:01	104957	2014-12-03 14:59:44
-200	ribozyme	1	1	gene	core,otherfeatures,presite	359	NULL	lnoncoding	SO:0001263	104957	2014-12-02 14:08:13	104957	2014-12-03 15:03:29
-202	vaultRNA	1	1	transcript	core,vega	388	short non coding RNA genes that form part of the vault ribonucleoprotein complex	snoncoding	SO:0002040	104957	2014-12-09 09:53:29	104957	2015-01-20 09:34:47
-203	macro_lncRNA	1	1	transcript	core,vega	388	Unspliced lncRNAs that are several kb in size	lnoncoding	SO:0001877	104957	2014-12-09 09:54:17	104957	2015-01-20 09:33:45
+Hence only required for EnsemblBacteria.	snoncoding	SO:0001263	ncRNA_gene	101255	2011-10-24 16:20:33	105967	2013-10-08 11:25:14
+156	tmRNA	1	1	transcript	core	0	One of the classes of ncRNA genes that is only found in bacteria. Hence only required for EnsemblBacteria.	snoncoding	SO:0000584	tmRNA	101255	2011-10-24 16:21:47	105967	2013-10-08 11:25:26
+157	SRP_RNA	1	1	gene	core	194	The signal recognition particle (SRP) RNA is one of the classes of ncRNA genes.	snoncoding	SO:0001263	ncRNA_gene	101255	2011-10-24 16:25:07	105967	2013-10-08 11:24:01
+158	SRP_RNA	1	1	transcript	core	0	The signal recognition particle (SRP) RNA is one of the classes of ncRNA genes.	snoncoding	SO:0000590	SRP_RNA	101255	2011-10-24 16:25:22	105967	2013-10-08 11:24:14
+160	ribozyme	1	1	transcript	core,otherfeatures,presite	0	NULL	lnoncoding	SO:0001877	lnc_RNA	101255	2012-04-04 15:52:41	104957	2015-01-20 14:37:05
+163	ncRNA_pseudogene	1	1	gene	otherfeatures	99	noncoding RNA pseudogene	pseudogene	SO:0000336	pseudogene	5132	2012-09-23 21:23:20	5132	2014-10-28 12:19:45
+164	ncRNA_pseudogene	1	1	transcript	otherfeatures	99	noncoding RNA pseudogene	pseudogene	SO:0000516	pseudogenic_transcript	5132	2012-09-23 21:23:39	5132	2014-10-28 12:19:45
+165	IG_LV_gene	1	1	gene	core	100	NULL	coding	SO:0001217	protein_coding_gene	5132	2012-11-14 18:01:19	0	0000-00-00 00:00:00
+166	IG_LV_gene	1	1	transcript	core	0	NULL	coding	SO:3000000	gene_segment	5132	2012-11-14 18:01:46	0	0000-00-00 00:00:00
+167	translated_processed_pseudogene	1	1	gene	core,vega,presite	0	NULL	pseudogene	SO:0000336	pseudogene	102717	2013-03-20 13:24:11	104957	2014-03-21 15:06:29
+168	translated_processed_pseudogene	1	1	transcript	core,vega,presite	0	NULL	pseudogene	SO:0000516	pseudogenic_transcript	102717	2013-03-20 13:24:42	104957	2014-03-21 15:06:36
+169	nontranslating_CDS	1	0	gene	core	0	An imported 'protein-coding' gene that does not translate due to one or more unannotated stop codons.	coding	SO:0001217	protein_coding_gene	105967	2013-04-24 11:44:22	0	0000-00-00 00:00:00
+170	nontranslating_CDS	1	0	transcript	core	0	An imported 'protein-coding' transcript that does not translate due to one or more unannotated stop codons.	coding	SO:0000234	mRNA	105967	2013-04-24 11:45:31	0	0000-00-00 00:00:00
+171	translated_unprocessed_pseudogene	1	1	gene	core,vega	0	NULL	pseudogene	SO:0000336	pseudogene	104957	2013-08-07 12:42:12	0	0000-00-00 00:00:00
+172	translated_unprocessed_pseudogene	1	1	transcript	core,vega	0	NULL	pseudogene	SO:0000516	pseudogenic_transcript	104957	2013-08-07 12:42:27	0	0000-00-00 00:00:00
+173	mRNA	1	1	gene	otherfeatures	0	From RefSeq import	coding	SO:0001217	protein_coding_gene	102717	2014-01-06 11:04:29	0	0000-00-00 00:00:00
+174	mRNA	1	1	transcript	otherfeatures	0	From RefSeq import	coding	SO:0000234	mRNA	102717	2014-01-06 11:48:30	0	0000-00-00 00:00:00
+175	pre_miRNA	1	1	gene	core	0	This is the pre miRNA information extracted from FlyBase annotations distinctive from the miRNA form for the same gene model.Gautier is happy for this to be in the short noncoding group.	snoncoding	SO:0001263	ncRNA_gene	105967	2014-01-14 13:02:47	0	0000-00-00 00:00:00
+176	artifact	1	0	gene	vega	0	Should not see this biotype in core db	undefined	\N	\N	106182	2014-06-02 08:50:01	5132	2014-06-10 06:56:58
+177	artifact	1	0	transcript	vega	0	Should not see this biotype in core db	undefined	\N	\N	106182	2014-06-02 08:50:24	5132	2014-06-10 06:57:13
+178	lncRNA	1	1	gene	core,otherfeatures,vega,presite	190	NULL	lnoncoding	SO:0001263	ncRNA_gene	102717	2014-06-09 13:14:33	102717	2014-08-31 11:51:02
+179	class_I_RNA	1	1	gene	core	0	Small non-coding RNA (55-65 nt long) containing highly conserved 5' and 3' ends (16 and 8 nt, respectively) that are predicted to come together to form a stem structure. Identified in the social amoeba Dictyostelium discoideum and localized in the cytoplasm.	snoncoding	SO:0001263	ncRNA_gene	101216	2014-08-07 13:41:46	0	0000-00-00 00:00:00
+180	class_I_RNA	1	1	transcript	core	0	Small non-coding RNA (55-65 nt long) containing highly conserved 5' and 3' ends (16 and 8 nt, respectively) that are predicted to come together to form a stem structure. Identified in the social amoeba Dictyostelium discoideum and localized in the cytoplasm.	snoncoding	SO:0000990	class_I_RNA	101216	2014-08-07 13:42:10	0	0000-00-00 00:00:00
+181	class_II_RNA	1	1	gene	core	0	Small non-coding RNA (59-60 nt long) containing 5' and 3' ends that are predicted to come together to form a stem structure. Identified in the social amoeba Dictyostelium discoideum and localized in the cytoplasm.	snoncoding	SO:0001263	ncRNA_gene	101216	2014-08-07 13:42:41	0	0000-00-00 00:00:00
+182	class_II_RNA	1	1	transcript	core	0	Small non-coding RNA (59-60 nt long) containing 5' and 3' ends that are predicted to come together to form a stem structure. Identified in the social amoeba Dictyostelium discoideum and localized in the cytoplasm.	snoncoding	SO:0000989	class_II_RNA	101216	2014-08-07 13:43:18	0	0000-00-00 00:00:00
+183	known_ncrna	1	1	gene	core,otherfeatures,vega,sangervega	99	NULL	snoncoding	\N	\N	104957	2014-08-15 13:33:26	104991	2014-08-26 12:03:28
+184	known_ncrna	1	1	transcript	core,otherfeatures,vega,sangervega	0	NULL	snoncoding	SO:0000655	ncRNA	104957	2014-08-15 13:33:44	104991	2014-08-26 12:03:41
+185	transcribed_unitary_pseudogene	1	1	transcript	core,vega	0	NULL	pseudogene	SO:0000516	pseudogenic_transcript	104957	2014-08-15 13:49:12	0	0000-00-00 00:00:00
+186	piRNA	1	1	gene	core	0	A small non coding RNA, part of a silencing system that prevents the spreading of selfish genetic elements.	snoncoding	SO:0001263	ncRNA_gene	104856	2014-10-17 15:51:11	0	0000-00-00 00:00:00
+187	piRNA	1	1	transcript	core	0	A small non coding RNA, part of a silencing system that prevents the spreading of selfish genetic elements.	snoncoding	SO:0001035	piRNA	104856	2014-10-19 20:08:35	0	0000-00-00 00:00:00
+188	IG_D_pseudogene	1	1	gene	core,presite	67	NULL	pseudogene	SO:0000336	pseudogene	101214	2014-10-22 15:18:32	0	0000-00-00 00:00:00
+189	macro_lncRNA	1	1	gene	core,vega	388	Unspliced lncRNAs that are several kb in size	lnoncoding	SO:0001263	ncRNA_gene	104991	2014-10-28 11:46:17	104957	2015-01-20 09:33:36
+191	vaultRNA	1	1	gene	core,vega	388	short non coding RNA genes that form part of the vault ribonucleoprotein complex	snoncoding	SO:0001263	ncRNA_gene	104991	2014-10-28 11:47:09	104957	2015-01-20 09:34:31
+192	scaRNA	1	1	gene	core,otherfeatures,presite	440	NULL	snoncoding	SO:0001263	ncRNA_gene	104957	2014-12-02 14:02:42	104957	2014-12-03 15:03:54
+193	scaRNA	1	1	transcript	core,otherfeatures,presite	0	NULL	snoncoding	SO:0000013	scRNA	104957	2014-12-02 14:02:56	0	0000-00-00 00:00:00
+194	sRNA	1	1	transcript	core,otherfeatures,presite	0	NULL	snoncoding	SO:0000274	snRNA	104957	2014-12-02 14:04:57	104957	2014-12-03 15:05:06
+195	sRNA	1	1	gene	core,otherfeatures,presite	441	NULL	snoncoding	SO:0001263	ncRNA_gene	104957	2014-12-02 14:05:38	104957	2014-12-03 15:05:18
+196	CRISPR	1	1	gene	core,otherfeatures,presite	442	NULL	snoncoding	SO:0001263	ncRNA_gene	104957	2014-12-02 14:06:35	104957	2014-12-03 15:00:56
+197	CRISPR	1	1	transcript	core,otherfeatures,presite	0	NULL	snoncoding	SO:0001459	CRISPR	104957	2014-12-02 14:06:52	0	0000-00-00 00:00:00
+198	antitoxin	1	1	transcript	core,otherfeatures,presite	0	NULL	lnoncoding	SO:0001877	lnc_RNA	104957	2014-12-02 14:07:48	104957	2014-12-03 14:59:20
+199	antitoxin	1	1	gene	core,otherfeatures,presite	443	NULL	lnoncoding	SO:0001263	ncRNA_gene	104957	2014-12-02 14:08:01	104957	2014-12-03 14:59:44
+200	ribozyme	1	1	gene	core,otherfeatures,presite	359	NULL	lnoncoding	SO:0001263	ncRNA_gene	104957	2014-12-02 14:08:13	104957	2014-12-03 15:03:29
+202	vaultRNA	1	1	transcript	core,vega	388	short non coding RNA genes that form part of the vault ribonucleoprotein complex	snoncoding	SO:0002040	vaultRNA_primary_transcript	104957	2014-12-09 09:53:29	104957	2015-01-20 09:34:47
+203	macro_lncRNA	1	1	transcript	core,vega	388	Unspliced lncRNAs that are several kb in size	lnoncoding	SO:0001877	lnc_RNA	104957	2014-12-09 09:54:17	104957	2015-01-20 09:33:45

--- a/modules/t/test-genome-DBs/multi/production/meta.txt
+++ b/modules/t/test-genome-DBs/multi/production/meta.txt
@@ -54,3 +54,4 @@
 60	\N	patch	patch_94_95_a.sql|schema_version
 61	\N	patch	patch_94_95_a.sql|vertebrate_division_rename
 62	\N	patch	patch_94_95_b.sql|vertebrate_division_rename
+63	\N	patch	patch_95_96_b.sql|biotype_so_term

--- a/modules/t/test-genome-DBs/multi/production/table.sql
+++ b/modules/t/test-genome-DBs/multi/production/table.sql
@@ -153,6 +153,7 @@ CREATE TABLE `master_biotype` (
   `description` text,
   `biotype_group` enum('coding','pseudogene','snoncoding','lnoncoding','mnoncoding','LRG','undefined','no_group') DEFAULT NULL,
   `so_acc` varchar(64) DEFAULT NULL,
+  `so_term` varchar(1023) DEFAULT NULL,
   `created_by` int(11) DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `modified_by` int(11) DEFAULT NULL,
@@ -216,7 +217,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(255)),
   KEY `species_value_idx` (`species_id`,`meta_value`(255))
-) ENGINE=MyISAM AUTO_INCREMENT=63 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=64 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_key` (
   `meta_key_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -291,7 +292,7 @@ CREATE ALGORITHM=UNDEFINED DEFINER=`ensadmin`@`%` SQL SECURITY INVOKER VIEW `att
 
 CREATE ALGORITHM=UNDEFINED DEFINER=`ensadmin`@`%` SQL SECURITY INVOKER VIEW `attrib_type` AS select `master_attrib_type`.`attrib_type_id` AS `attrib_type_id`,`master_attrib_type`.`code` AS `code`,`master_attrib_type`.`name` AS `name`,`master_attrib_type`.`description` AS `description` from `master_attrib_type` where (`master_attrib_type`.`is_current` = 1) order by `master_attrib_type`.`attrib_type_id`;
 
-CREATE ALGORITHM=UNDEFINED DEFINER=`test_user`@`localhost` SQL SECURITY INVOKER VIEW `biotype` AS select `master_biotype`.`biotype_id` AS `biotype_id`,`master_biotype`.`name` AS `name`,`master_biotype`.`object_type` AS `object_type`,`master_biotype`.`db_type` AS `db_type`,`master_biotype`.`attrib_type_id` AS `attrib_type_id`,`master_biotype`.`description` AS `description`,`master_biotype`.`biotype_group` AS `biotype_group`,`master_biotype`.`so_acc` AS `so_acc` from `master_biotype` where (`master_biotype`.`is_current` = 1) order by `master_biotype`.`biotype_id`;
+CREATE ALGORITHM=UNDEFINED DEFINER=`test_user`@`localhost` SQL SECURITY INVOKER VIEW `biotype` AS select `master_biotype`.`biotype_id` AS `biotype_id`,`master_biotype`.`name` AS `name`,`master_biotype`.`object_type` AS `object_type`,`master_biotype`.`db_type` AS `db_type`,`master_biotype`.`attrib_type_id` AS `attrib_type_id`,`master_biotype`.`description` AS `description`,`master_biotype`.`biotype_group` AS `biotype_group`,`master_biotype`.`so_acc` AS `so_acc`,`master_biotype`.`so_term` AS `so_term` from `master_biotype` where (`master_biotype`.`is_current` = TRUE) order by `master_biotype`.`biotype_id`;
 
 CREATE ALGORITHM=UNDEFINED DEFINER=`ensadmin`@`%` SQL SECURITY INVOKER VIEW `db_list` AS select `db`.`db_id` AS `db_id`,concat(concat_ws('_',`species`.`db_name`,`db`.`db_type`,`db`.`db_release`,`db`.`db_assembly`),`db`.`db_suffix`) AS `full_db_name` from (`species` join `db` on((`species`.`species_id` = `db`.`species_id`))) where (`species`.`is_current` = 1);
 

--- a/modules/t/test-genome-DBs/saccharomyces_cerevisiae/core/meta.txt
+++ b/modules/t/test-genome-DBs/saccharomyces_cerevisiae/core/meta.txt
@@ -165,3 +165,4 @@
 654	\N	patch	patch_94_95_a.sql|schema_version
 655	\N	patch	patch_94_95_b.sql|vertebrate_division_rename
 656	\N	patch	patch_95_96_a.sql|schema_version
+657	\N	patch	patch_95_96_b.sql|biotype_so_term

--- a/modules/t/test-genome-DBs/saccharomyces_cerevisiae/core/table.sql
+++ b/modules/t/test-genome-DBs/saccharomyces_cerevisiae/core/table.sql
@@ -113,6 +113,7 @@ CREATE TABLE `biotype` (
   `description` text,
   `biotype_group` enum('coding','pseudogene','snoncoding','lnoncoding','mnoncoding','LRG','undefined','no_group') DEFAULT NULL,
   `so_acc` varchar(64) DEFAULT NULL,
+  `so_term` varchar(1023) DEFAULT NULL,
   PRIMARY KEY (`biotype_id`),
   UNIQUE KEY `name_type_idx` (`name`,`object_type`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
@@ -500,7 +501,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=657 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=658 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) NOT NULL,

--- a/sql/patch_95_96_b.sql
+++ b/sql/patch_95_96_b.sql
@@ -1,0 +1,86 @@
+-- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+-- Copyright [2016-2019] EMBL-European Bioinformatics Institute
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+# patch_95_96_b.sql
+#
+# Title: Add so_term column to biotype table
+#
+# Description:
+#   Update master_biotype table and biotype view to include a new so_term column.
+
+
+-- Add new column so_term
+ALTER TABLE master_biotype ADD COLUMN so_term VARCHAR(1023) AFTER so_acc;
+
+-- Populate so_term column
+UPDATE master_biotype SET so_term = 'protein_coding_gene' WHERE so_acc = 'SO:0001217';
+UPDATE master_biotype SET so_term = 'C_gene_segment' WHERE so_acc = 'SO:0000478';
+UPDATE master_biotype SET so_term = 'D_gene_segment' WHERE so_acc = 'SO:0000458';
+UPDATE master_biotype SET so_term = 'J_gene_segment' WHERE so_acc = 'SO:0000470';
+UPDATE master_biotype SET so_term = 'pseudogene' WHERE so_acc = 'SO:0000336';
+UPDATE master_biotype SET so_term = 'pseudogenic_transcript' WHERE so_acc = 'SO:0000516';
+UPDATE master_biotype SET so_term = 'V_gene_segment' WHERE so_acc = 'SO:0000466';
+UPDATE master_biotype SET so_term = 'gene_segment' WHERE so_acc = 'SO:3000000';
+UPDATE master_biotype SET so_term = 'ncRNA_gene' WHERE so_acc = 'SO:0001263';
+UPDATE master_biotype SET so_term = 'rRNA' WHERE so_acc = 'SO:0000252';
+UPDATE master_biotype SET so_term = 'tRNA' WHERE so_acc = 'SO:0000253';
+UPDATE master_biotype SET so_term = 'unconfirmed_transcript' WHERE so_acc = 'SO:0002139';
+UPDATE master_biotype SET so_term = 'lnc_RNA' WHERE so_acc = 'SO:0001877';
+UPDATE master_biotype SET so_term = 'cDNA' WHERE so_acc = 'SO:0000756';
+UPDATE master_biotype SET so_term = 'EST' WHERE so_acc = 'SO:0000345';
+UPDATE master_biotype SET so_term = 'miRNA' WHERE so_acc = 'SO:0000276';
+UPDATE master_biotype SET so_term = 'ncRNA' WHERE so_acc = 'SO:0000655';
+UPDATE master_biotype SET so_term = 'mRNA' WHERE so_acc = 'SO:0000234';
+UPDATE master_biotype SET so_term = 'retrotransposed' WHERE so_acc = 'SO:0000569';
+UPDATE master_biotype SET so_term = 'snRNA' WHERE so_acc = 'SO:0000274';
+UPDATE master_biotype SET so_term = 'snoRNA' WHERE so_acc = 'SO:0000275';
+UPDATE master_biotype SET so_term = 'three_prime_overlapping_ncrna' WHERE so_acc = 'SO:0002120';
+UPDATE master_biotype SET so_term = 'scRNA' WHERE so_acc = 'SO:0000013';
+UPDATE master_biotype SET so_term = 'RNase_MRP_RNA' WHERE so_acc = 'SO:0000385';
+UPDATE master_biotype SET so_term = 'RNase_P_RNA' WHERE so_acc = 'SO:0000386';
+UPDATE master_biotype SET so_term = 'telomerase_RNA' WHERE so_acc = 'SO:0000390';
+UPDATE master_biotype SET so_term = 'pre_miRNA' WHERE so_acc = 'SO:0001244';
+UPDATE master_biotype SET so_term = 'tmRNA' WHERE so_acc = 'SO:0000584';
+UPDATE master_biotype SET so_term = 'SRP_RNA' WHERE so_acc = 'SO:0000590';
+UPDATE master_biotype SET so_term = 'class_I_RNA' WHERE so_acc = 'SO:0000990';
+UPDATE master_biotype SET so_term = 'class_II_RNA' WHERE so_acc = 'SO:0000989';
+UPDATE master_biotype SET so_term = 'piRNA' WHERE so_acc = 'SO:0001035';
+UPDATE master_biotype SET so_term = 'CRISPR' WHERE so_acc = 'SO:0001459';
+UPDATE master_biotype SET so_term = 'vaultRNA_primary_transcript' WHERE so_acc = 'SO:0002040';
+UPDATE master_biotype SET so_term = 'guide_RNA' WHERE so_acc = 'SO:0000602';
+UPDATE master_biotype SET so_term = 'Y_RNA' WHERE so_acc = 'SO:0000405';
+UPDATE master_biotype SET so_term = 'transposable_element' WHERE so_acc = 'SO:0000101';
+UPDATE master_biotype SET so_term = 'transposable_element_gene' WHERE so_acc = 'SO:0000111';
+UPDATE master_biotype SET so_term = 'bidirectional_promoter_lncRNA' WHERE so_acc = 'SO:0002185';
+
+-- update biotype view
+ALTER VIEW biotype AS
+SELECT
+  biotype_id AS biotype_id,
+  name AS name,
+  object_type AS object_type,
+  db_type AS db_type,
+  attrib_type_id AS attrib_type_id,
+  description AS description,
+  biotype_group AS biotype_group,
+  so_acc AS so_acc,
+  so_term AS so_term
+FROM master_biotype
+WHERE is_current = true
+ORDER BY biotype_id;
+
+# Patch identifier
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_95_96_b.sql|biotype_so_term');

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -41,6 +41,8 @@ INSERT INTO meta (species_id, meta_key, meta_value)
 INSERT INTO meta (species_id, meta_key, meta_value)
   VALUES (NULL, 'patch', 'patch_94_95_b.sql|vertebrate_division_rename');
 
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_95_96_b.sql|biotype_so_term');
 
 -- The 'species' table.
 -- Lists the species for which there is a Core database.
@@ -129,6 +131,7 @@ CREATE TABLE master_biotype (
   description     TEXT,
   biotype_group   ENUM('coding','pseudogene','snoncoding','lnoncoding','mnoncoding','LRG','undefined','no_group') DEFAULT NULL,
   so_acc          VARCHAR(64),
+  so_term         VARCHAR(1023),
 
   -- Columns for the web interface:
   created_by      INT,
@@ -542,7 +545,8 @@ SELECT
   attrib_type_id AS attrib_type_id,
   description AS description,
   biotype_group AS biotype_group,
-  so_acc AS so_acc
+  so_acc AS so_acc,
+  so_term AS so_term
 FROM master_biotype
 WHERE is_current = true
 ORDER BY biotype_id;


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

This adds a new column (so_term) to the mater_biotype table.
Column is populated and test dbs patched. 

## Use case

This will allow the Biotype object in core to have the SO term in addition to the SO accession.

## Benefits

Having the SO term accessible through the Biotype removes the requirement of an OntologyTermAdaptor and an ontology db to look up such terms.

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._
A bit more data in the db...

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
