### PR TITLE
We also need to remove dependent xref that could have been linked to …

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GPAD_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GPAD_conf.pm
@@ -205,6 +205,10 @@ sub pipeline_analyses {
       -analysis_capacity => 20,
       -parameters        => {
                               sql => [
+                                'DELETE dx.* FROM '.
+                                  'dependent_xref dx LEFT OUTER JOIN '.
+                                  'object_xref ox USING (object_xref_id) '.
+                                  'WHERE ox.object_xref_id IS NULL',
                                 'DELETE onx.* FROM '.
                                   'ontology_xref onx LEFT OUTER JOIN '.
                                   'object_xref ox USING (object_xref_id) '.


### PR DESCRIPTION
…object_xref row

**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

A previous PR updated the GPAD pipeline to properly clean up old GOA data stealing code from the Protein features pipeline. I only took the cleanup of the ontology_xref table but this is not enough as sometime and object_xref can be link to an ontology_xref and dependent_xref (Thanks James for the explanation). This change make sure that we clean up dependent xrefs too. 

## Use case

All the time we run this pipeline, we need to clean up dependent xrefs too or we will endup with FK issues

## Benefits

We won't get FK error anymore after running the GPAD pipeline

## Possible Drawbacks

None really. 

## Testing

- [N ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ N] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
