### PR TITLE
Update script to avoid duplication of the word 'tables' in the legend…

### DIFF
--- a/scripts/sql2html.pl
+++ b/scripts/sql2html.pl
@@ -592,8 +592,9 @@ sub sub_table_box {
 
 sub generate_sub_diagram {
     my ($cluster, $column_links) = @_;
+    my $cluster_label = ($cluster =~ /tables$/) ? $cluster : "$cluster tables";
     my $graph = Bio::EnsEMBL::Hive::Utils::GraphViz->new(
-        'label' => "$db_team schema diagram: $cluster tables",
+        'label' => "$db_team schema diagram: $cluster_label",
         'fontsize' => 20,
         $column_links
           ? ( 'rankdir' => 'LR', 'concentrate' => 'true', )


### PR DESCRIPTION
… of the diagrams (issue for the Variation diagrams)

## Description

Remove the duplicated word `tables` in the legend of the schema diagram by checking if this word is already in the name of the group of tables.

## Use case

In Variation we already name the tables groups with the word `tables` in it and this script add this word at the end of the legend by default.

## Benefits

No more duplication!

