### PR TITLE
Account for indel variation features with seq_region_start > seq_region_end

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Production/SnpDensity.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Production/SnpDensity.pm
@@ -34,8 +34,8 @@ sub get_density {
   my $sql = q{
      SELECT count(*) FROM variation_feature
      WHERE seq_region_id = ?
-     AND seq_region_start <= ?
-     AND seq_region_end >= ? };
+     AND LEAST(seq_region_start, seq_region_end) <= ?
+     AND GREATEST(seq_region_start, seq_region_end) >= ? };
   my @params = [$block->get_seq_region_id, $block->end, $block->start];
   my $count = $helper->execute_single_result(-SQL => $sql, -PARAMS => @params);
   return $count;


### PR DESCRIPTION
## Description
Modify SQL for calculating SNP density, to account for indels.

## Use case
Indels are represented in the variation_feature table with seq_region_start > seq_region_end. The SQL in the density calculations assumed seq_region_start <= seq_region_end. This is only a problem if one boundary of the block within which the calculation are done falls exactly between the start and end of the  indel. That happens twice in the human 96 database, which means that two SNPs are not included in the density totals.

These 2 missing SNPs are not an issue for web display, because they're a drop in the ocean. But the datacheck I've just written isn't happy about the discrepancy... (The old healthcheck for this functionality arbitrarily allowed a discrepancy of up to 1000 before failing.)

## Benefits
Marginally more accurate density calculations. Datacheck passes.

## Possible Drawbacks
Possible longer runtime, for a more complex query; in practice, a few test queries suggest this is not an issue.

## Testing
No tests existed, none created.
Full test suite passes when run locally, I expect travis to fail due to unrelated, as-yet-undiagnosed, problems with master branch.

## Dependencies
None added
