### PR TITLE
switch clone branch to release/96

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
 - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-taxonomy.git
 - git clone --branch release/96 --depth 1 https://github.com/Ensembl/ensembl-metadata.git
 - git clone --branch release/96 --depth 1 https://github.com/Ensembl/ensembl-funcgen.git
-- git clone --branch develop --depth 1 https://github.com/samtools/htslib.git
+- git clone --branch 1.9 --depth 1 https://github.com/samtools/htslib.git
 - cd htslib
 - make
 - export HTSLIB_DIR=$(pwd -P)

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,16 +17,16 @@ addons:
     - emboss
 
 before_install:
-- git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-test.git
-- git clone --branch master --depth 1 https://github.com/Ensembl/ensembl.git
+- git clone --branch release/96 --depth 1 https://github.com/Ensembl/ensembl-test.git
+- git clone --branch release/96 --depth 1 https://github.com/Ensembl/ensembl.git
 - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-hive.git
-- git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-compara.git
+- git clone --branch release/96 --depth 1 https://github.com/Ensembl/ensembl-compara.git
 - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-datacheck.git
-- git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-variation.git
+- git clone --branch release/96 --depth 1 https://github.com/Ensembl/ensembl-variation.git
 - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-orm.git
 - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-taxonomy.git
-- git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-metadata.git
-- git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-funcgen.git
+- git clone --branch release/96 --depth 1 https://github.com/Ensembl/ensembl-metadata.git
+- git clone --branch release/96 --depth 1 https://github.com/Ensembl/ensembl-funcgen.git
 - git clone --branch develop --depth 1 https://github.com/samtools/htslib.git
 - cd htslib
 - make


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Travis is failing because it's using new code on ensembl master associated with release/97 production database schema changes. Travis should use release/96 branch instead of master for all the APIs repos.

## Use case

Travis is failing because it's using new code on ensembl master associated with release/97 production database schema changes. Travis should use release/96 branch instead of master for all the APIs repos.

## Benefits

Travis will work again and then we can merge the PRs.

## Possible Drawbacks

none really, except that this is not a proper fix. We should look into configuring Travis yml to work on any branches. On master, the repos should be on master. On the release branch, the repos should be on release branch. on a dev branch repos should be on branch it originated from. 

## Testing

- [N ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [Y ] Have you run the entire test suite and no regression was detected?
- [ Y] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
