### PR TITLE
Automatically checking out release branch for dependant repos when th…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,16 +17,20 @@ addons:
     - emboss
 
 before_install:
-- git clone --branch release/96 --depth 1 https://github.com/Ensembl/ensembl-test.git
-- git clone --branch release/96 --depth 1 https://github.com/Ensembl/ensembl.git
+- echo "TRAVIS_BRANCH=$TRAVIS_BRANCH"
+- export ENSEMBL_BRANCH=master
+- if [[ $TRAVIS_BRANCH =~ ^release\/[0-9]+$ ]]; then export ENSEMBL_BRANCH=$TRAVIS_BRANCH; fi
+- echo "ENSEMBL_BRANCH=$ENSEMBL_BRANCH"
+- git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-test.git
+- git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl.git
 - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-hive.git
-- git clone --branch release/96 --depth 1 https://github.com/Ensembl/ensembl-compara.git
+- git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-compara.git
 - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-datacheck.git
-- git clone --branch release/96 --depth 1 https://github.com/Ensembl/ensembl-variation.git
+- git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-variation.git
 - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-orm.git
 - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-taxonomy.git
-- git clone --branch release/96 --depth 1 https://github.com/Ensembl/ensembl-metadata.git
-- git clone --branch release/96 --depth 1 https://github.com/Ensembl/ensembl-funcgen.git
+- git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-metadata.git
+- git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-funcgen.git
 - git clone --branch 1.9 --depth 1 https://github.com/samtools/htslib.git
 - cd htslib
 - make


### PR DESCRIPTION
…e current branch is a release branch. This is to make sure Travis won't fail on release branch when master on other repos contains new commits

**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Ported Ensembl Rest repo .travis.yml to automatically checking out release branch for dependant repos when the current branch is a release branch. This is to make sure Travis won't fail on release branch when master on other repos contains new commits

## Use case

When master branch on other repos contains new feature, the release branch Travis could fail because codes don't match. On a release branch we should run Travis against release branch on all other repos

## Benefits

No hardcoded release branch name anymore. More flexible and less failure from Travis.

## Possible Drawbacks

None

## Testing

- [ N] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
