### PR TITLE
Excluding the Mouse strains from the GPAD load since we don't have GP…

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GPAD_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GPAD_conf.pm
@@ -61,7 +61,7 @@ sub default_options {
 
     ## 'job_factory' parameters
     'species'     => [], 
-    'antispecies' => [],
+    'antispecies' => [qw/mus_musculus_129s1svimj mus_musculus_aj mus_musculus_akrj mus_musculus_balbcj mus_musculus_c3hhej mus_musculus_c57bl6nj mus_musculus_casteij mus_musculus_cbaj mus_musculus_dba2j mus_musculus_fvbnj mus_musculus_lpj mus_musculus_nodshiltj mus_musculus_nzohlltj mus_musculus_pwkphj mus_musculus_wsbeij/],
     'division' 	 => [], 
     'run_all'     => 0,	
 


### PR DESCRIPTION
…AD file for them

**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

In release 96, the GPAD pipeline was updated to use species factory instead of getting list of GPAD files and processing species. As a result the mouse strains were processed, GO xrefs deleted and then no GPAD file were loaded since they don't exist...
We need to exclude the mouse strains from the config file to get around this.

## Use case

When we run the pipeline on vertebrates, we need to exclude the mouse strains.

## Benefits

Pipeline won't delete existing GO xrefs for mouse strains anymore. 

## Possible Drawbacks

None that I can think of.

## Testing

- [ N] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ N] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
