### PR TITLE
Extending regex that matches protein accessions to include hyphens

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/GPAD/LoadFile.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/GPAD/LoadFile.pm
@@ -142,7 +142,7 @@ sub run {
           $go_evidence=$annotation_propertie;
         }
         elsif ($annotation_propertie =~ m/tgt_protein/){
-          $annotation_propertie =~ s/tgt_protein=\w+://;
+          $annotation_propertie =~ s/tgt_protein=[\w\-]+://;
           $tgt_protein=$annotation_propertie;
         }
         elsif ($annotation_propertie =~ m/tgt_transcript/){
@@ -150,7 +150,7 @@ sub run {
           $tgt_transcript=$annotation_propertie;
         }
         elsif ($annotation_propertie =~ m/src_protein/){
-          $annotation_propertie =~ s/src_protein=\w+://;
+          $annotation_propertie =~ s/src_protein=[\w\-]+://;
           $src_protein=$annotation_propertie;
         }
         elsif ($annotation_propertie =~ m/src_species/){


### PR DESCRIPTION
## Description
Extending regex that matches protein accessions to include hyphens.

## Use case
Needed for successful import of plant species.

## Benefits
Pipeline won't fail...

## Testing
Pipeline with this fix ran successfully.

