### PR TITLE
Removing the database directory for a fresh dump makes the script fai…

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Utils/MySQLDumping.sh
+++ b/modules/Bio/EnsEMBL/Production/Utils/MySQLDumping.sh
@@ -7,7 +7,9 @@ user=$4
 password=$5
 port=$6
 
-rm -r "$output_dir/$database"
+if [ -d "$output_dir/$database" ]; then
+    rm -r "$output_dir/$database"
+fi
 mkdir -m 777 -p "$output_dir/$database"
 cd "$output_dir/$database"
 echo "Dumping $database";


### PR DESCRIPTION
…l over

**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

The MySQL dumping pipeline will now fail dumping any new databases since the previous fix. We need to check if the directory exist before cleaning it up

## Use case

The MySQL dumping pipeline will now fail dumping any new databases since the previous fix. We need to check if the directory exist before cleaning it up


## Benefits

We can now dump new databases

## Possible Drawbacks

none
## Testing

- [ N] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
