### PR TITLE
Disabled flush and lock for all the mart databases. The gene mart now…

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Utils/MySQLDumping.sh
+++ b/modules/Bio/EnsEMBL/Production/Utils/MySQLDumping.sh
@@ -42,11 +42,15 @@ for TABLE in "${EXCLUDED_TABLES[@]}"
 do :
    IGNORED_TABLES_STRING+=" --ignore-table=${database}.${TABLE}"
 done
-mysqldump -T ${output_dir}/${database} ${IGNORED_TABLES_STRING} --host=$host --user=$user --password=$password --port=$port $database;
+cmd_line_options=""
+if [[ $database =~ .*mart.* ]]; then
+    cmd_line_options=" --skip-lock-tables"
+fi
+mysqldump -T ${output_dir}/${database} ${IGNORED_TABLES_STRING} ${cmd_line_options} --host=$host --user=$user --password=$password --port=$port $database;
 echo "Removing the individual table sql files for $database"
 rm -f *.sql
 echo "Dumping sql file for $database";
-mysqldump --host=$host --user=$user --password=$password --port=$port ${IGNORED_TABLES_STRING} -d $database > ${output_dir}/$database/$database.sql;
+mysqldump --host=$host --user=$user --password=$password --port=$port ${IGNORED_TABLES_STRING} ${cmd_line_options} -d $database > ${output_dir}/$database/$database.sql;
 echo "Gzipping txt files";
 ls -1 | grep .txt | grep -v LOADER-LOG | while read file; do
         gzip -nc "$file" > "$output_dir/$database/$file.gz"


### PR DESCRIPTION
… contains more than 63000 tables which causes the flush and lock to run out of open tables. Copying/Dumping without lock can be dangerous if other processes are writing to the database so be careful

**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Disabled flush and lock for all the mart databases. The gene mart now contains more than 63000 tables which causes the flush and lock to run out of open tables. Copying/Dumping without lock can be dangerous if other processes are writing to the database so be careful. More details on this JIRA ticket: https://www.ebi.ac.uk/panda/jira/browse/ENSPROD-3230


## Use case

see above

## Benefits

We can now copy and dump the vertebrates gene mart. 

## Possible Drawbacks

We won't flush and lock the database before dumping/copying so we have to make sure that we don't have a process writing to it.

## Testing

- [N ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
