### PR TITLE
Checking that the target table name doesn't exceed the 64 characters …

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/CopyDatabases/CopyDatabaseHive.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/CopyDatabases/CopyDatabaseHive.pm
@@ -83,6 +83,9 @@ my $runtime =  duration(time() - $start_time);
 #Clean up if job already exist in result.
 my $sql=q/DELETE FROM result WHERE job_id = ?/;
 $hive_dbc->sql_helper()->execute_update(-SQL=>$sql,-PARAMS=>[$self->input_job()->dbID()]);
+#Same for job_progress
+my $sql=q/DELETE FROM job_progress WHERE job_id = ?/;
+$hive_dbc->sql_helper()->execute_update(-SQL=>$sql,-PARAMS=>[$self->input_job()->dbID()]);
 my $output = {
 		  source_db_uri=>$source_db_uri,
 		  target_db_uri=>$target_db_uri,


### PR DESCRIPTION
…limit from MySQL, doing this check very early to avoid creating temp file on the server that need to be cleaned up by DBA. Increased space left after copy from 10% to 20% to match DBA policy guidelines. Extended check_space_before_copy to also check copy via mysqldumps. Added Pre-Copy Checks at the start of the copy to have something displayed on the interface while we are doing checks and prep for copy. Cleaning up job_progress table to avoid wrong progress when re-running an existing job

**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Checking that the target table name doesn't exceed the 64 characters limit from MySQL, doing this check very early to avoid creating temp file on the server that need to be cleaned up by DBA. Increased space left after copy from 10% to 20% to match DBA policy guidelines (https://tsc.ebi.ac.uk/article/policy-ensembl-specific-direct-file-copies). Extended check_space_before_copy to also check copy via mysqldumps. Added Pre-Copy Checks at the start of the copy to have something displayed on the interface while we are doing checks and prep for copy. Cleaning up job_progress table to avoid wrong progress when re-running an existing job

See this ticket for details: https://www.ebi.ac.uk/panda/jira/browse/ENSPROD-3462


## Use case

This was spotted after Jose tried to copy a database with target name jcmarca_homo_sapiens_funcgen_97_37_linked_ctls_fixed exceeding the MySQL 64 char limit. The copy failed but DBA had to cleanup files created by the copy script. 

## Benefits

We can now check that database name doesn't exceed MySQL limit. We can also check size of database when doing MySQL dumps

## Possible Drawbacks

None.

## Testing

- [ N] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
