### PR TITLE
ls -1 doesn't work in a directory with too many files: Argument list …

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Utils/MySQLDumping.sh
+++ b/modules/Bio/EnsEMBL/Production/Utils/MySQLDumping.sh
@@ -62,7 +62,7 @@ if [ -e "$database.sql" ]; then
     rm -f $database.sql
 fi
 echo "Creating CHECKSUM for $database"
-ls -1 *.gz | while read file; do
+find  -type f -name '*.gz' -printf '%P\n' | while read file; do
     sum=$(sum $file)
     echo -ne "$sum\t$file\n" >> CHECKSUMS
 done


### PR DESCRIPTION
…too long. This is causing issue when creating CHECKSUMS for the vertebrates gene mart 96. Replacing with find seems to be faster and works for the gene mart

**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

ls -1 doesn't work in a directory with too many files: Argument list too long. This is causing issue when creating CHECKSUMS for the vertebrates gene mart 96. Replacing with find seems to be faster and works for the gene mart

## Use case

When creating checksums for MySQL dumps of databases with many tables.

## Benefits

We can now generate the CHECKSUMS file

## Possible Drawbacks

none

## Testing

- [ N] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
