### PR TITLE
Compara file names changed, update string to match

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/FtpChecker/CheckComparaFtp.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FtpChecker/CheckComparaFtp.pm
@@ -39,7 +39,7 @@ my $expected_files = {
 							  ]},
 		      "xml" => {"dir" => "{division}xml/ensembl-compara/homologies/", "expected" =>[
 						       'Compara.*.xml.gz',
-						       'Compara.*.phyloxml.xml.tar.gz',
+						       'Compara.*.phyloxml.xml.*.tar.gz',
 						       'README.*',
 						       'MD5SUM*'
 						      ]},


### PR DESCRIPTION
## Description
Compara phyloxml files now have ID ranges embedded in the file names. Need to adjust the pattern for matching in the FTP Checker pipeline.
