### PR TITLE
Adding analysis_capacity values for mapping modules.

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/Xref_update_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/Xref_update_conf.pm
@@ -208,12 +208,14 @@ sub pipeline_analyses {
              -rc_name    => 'normal',
              -parameters => {'base_path'   => $self->o('base_path'),
                              'release'     => $self->o('release')},
+            -analysis_capacity => 30
             },
             {-logic_name => 'process_alignment',
              -module     => 'Bio::EnsEMBL::Production::Pipeline::Xrefs::ProcessAlignment',
              -rc_name    => 'normal',
              -parameters => {'base_path'   => $self->o('base_path'),
                              'release'     => $self->o('release')},
+            -analysis_capacity => 30
             },
             {-logic_name => 'rnacentral_mapping',
              -module     => 'Bio::EnsEMBL::Production::Pipeline::Xrefs::RNAcentralMapping',
@@ -236,12 +238,14 @@ sub pipeline_analyses {
              -rc_name    => 'mem',
              -parameters => {'base_path'   => $self->o('base_path'),
                              'release'     => $self->o('release')},
+            -analysis_capacity => 30
             },
             {-logic_name => 'mapping',
              -module     => 'Bio::EnsEMBL::Production::Pipeline::Xrefs::Mapping',
              -rc_name    => 'mem',
              -parameters => {'base_path'   => $self->o('base_path'),
                              'release'     => $self->o('release')},
+            -analysis_capacity => 30
             },
             {-logic_name => 'notify_by_email',
              -module     => 'Bio::EnsEMBL::Hive::RunnableDB::NotifyByEmail',


### PR DESCRIPTION
## Description
As jobs for mapping analyses accumulate, they start to get in each other's way, since they are trying to access the same database tables, and at a critical mass average runtime increases for a while, before dropping down again as jobs complete.

## Benefits
Reduce unnecessary database load.

## Possible Drawbacks
Not aware of any.

## Testing
Pipeline not run with these settings, because to properly test would require a complete run of the pipeline, with seems a bit much. Config file initialises fine.
