### PR TITLE
Updated script to use ensembl_metadata instead of ensembl-production …

### DIFF
--- a/scripts/production_database/populate_species_meta.pl
+++ b/scripts/production_database/populate_species_meta.pl
@@ -236,15 +236,15 @@ SQL
 
 sub _meta {
   my ( $self, $db ) = @_;
-  my $production = $self->_metadata($db);
+  my $metadata = $self->_metadata($db);
   my $taxonomy   = $self->_taxonomy($db);
-  $production->{'species.classification'} = $taxonomy;
+  $metadata->{'species.classification'} = $taxonomy;
 
   $self->v('Updating meta');
   my $dba = $self->_core_dba($db);
   my $mc  = $dba->get_MetaContainer();
-  foreach my $key ( keys %{$production} ) {
-    my $array = wrap_array( $production->{$key} );
+  foreach my $key ( keys %{$metadata} ) {
+    my $array = wrap_array( $metadata->{$key} );
     $mc->delete_key($key);
     foreach my $value ( @{$array} ) {
       $mc->store_key_value( $key, $value );


### PR DESCRIPTION
…db since species data has now been retired. Removed sync of species.common_name and species.stable_id_prefix since the data is not in the metadata db. Removed sync of species.division since it's not really needed and it causes confusions for C.elegans, D.melanogaster,... I don't want to make the script more complex for this. Renamed production sub to metadata

**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

The script is now broken since we have removed the species data from the production database. This update now uses the metadata db instead.

## Use case

This script populate various meta keys and keep the taxonomy up to date.

## Benefits

Script will work again.

## Possible Drawbacks

We have lost the sync of species.common_name and species.stable_id_prefix data since it's not in metadata. I have removed sync of species.division since causes confusions for C.elegans, D.melanogaster,.. for the script

## Testing

- [ N] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
