### PR TITLE
Handle empty variation db

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Common/SpeciesFactory.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Common/SpeciesFactory.pm
@@ -169,7 +169,19 @@ sub has_variation {
   my $dbva =
     Bio::EnsEMBL::Registry->get_DBAdaptor( $species, 'variation' );
 
-  my $has_variation = defined $dbva ? 1 : 0;
+  my $has_variation;
+  if (defined $dbva){
+    my $source_database = $dbva->get_MetaContainer->list_value_by_key('variation.source.database')->[0];
+    if(defined($source_database)){
+      $has_variation = $source_database == 1 ? 1 : 0;
+    }
+    else{
+      $has_variation = 1;
+    }
+  }
+  else{
+    $has_variation = 0;
+  }
   
   $has_variation && $dbva->dbc->disconnect_if_idle();
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/VariationStatistics_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/VariationStatistics_conf.pm
@@ -81,6 +81,7 @@ sub pipeline_analyses {
                                         'SnpDensity',
                                       ],
                             'A->1' => ['GenomeStats'],
+                          },
       -rc_name         => 'normal',
     },
 


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Some variation databases are now empty since the data is coming from a VCF file. Our pipeline cannot deal with these at the moment so we should exclude them. The Variation team have introduced two new meta keys variation.source.vcf = 1/0 and variation.source.database = 1/0. Since we are only interested if the database contain data, we need to check that value of variation.source.database. Only vertebrate division has these meta key so it's important to check the existance of this meta key first. More information here: https://www.ebi.ac.uk/panda/jira/browse/ENSPROD-3161

## Use case

In release 96, Vervet monkey was the first empty variation db. In release 97 the database now has the following meta keys: 
- variation.source.vcf = 1
- variation.source.database = 0
The other vertebrates will have:
- variation.source.vcf = 0
- variation.source.database = 1
The non-vert won't have these meta keys.

## Benefits

Pipelines won't be failing on empty databases anymore.

## Possible Drawbacks

None really. In the future we could implement code to process these dbs if possible/required.

## Testing

- [ N] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
