### PR TITLE
Added PHI base ontology loading step (skip_phi parameter to skip)

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/OLSLoad_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/OLSLoad_conf.pm
@@ -65,7 +65,8 @@ sub default_options {
       'mart_db_name'  => 'ontology_mart_' . $self->o('ens_version'),
       'pipeline_name' => 'ols_ontology_' . $self->o('ens_version'),
       'db_url'        => $self->o('db_host') . $self->o('db_name'),
-      'ontologies'    => []
+      'ontologies'    => [],
+      'skip_phi'      => 0
   }
 }
 
@@ -140,7 +141,7 @@ sub pipeline_analyses {
           -flow_into  => {
               # To "fold", the fan requires access to its parent's parameters, via either INPUT_PLUS or the parameter stack
               '2->A' => { 'ontology_load' => INPUT_PLUS },
-              'A->1' => WHEN('#_list_exhausted#' => [ 'compute_closure' ], ELSE [ 'ontologies_factory' ])
+              'A->1' => WHEN('#_list_exhausted#' => [ 'phibase_init' ], ELSE [ 'ontologies_factory' ])
           }
       },
       {
@@ -170,11 +171,6 @@ sub pipeline_analyses {
           },
       },
       {
-          -logic_name      => 'dummy',
-          -module          => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
-          -max_retry_count => 1,
-      },
-      {
           -logic_name        => 'ontology_term_load',
           -module            => 'bio.ensembl.ontology.hive.OLSTermsLoader',
           -language          => 'python3',
@@ -194,6 +190,43 @@ sub pipeline_analyses {
           -rc_name         => 'default',
           -parameters      => {
               -output_dir => $self->o('output_dir')
+          }
+      },
+      {
+          -logic_name      => 'phibase_init',
+          -module          => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+          -max_retry_count => 1,
+          -flow_into       => {
+              1 => WHEN(
+                  '#skip_phi#' => [ 'compute_closure' ],
+                  ELSE [ 'phibase_load_factory' ]
+              )
+          }
+      },
+      {
+          -logic_name => 'phibase_load_factory',
+          -module     => 'Bio::EnsEMBL::Hive::RunnableDB::JobFactory',
+          -parameters => {
+              'inputlist'     => [ 0 .. 9999 ],
+              'step'          => 2000,
+              'ontology_name' => "PHI",
+              'column_names'  => [ 'term_index' ]
+          },
+          -flow_into  => {
+              '2->A' => [ 'phibase_load' ],
+              'A->1' => [ 'compute_closure' ]
+          }
+      },
+      {
+          -logic_name      => 'phibase_load',
+          -module          => 'bio.ensembl.ontology.hive.OLSLoadPhiBaseIdentifier',
+          -language        => 'python3',
+          -max_retry_count => 1,
+          -rc_name         => 'default',
+          -parameters      => {
+              'ontology_name' => "PHI",
+              'db_url'        => $self->o('db_url'),
+              'output_dir'    => $self->o('output_dir')
           }
       },
       {


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Phibase identifier were loaded after closure computation. Need to change

## Use case

Closure table don't include PHI base identifier list
## Benefits

Phi identifier are in closure => left link actively displayed on ontologies menu

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
Another PR to ols-loader to come
