### PR TITLE
Restoring ability to update a list of table in an existing database r…

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Utils/CopyDatabase.pm
+++ b/modules/Bio/EnsEMBL/Production/Utils/CopyDatabase.pm
@@ -140,7 +140,7 @@ sub copy_database {
       $target_dbh->do("DROP DATABASE IF EXISTS $target_db->{dbname};") or die $target_dbh->errstr;
     }
     # If we update or copy some tables, we need the target database on target server
-    elsif ($update){
+    elsif ($update || $opt_only_tables){
       1;
     }
     # If drop not enabled, die
@@ -346,7 +346,7 @@ sub create_temp_dir {
   if (defined($target_db_exist)) {
     # If we update the database, we don't need a tmp dir
     # We will use the dest dir instead of staging dir.
-    if ($update){
+    if ($update || $opt_only_tables){
       $staging_dir=$destination_dir;
     }
     else{
@@ -354,7 +354,7 @@ sub create_temp_dir {
       ($force,$staging_dir)=create_staging_db_tmp_dir($target_dbh,$target_db,$staging_dir,$force);
     }
   }
-  # If database don't exist on source server
+  # If database doesn't exist on target server
   else {
     # If option update is defined, the database need to exist on target server.
     if ($update){


### PR DESCRIPTION
…emoved in this PR: https://github.com/Ensembl/ensembl-production/pull/265. opt_only_tables option can now be used to either create a new database with a list of given tables or copy a list of tables to an existing database

**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Restoring ability to update a list of table in an existing database removed in this PR: https://github.com/Ensembl/ensembl-production/pull/265. opt_only_tables option can now be used to either create a new database with a list of given tables or copy a list of tables to an existing database

## Use case

This only applied if someone want to update a list of table in an existing database without re-copying all the tables.

## Benefits

After this fix opt_only_tables option can now be used to either create a new database with a list of given tables or copy a list of tables to an existing database

## Possible Drawbacks

None, as far as I know

## Testing

- [N ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
