### PR TITLE
Fixed wrong regex for embl/genbank files since files are splitted by …

### DIFF
--- a/scripts/copy_ftp_release.pl
+++ b/scripts/copy_ftp_release.pl
@@ -67,7 +67,7 @@ my $gzip_files = [
     qr/.*\.(${old_rel})\.gtf\.gz/,
     qr/.*\.(${old_rel})\.emf\.gz/,
     qr/.*\.(${old_rel})\.[a-z]+\.tsv\.gz/,
-    qr/.*\.(${old_rel})\.dat\.gz/,
+    qr/.*\.(${old_rel})\..*\.dat\.gz/,
     qr/.*\.gz/
 ];
 


### PR DESCRIPTION
…chr, like this: Homo_sapiens.GRCh38.96.chromosome.1.dat.gz

**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Regex for copying last release embl/genbank file is wrong so as a result no files get copied.

## Use case

When using the script to copy last release dumps to this release, embl/genbank files are not being processed by the script

## Benefits

The script can now copy embl/genbank files

## Possible Drawbacks

None

## Testing

- [ N] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
