### PR TITLE
Changed Default destination for dump outputs to a less "occupied" one…

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/MySQLDumping_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/MySQLDumping_conf.pm
@@ -28,36 +28,36 @@ package Bio::EnsEMBL::Production::Pipeline::PipeConfig::MySQLDumping_conf;
 use strict;
 use warnings;
 use Data::Dumper;
-use base ('Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf');  # All Hive databases configuration files should inherit from HiveGeneric, directly or indirectly
+use base ('Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf'); # All Hive databases configuration files should inherit from HiveGeneric, directly or indirectly
 use Cwd;
 
 sub resource_classes {
-    my ($self) = @_;
-    return { 'default' => { 'LSF' => '-q production-rh74' }};
+  my ($self) = @_;
+  return { 'default' => { 'LSF' => '-q production-rh74' } };
 }
 
 
 sub default_options {
-    my ($self) = @_;
-    return {
-        %{$self->SUPER::default_options},
-        	   ## General parameters
-        'user'     => $self->o('user'),
-        'pass'     => $self->o('pass'),
-        'host'     => $self->o('host'),
-        'port'     => $self->o('port'),
-        'meta_user'     => $self->o('meta_user'),
-        'meta_host'     => $self->o('meta_host'),
-        'meta_port'     => $self->o('meta_port'),
-        'meta_database' => $self->o('meta_database'),
-        'base_dir'  => $self->o('ensembl_cvs_root_dir'),
-        'pipeline_name'  => 'mysql_dumping',
-        'division' => [],
-        'base_output_dir' => '/nfs/production/ensembl/production/',
-        'release' => $self->o('release'),
-        ## 'DbDumpingFactory' parameters
-        'database'    => [],
-    }
+  my ($self) = @_;
+  return {
+      %{$self->SUPER::default_options},
+      ## General parameters
+      'user'            => $self->o('user'),
+      'pass'            => $self->o('pass'),
+      'host'            => $self->o('host'),
+      'port'            => $self->o('port'),
+      'meta_user'       => $self->o('meta_user'),
+      'meta_host'       => $self->o('meta_host'),
+      'meta_port'       => $self->o('meta_port'),
+      'meta_database'   => $self->o('meta_database'),
+      'base_dir'        => $self->o('ensembl_cvs_root_dir'),
+      'pipeline_name'   => 'mysql_dumping',
+      'division'        => [],
+      'base_output_dir' => '/nfs/production/ensembl/production/',
+      'release'         => $self->o('release'),
+      ## 'DbDumpingFactory' parameters
+      'database'        => [],
+  }
 }
 
 =head2 pipeline_wide_parameters
@@ -66,8 +66,8 @@ sub default_options {
 sub pipeline_wide_parameters {
   my ($self) = @_;
   return {
-    %{ $self->SUPER::pipeline_wide_parameters
-      } # here we inherit anything from the base class, then add our own stuff
+      %{$self->SUPER::pipeline_wide_parameters
+        } # here we inherit anything from the base class, then add our own stuff
   };
 }
 
@@ -76,47 +76,59 @@ sub pipeline_wide_parameters {
 =cut
 
 sub pipeline_analyses {
-    my ($self) = @_;
-    return [
-    {
-      -logic_name        => 'DbDumpingFactory',
-      -module            => 'Bio::EnsEMBL::Production::Pipeline::DatabaseDumping::DbDumpingFactory',
-      -max_retry_count   => 1,
-      -input_ids         => [ {} ],
-      -parameters        => {
-                              division        => $self->o('division'),
-                              database         => $self->o('database'),
-                              meta_user      => $self->o('meta_user'),
-                              meta_host      => $self->o('meta_host'),
-                              meta_port      => $self->o('meta_port'),
-                              meta_database => $self->o('meta_database'),
-                              base_output_dir => $self->o('base_output_dir'),
-                              release => $self->o('release'),
-                              user      => $self->o('user'),
-                              password      => $self->o('pass'),
-                              host      => $self->o('host'),
-                              port      => $self->o('port'),
-                            },
-      -flow_into         => {
-                              1 => 'DatabaseDump',
-                            }
-    },
-     {
-      -logic_name  => 'DatabaseDump',
-      -module      => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-      -meadow_type => 'LSF',
-      -parameters  => {
-        'cmd' =>
-'#base_dir#/ensembl-production/modules/Bio/EnsEMBL/Production/Utils/MySQLDumping.sh  #database# #output_dir# #host# #user# #password# #port#',
-        'user'      => $self->o('user'),
-        'password'      => $self->o('pass'),
-        'host'      => $self->o('host'),
-        'port'      => $self->o('port'),
-        'base_dir'  => $self->o('base_dir')
-        },
-      -rc_name          => 'default',
-      -analysis_capacity => 10
-    },
-   ];
+  my ($self) = @_;
+  return [
+      {
+          -logic_name      => 'DbDumpingFactory',
+          -module          => 'Bio::EnsEMBL::Production::Pipeline::DatabaseDumping::DbDumpingFactory',
+          -max_retry_count => 1,
+          -input_ids       => [ {} ],
+          -parameters      => {
+              division        => $self->o('division'),
+              database        => $self->o('database'),
+              meta_user       => $self->o('meta_user'),
+              meta_host       => $self->o('meta_host'),
+              meta_port       => $self->o('meta_port'),
+              meta_database   => $self->o('meta_database'),
+              base_output_dir => $self->o('base_output_dir'),
+              release         => $self->o('release'),
+              user            => $self->o('user'),
+              password        => $self->o('pass'),
+              host            => $self->o('host'),
+              port            => $self->o('port'),
+          },
+          -flow_into       => {
+              1 => 'DatabaseDump',
+          }
+      },
+      {
+          -logic_name        => 'DatabaseDump',
+          -module            => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+          -meadow_type       => 'LSF',
+          -parameters        => {
+              'cmd'      =>
+                  '#base_dir#/ensembl-production/modules/Bio/EnsEMBL/Production/Utils/MySQLDumping.sh  #database# #output_dir# #host# #user# #password# #port#',
+              'user'     => $self->o('user'),
+              'password' => $self->o('pass'),
+              'host'     => $self->o('host'),
+              'port'     => $self->o('port'),
+              'base_dir' => $self->o('base_dir')
+          },
+          -rc_name           => '16GB',
+          -analysis_capacity => 10
+      },
+  ];
+}
+
+sub resource_classes {
+  my $self = shift;
+  return {
+      'default' => { 'LSF' => '-q production-rh74 -n 4 -M 4000   -R "rusage[mem=4000]"' },
+      '16GB'    => { 'LSF' => '-q production-rh74 -n 4 -M 16000  -R "rusage[mem=16000]"' },
+      '32GB'    => { 'LSF' => '-q production-rh74 -n 4 -M 32000  -R "rusage[mem=32000]"' },
+      '64GB'    => { 'LSF' => '-q production-rh74 -n 4 -M 64000  -R "rusage[mem=64000]"' },
+      '128GB'   => { 'LSF' => '-q production-rh74 -n 4 -M 128000 -R "rusage[mem=128000]"' },
+      '256GB'   => { 'LSF' => '-q production-rh74 -n 4 -M 256000 -R "rusage[mem=256000]"' },
+  }
 }
 1;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/MySQLDumping_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/MySQLDumping_conf.pm
@@ -53,7 +53,7 @@ sub default_options {
         'base_dir'  => $self->o('ensembl_cvs_root_dir'),
         'pipeline_name'  => 'mysql_dumping',
         'division' => [],
-        'base_output_dir'     	   => '/nfs/nobackup/dba/sysmysql/',
+        'base_output_dir' => '/nfs/production/ensembl/production/',
         'release' => $self->o('release'),
         ## 'DbDumpingFactory' parameters
         'database'    => [],

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/MySQLDumping_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/MySQLDumping_conf.pm
@@ -114,7 +114,7 @@ sub pipeline_analyses {
               'port'     => $self->o('port'),
               'base_dir' => $self->o('base_dir')
           },
-          -rc_name           => '16GB',
+          -rc_name           => 'default',
           -analysis_capacity => 10
       },
   ];

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/MySQLDumping_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/MySQLDumping_conf.pm
@@ -31,11 +31,6 @@ use Data::Dumper;
 use base ('Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf'); # All Hive databases configuration files should inherit from HiveGeneric, directly or indirectly
 use Cwd;
 
-sub resource_classes {
-  my ($self) = @_;
-  return { 'default' => { 'LSF' => '-q production-rh74' } };
-}
-
 
 sub default_options {
   my ($self) = @_;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/MySQLDumping_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/MySQLDumping_conf.pm
@@ -48,7 +48,7 @@ sub default_options {
       'base_dir'        => $self->o('ensembl_cvs_root_dir'),
       'pipeline_name'   => 'mysql_dumping',
       'division'        => [],
-      'base_output_dir' => '/nfs/production/ensembl/production/',
+      'base_output_dir' => '/hps/nobackup2/production/ensembl/ensprod/release_dumps/',
       'release'         => $self->o('release'),
       ## 'DbDumpingFactory' parameters
       'database'        => [],

--- a/modules/Bio/EnsEMBL/Production/Utils/MySQLDumping.sh
+++ b/modules/Bio/EnsEMBL/Production/Utils/MySQLDumping.sh
@@ -21,12 +21,17 @@ user=$4
 password=$5
 port=$6
 
-if [ -d "$output_dir/$database" ]; then
+if [ -d "$output_dir/$database" ]
+ then
     rm -r "$output_dir/$database"
 fi
+
 mkdir -m 777 -p "$output_dir/$database"
+
 cd "$output_dir/$database"
+
 echo "Dumping $database";
+
 EXCLUDED_TABLES=(
 MTMP_probestuff_helper
 MTMP_evidence
@@ -51,7 +56,7 @@ if [[ $database =~ .*mart.* ]]; then
 fi
 
 query="show tables WHERE tables_in_${database} NOT IN (${IGNORED_TABLES_SHOW})"
-echo $query
+# echo $query
 echo "Dumping sql file for $database";
 
 mysqldump --host=$host --user=$user --password=$password --port=$port ${IGNORED_TABLES_STRING} ${cmd_line_options} -d $database | gzip > ${output_dir}/$database/$database.sql.gz
@@ -60,8 +65,10 @@ for t in $(mysql -NBA --host=$host --user=$user --password=$password --port=$por
 do
     echo "DUMPING TABLE: $database.$t"
     mysql --host=$host --user=$user --password=$password --port=$port -e "SELECT * FROM ${database}.${t}" --silent --raw --skip-column-names > ${output_dir}/$database/$t.txt
-    sed -i -e 's/NULL/\\N/g' ${output_dir}/$database/$t.txt
-    gzip ${output_dir}/$database/$t.txt
+    sed -i -e '/NULL/ s//\\N/g' ${output_dir}/$database/$t.txt
+    gzip < ${output_dir}/$database/$t.txt > ${output_dir}/$database/$t.txt.gz
+    # Remove the txt file if it exists
+    rm ${output_dir}/$database/$t.txt 2> /dev/null
 done
 
 echo "Creating CHECKSUM for $database"

--- a/modules/Bio/EnsEMBL/Production/Utils/MySQLDumping.sh
+++ b/modules/Bio/EnsEMBL/Production/Utils/MySQLDumping.sh
@@ -56,7 +56,7 @@ if [[ $database =~ .*mart.* ]]; then
 fi
 
 query="show tables WHERE tables_in_${database} NOT IN (${IGNORED_TABLES_SHOW})"
-# echo $query
+
 echo "Dumping sql file for $database";
 
 mysqldump --host=$host --user=$user --password=$password --port=$port ${IGNORED_TABLES_STRING} ${cmd_line_options} -d $database | gzip > ${output_dir}/$database/$database.sql.gz
@@ -64,11 +64,7 @@ mysqldump --host=$host --user=$user --password=$password --port=$port ${IGNORED_
 for t in $(mysql -NBA --host=$host --user=$user --password=$password --port=$port -D $database -e "${query}")
 do
     echo "DUMPING TABLE: $database.$t"
-    mysql --host=$host --user=$user --password=$password --port=$port -e "SELECT * FROM ${database}.${t}" --quick --silent --raw --skip-column-names > ${output_dir}/$database/$t.txt
-    sed -i -e '/NULL/ s//\\N/g' ${output_dir}/$database/$t.txt
-    echo "GZipping text files"
-    gzip -nc "$output_dir/$database/$t.txt" > "$output_dir/$database/$t.txt.gz"
-    rm -f "$output_dir/$database/$t.txt" 2> /dev/null
+    mysql --host=$host --user=$user --password=$password --port=$port -e "SELECT * FROM ${database}.${t}" --quick --silent --raw --skip-column-names | sed '/NULL/ s//\\N/g' |  gzip -1nc > ${output_dir}/$database/$t.txt.gz
 done
 
 echo "Creating CHECKSUM for $database"

--- a/modules/Bio/EnsEMBL/Production/Utils/MySQLDumping.sh
+++ b/modules/Bio/EnsEMBL/Production/Utils/MySQLDumping.sh
@@ -64,11 +64,11 @@ mysqldump --host=$host --user=$user --password=$password --port=$port ${IGNORED_
 for t in $(mysql -NBA --host=$host --user=$user --password=$password --port=$port -D $database -e "${query}")
 do
     echo "DUMPING TABLE: $database.$t"
-    mysql --host=$host --user=$user --password=$password --port=$port -e "SELECT * FROM ${database}.${t}" --silent --raw --skip-column-names > ${output_dir}/$database/$t.txt
+    mysql --host=$host --user=$user --password=$password --port=$port -e "SELECT * FROM ${database}.${t}" --quick --silent --raw --skip-column-names > ${output_dir}/$database/$t.txt
     sed -i -e '/NULL/ s//\\N/g' ${output_dir}/$database/$t.txt
-    gzip < ${output_dir}/$database/$t.txt > ${output_dir}/$database/$t.txt.gz
-    # Remove the txt file if it exists
-    rm ${output_dir}/$database/$t.txt 2> /dev/null
+    echo "GZipping text files"
+    gzip -nc "$output_dir/$database/$t.txt" > "$output_dir/$database/$t.txt.gz"
+    rm -f "$output_dir/$database/$t.txt" 2> /dev/null
 done
 
 echo "Creating CHECKSUM for $database"


### PR DESCRIPTION
… - Avoid using mysqldump command then

**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Don't use mysql Dump to dump sql - no need for server FILE access then.

## Use case

MYSQL dump requires that user has FILE access/grant to dump into multiple files as txt.

## Benefits

Dump directly from client node, can export wherever we want then

## Possible Drawbacks

Latency in dumping due to network

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
