### PR TITLE
Added a new option to convert InnoDB tables to MyISAM on the target d…

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/CopyDatabases/CopyDatabaseHive.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/CopyDatabases/CopyDatabaseHive.pm
@@ -48,6 +48,7 @@ my $only_tables = $self->param('only_tables');
 my $skip_tables = $self->param('skip_tables');
 my $update = $self->param('update');
 my $drop = $self->param('drop');
+my $convert_innodb = $self->param('convert_innodb');
 my $start_time = time();
 my $hive_dbc = $self->dbc;
 
@@ -77,7 +78,7 @@ if(!Log::Log4perl->initialized()) {
 
 $hive_dbc->disconnect_if_idle() if defined $hive_dbc;
 
-copy_database($source_db_uri, $target_db_uri, $only_tables, $skip_tables, $update, $drop);
+copy_database($source_db_uri, $target_db_uri, $only_tables, $skip_tables, $update, $drop, $convert_innodb);
 
 my $runtime =  duration(time() - $start_time);
 #Clean up if job already exist in result.

--- a/scripts/copy_database.pl
+++ b/scripts/copy_database.pl
@@ -28,7 +28,7 @@ my $opts = {};
 GetOptions( $opts,                 'source_db_uri=s',
             'target_db_uri=s',     'only_tables=s',
             'skip_tables=s',       'update|u',
-            'drop|d', 'verbose' );
+            'drop|d', 'convert_innodb|c', 'verbose' );
 
 if ( $opts->{verbose} ) {
   Log::Log4perl->easy_init($DEBUG);
@@ -40,9 +40,9 @@ else {
 my $logger = get_logger;
 
 if ( !defined $opts->{source_db_uri} || !defined $opts->{target_db_uri} ) {
-  croak "Usage: copy_database.pl -source_db_uri <mysql://user:password\@host:port/db_name> -target_db_uri <mysql://user:password\@host:port/db_name> [-only_tables=table1,table2] [-skip_tables=table1,table2] [-update] [-drop] [-verbose]";
+  croak "Usage: copy_database.pl -source_db_uri <mysql://user:password\@host:port/db_name> -target_db_uri <mysql://user:password\@host:port/db_name> [-only_tables=table1,table2] [-skip_tables=table1,table2] [-update] [-drop] [-convert_innodb] [-verbose]";
 }
 
 $logger->debug("Copying $opts->{source_db_uri} to $opts->{target_db_uri}");
 
-copy_database($opts->{source_db_uri}, $opts->{target_db_uri}, $opts->{only_tables}, $opts->{skip_tables}, $opts->{update}, $opts->{drop}, $opts->{verbose});
+copy_database($opts->{source_db_uri}, $opts->{target_db_uri}, $opts->{only_tables}, $opts->{skip_tables}, $opts->{update}, $opts->{drop}, $opts->{convert_innodb}, $opts->{verbose});


### PR DESCRIPTION
…atabase. This work by changing the engine in the dump file.

**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Added a new option to convert InnoDB tables to MyISAM on the target database. This work by changing the engine in the dump file.


## Use case

This is useful when copying an InnoDB to the staging servers as we don't support innoDB databases.

## Benefits

We can now copy InnoDB databases and convert them to MyISAM on the fly.

## Possible Drawbacks

None.

## Testing

- [N ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
