### PR TITLE
Revert "Updated rsync command to use ciphers when copying over ssh. The rsync …"

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Utils/CopyDatabase.pm
+++ b/modules/Bio/EnsEMBL/Production/Utils/CopyDatabase.pm
@@ -621,7 +621,9 @@ sub copy_mysql_files {
 
   push(@copy_cmd, '--whole-file', '--archive');
 
-  push (@copy_cmd, '--progress');
+  if ($verbose){
+    push (@copy_cmd, '--progress');
+  }
 
   if ($force) {
     push( @copy_cmd, '--delete', '--delete-excluded' );
@@ -635,19 +637,8 @@ sub copy_mysql_files {
   # Set files permission to 755 (rwxr-xr-x)
   push (@copy_cmd, '--chmod=Du=rwx,go=rx,Fu=rwx,go=rx');  
 
-  # -o disable compression, -x disable X11 forwarding and -T option lower CPU usage
-  # Use aes128-gcm@openssh.com cipher which goes pretty fast (~205 MB/s) compared to (~129 MB/s)
-  if (system("ssh -c aes128-gcm\@openssh.com $target_db->{host}  df -P /instances/ >/dev/null 2>&1") == 0){
-    push(@copy_cmd, '-e', q{'ssh -T -c aes128-gcm@openssh.com -o Compression=no -x'});
-  }
-  # On older server use aes128-ctr cipher instead
-  elsif (system("ssh -c aes128-ctr $target_db->{host}  df -P /instances/ >/dev/null 2>&1") == 0){
-    push(@copy_cmd, '-e', q{'ssh -T -c aes128-ctr -o Compression=no -x'});
-  }
-  # Finally on other server, do not use any ciphers
-  else{
-    push(@copy_cmd, '-e', q{'ssh -T -o Compression=no -x'});
-  }
+  # Add TCP with arcfour encryption, TCP does go pretty fast (~110 MB/s) and is a better choice in LAN situation.
+  push(@copy_cmd, '-e ssh');
 
   # If we have a subset of tables to copy
   if ( defined($opt_only_tables) ) {
@@ -700,6 +691,7 @@ sub copy_mysql_files {
 
   # For debugging:
   # print( join( ' ', @copy_cmd ), "\n" );
+
   my $copy_failed = 0;
   if ( system(@copy_cmd) != 0 ) {
      $logger->info("Failed to copy database. Please clean up $staging_dir (if needed).");


### PR DESCRIPTION
Reverts Ensembl/ensembl-production#275.
Found issues when copying between mysql-ens-meta-prod-1 and mysql-ens-sta-1. I don't know what is going on but need to investigate further