### PR TITLE
The param used by SpeciesNoOrthologs was not the right one, as a resu…

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Ortholog/SpeciesNoOrthologs.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Ortholog/SpeciesNoOrthologs.pm
@@ -45,7 +45,7 @@ use base('Bio::EnsEMBL::Production::Pipeline::Common::Base');
 sub run {
     my ($self) = @_;
     #Getting the list of all species, output dir and release
-    my $all_species = $self->param('species');
+    my $all_species = $self->param('all_species');
     my @all_projected_species=();
     my $datestring  = localtime();
     my $output_dir  = $self->param('output_dir');
@@ -83,6 +83,10 @@ sub run {
       $meta_container->dbc->disconnect_if_idle()
     }
     close FILE;
+    my $count_line = `wc -l < $output_file`;
+    if ($count_line <= 3 and scalar @species_without_orthologs != 0){
+      $self->throw("$output_file is empty");
+    }
 	  $self->dataflow_output_id( {  'output_dir'     => $output_dir },
 				   1 );
 return;


### PR DESCRIPTION
…lt no species were dumped into the genome_no_orthologs.txt file. Added a check if we have less than 3 lines which are timestamp, release and division dump location. This file is empty for Plants and that is ok since we project all the plants

**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description
In release 97, the hc spotted that some Protists that got renamed had no GO xrefs. This is because of a bug in DumpOrthologs pipeline since release 93. The wrong param was used so no files were generated.
See for details: https://www.ebi.ac.uk/panda/jira/browse/ENSPROD-3590


## Use case

This only affect species were we don't get GO xrefs via projections so mainly Fungi, protists and Metazoa.

## Benefits

The pipeline now works as expected.

## Possible Drawbacks

None

## Testing

- [N ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
