### PR TITLE
Minor changes to species factory. Itroduced new 15GB memory and incre…

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Common/SpeciesFactory.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Common/SpeciesFactory.pm
@@ -168,10 +168,9 @@ sub has_variation {
   my ( $self, $species ) = @_;
   my $dbva =
     Bio::EnsEMBL::Registry->get_DBAdaptor( $species, 'variation' );
-
   my $has_variation;
   if (defined $dbva){
-    my $source_database = $dbva->get_MetaContainer->list_value_by_key('variation.source.database')->[0];
+    my $source_database = $dbva->get_MetaContainer->single_value_by_key('variation.source.database');
     if(defined($source_database)){
       $has_variation = $source_database == 1 ? 1 : 0;
     }

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_conf.pm
@@ -150,6 +150,7 @@ sub resource_classes {
     my $self = shift;
     return {
       'default'  	=> {'LSF' => '-q production-rh74 -n 4 -M 4000   -R "rusage[mem=4000]"'},
+      '15GB'      => {'LSF' => '-q production-rh74 -n 4 -M 15000   -R "rusage[mem=15000]"'},
       '32GB'  	 	=> {'LSF' => '-q production-rh74 -n 4 -M 32000  -R "rusage[mem=32000]"'},
       '64GB'  	 	=> {'LSF' => '-q production-rh74 -n 4 -M 64000  -R "rusage[mem=64000]"'},
       '128GB'  	 	=> {'LSF' => '-q production-rh74 -n 4 -M 128000 -R "rusage[mem=128000]"'},
@@ -205,6 +206,7 @@ sub pipeline_analyses {
        -module     => 'Bio::EnsEMBL::Production::Pipeline::Common::ChksumGenerator',
        -wait_for   => $pipeline_flow,
        -hive_capacity => 10,
+       -rc_name       => '15GB'
     },
 ### GTF
 	{ -logic_name     => 'dump_gtf',


### PR DESCRIPTION
…ased memory for ChksumGenerator as it ran out of memory for Protists in 97

**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Checksumgenerator ran out of space for protists in release 97. Since this analysis doesn't quite need the next available resource of 32GB, I've introduced a new 15GB.
Also did a minor change to the species factory to tidy things up

## Use case

When we run the pipeline during release process.

## Benefits

Job will not run out of memory again

## Possible Drawbacks

none

## Testing

- [N] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
