### PR TITLE
Renamed all the analysis to remove the dump_ prefix. We now have json…

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_non_vertebrates_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_non_vertebrates_conf.pm
@@ -43,7 +43,7 @@ sub default_options {
        %{ $self->SUPER::default_options() }, 
 	   'perl_command'  		 => 'perl',
 	   'blast_header_prefix' => 'EG:',
-      ## dump_gff3 & dump_gtf parameter
+      ## gff3 & gtf parameter
       'abinitio'        => 0,
       # Previous release FASTA DNA files location
       'prev_rel_dir' => '/nfs/ensemblgenomes/ftp/pub/',
@@ -67,7 +67,7 @@ sub pipeline_analyses {
         }
         # Else, we run all the dumps
         else {
-          $pipeline_flow  = ['dump_json','dump_gtf', 'dump_gff3', 'dump_embl', 'dump_genbank', 'dump_chain', 'dump_tsv_uniprot', 'dump_tsv_ena', 'dump_tsv_metadata', 'dump_tsv_refseq', 'dump_tsv_entrez', 'dump_rdf'];
+          $pipeline_flow  = ['json','gtf', 'gff3', 'embl', 'genbank', 'assembly_chain', 'tsv_uniprot', 'tsv_ena', 'tsv_metadata', 'tsv_refseq', 'tsv_entrez', 'rdf'];
         }
     
     my %analyses_by_name = map {$_->{'-logic_name'} => $_} @$super_analyses;
@@ -94,10 +94,12 @@ sub tweak_analyses {
     ## Removed unused dataflow
     $analyses_by_name->{'concat_fasta'}->{'-flow_into'} = { };
     $analyses_by_name->{'primary_assembly'}->{'-wait_for'} = [];
-    $analyses_by_name->{'job_factory'}->{'-flow_into'} = {
-                '2'    => $pipeline_flow,
-							  '2->A' => ['dump_fasta_dna','dump_fasta_pep'],
-							  'A->2' => ['convert_fasta'],
+    $analyses_by_name->{'checksum_generator'}->{'-wait_for'} = ['convert_fasta'];
+    $analyses_by_name->{'backbone_job_pipeline'}->{'-flow_into'} = {
+                '1->A' => $pipeline_flow,
+                'A->1' => ['checksum_generator'],
+                '1->B' => ['fasta_dna','fasta_pep'],
+							  'B->1' => ['convert_fasta'],
 							 };   
 
     return;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_vertebrates_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_vertebrates_conf.pm
@@ -125,6 +125,35 @@ sub pipeline_analyses {
         -can_be_empty => 1,
       },
 
+      {
+          -logic_name        => 'ChecksumGeneratorBLAT',
+          -parameters => {
+                            dir => $self->o('ftp_dir')."/vertebrates/blat/dna/"
+          },
+          -wait_for => 'checksum_generator',
+          -module            => 'Bio::EnsEMBL::Production::Pipeline::Common::ChecksumGenerator',
+          -analysis_capacity => 10,
+      },
+      {
+          -logic_name        => 'ChecksumGeneratorBLASTGENE',
+                    -parameters => {
+                            dir => $self->o('ftp_dir')."/vertebrates/ncbi_blast/genes/"
+          },
+          -wait_for => 'checksum_generator',
+          -module            => 'Bio::EnsEMBL::Production::Pipeline::Common::ChecksumGenerator',
+          -analysis_capacity => 10,
+      },
+            {
+          -logic_name        => 'ChecksumGeneratorBLASTGENOMIC',
+                    -parameters => {
+                            dir => $self->o('ftp_dir')."/vertebrates/ncbi_blast/genomic/"
+          },
+          -wait_for => 'checksum_generator',
+          -module            => 'Bio::EnsEMBL::Production::Pipeline::Common::ChecksumGenerator',
+          -analysis_capacity => 10,
+      },
+
+
     ];
 }
 
@@ -134,7 +163,8 @@ sub tweak_analyses {
 
     ## Extend this section to redefine portion some analysis
     $analyses_by_name->{'concat_fasta'}->{'-flow_into'}   = { 1 => [qw/index_ncbiblastDNA index_BlatDNAIndex primary_assembly/] };
-    $analyses_by_name->{'dump_fasta_pep'}->{'-flow_into'} = { 2 => ['index_ncbiblastPEP'], 3 => ['index_ncbiblastGENE'] };
+    $analyses_by_name->{'fasta_pep'}->{'-flow_into'} = { 2 => ['index_ncbiblastPEP'], 3 => ['index_ncbiblastGENE'] };
+    $analyses_by_name->{'job_factory'}->{'-flow_into'} = { '2' => 'backbone_job_pipeline', '1' => ['ChecksumGeneratorBLAT','ChecksumGeneratorBLASTGENE','ChecksumGeneratorBLASTGENOMIC'] };
 }
 
 


### PR DESCRIPTION
… instead of dump_json. Optimized RDF dumps, now using default memory for most of the jobs, then 15GB, 32GB and finally 64GB. Optimized json and RDF dumps, to try 15GB before 32GB since 32GB and 64GB queues are hard to get on it. Changed how we generate checksums as we can't run checksum in the dump_path anymore since we have many divisions and other dumps in /hps/nobackup2, checksums are now generated on a species basis and only for dumps generated by the pipeline. There are extra code for Blat, ncbi_blast since we have all the species into the main directory and fasta_blast are not in the list of dumps for non-vert.

**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Renamed all the analysis to remove the dump_ prefix. We now have json instead of dump_json. Optimized RDF dumps, now using default memory for most of the jobs, then 15GB, 32GB and finally 64GB. Optimized json and RDF dumps, to try 15GB before 32GB since 32GB and 64GB queues are hard to get on it. Changed how we generate checksums as we can't run checksum in the dump_path anymore since we have many divisions and other dumps in /hps/nobackup2, checksums are now generated on a species basis and only for dumps generated by the pipeline. There are extra code for Blat, ncbi_blast since we have all the species into the main directory and fasta_blast are not in the list of dumps for non-vert.
Checksums were generated with a chmod making them non-group writable which is what we want to avoid...
The pipeline layout has changed, please see attached screenshot.


## Use case

We have multiple issues here. For RDF the 64GB queue is really hard to get onto and most species don't need that much memory. For checksums are current system doesn't work anymore in the new /hps/nobackup2 since we now have all the divisions and other type of dumps like compara, variation.
For json we can run many species on less memory. 

## Benefits

The pipeline will be more efficient at generating checksums and it will now work in all situation. RDF dumping will be more efficient too since we will manage memory in a better way.

## Possible Drawbacks

Adding new dumps with subdirectories might requires changes to the ChksumGenerator but I am not sure there are any plans for new dumps at the moment.

## Testing

Tested on a sample of vert and non-vert including collections using 97 data.

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
