### PR TITLE
Updated configuration for mysql dumps:

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/DatabaseDumping/DbDumpingFactory.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/DatabaseDumping/DbDumpingFactory.pm
@@ -44,13 +44,14 @@ sub run {
   my $database = $self->param('database');
   my $release = $self->param('release');
   my $base_output_dir = $self->param('base_output_dir');
+  my $isGrch37 = $self->param('isGrch37');
 
   #Connect to the metadata database
   my $dba = Bio::EnsEMBL::MetaData::DBSQL::MetaDataDBAdaptor->new(
-          -USER=>$self->param('meta_user'),
-          -HOST=> $self->param('meta_host'),
-          -PORT=>$self->param('meta_port'),
-          -DBNAME=>$self->param('meta_database'),
+      -USER   => $self->param('meta_user'),
+      -HOST   => $self->param('meta_host'),
+      -PORT   => $self->param('meta_port'),
+      -DBNAME => $self->param('meta_database'),
   );
   #Get metadata adaptors
   my $gcdba = $dba->get_GenomeComparaInfoAdaptor();
@@ -58,80 +59,98 @@ sub run {
   my $dbdba = $dba->get_DatabaseInfoAdaptor();
   my $rdba = $dba->get_DataReleaseInfoAdaptor();
   #Get and set release
-  my ($release_num,$release_info);
-  ($rdba,$gdba,$release_num,$release_info) = fetch_and_set_release($release,$rdba,$gdba);
+  my ($release_num, $release_info);
+  ($rdba, $gdba, $release_num, $release_info) = fetch_and_set_release($release, $rdba, $gdba);
 
   # Either dump databases from databases array or loop through divisions
   if (@$database) {
     #Dump given databases
-    foreach my $db (@$database){
+    foreach my $db (@$database) {
       if (scalar @$division > 1) {
         die "Please run a separare pipeline for each divisions";
       }
-      my ($division_short_name,$division_name)=process_division_names($division->[0]);
-      my $dir_release = directory_release($division_short_name,$release_info);
-      $self->dataflow_output_id({
-            database=>$db,
-            output_dir => $base_output_dir.'/release-'.$dir_release.'/'.$division_short_name.'/mysql/',
-            }, 1);
+      my ($division_short_name, $division_name) = process_division_names($division->[0]);
+      my $dir_release = directory_release($division_short_name, $release_info);
+      if ($isGrch37 == 1) {
+        $self->dataflow_output_id({
+            database   => $db,
+            output_dir => $base_output_dir . '/grch37/release-' . $dir_release . '/mysql/',
+        }, 1);
+
+      }
+      else {
+        $self->dataflow_output_id({
+            database   => $db,
+            output_dir => $base_output_dir . '/release-' . $dir_release . '/' . $division_short_name . '/mysql/',
+        }, 1);
+      }
     }
   }
-  else{
+  else {
     #Foreach divisions, get all the genomes and then databases associated.
     # Get the compara databases and other databases like mart
-    foreach my $div (@$division){
-      my ($division_short_name,$division_name)=process_division_names($div);
+    foreach my $div (@$division) {
+      my ($division_short_name, $division_name) = process_division_names($div);
       my $division_databases;
       my $genomes = $gdba->fetch_all_by_division($division_name);
-      my $dir_release = directory_release($division_short_name,$release_info);
+      my $dir_release = directory_release($division_short_name, $release_info);
       #Genome databases
-      foreach my $genome (@$genomes){
-        foreach my $database (@{$genome->databases()}){
-          push (@$division_databases,$database->dbname);
+      foreach my $genome (@$genomes) {
+        foreach my $database (@{$genome->databases()}) {
+          push(@$division_databases, $database->dbname);
         }
       }
       #release and mart databases
-      foreach my $release_database (@{$dbdba->fetch_databases_DataReleaseInfo($release_info,$division_name)}){
-        if ($division_short_name eq "pan"){
-          if (check_if_db_exists($self,$release_database)){
-            push (@$division_databases,$release_database->dbname);
+      foreach my $release_database (@{$dbdba->fetch_databases_DataReleaseInfo($release_info, $division_name)}) {
+        if ($division_short_name eq "pan") {
+          if (check_if_db_exists($self, $release_database)) {
+            push(@$division_databases, $release_database->dbname);
           }
-          else{
-            $self->warning("Can't find ".$release_database->dbname." on server: ".$self->param('host'));
+          else {
+            $self->warning("Can't find " . $release_database->dbname . " on server: " . $self->param('host'));
           }
         }
-        else{
-          push (@$division_databases,$release_database->dbname);
+        else {
+          push(@$division_databases, $release_database->dbname);
         }
       }
       # For vertebrates, we want the pan databases in the same directory
-      if ($division_short_name eq "vertebrates"){
-        foreach my $release_database (@{$dbdba->fetch_databases_DataReleaseInfo($release_info,"EnsemblPan")}){
-          if (check_if_db_exists($self,$release_database)){
-            push (@$division_databases,$release_database->dbname);
+      if ($division_short_name eq "vertebrates") {
+        foreach my $release_database (@{$dbdba->fetch_databases_DataReleaseInfo($release_info, "EnsemblPan")}) {
+          if (check_if_db_exists($self, $release_database)) {
+            push(@$division_databases, $release_database->dbname);
           }
-          else{
-            $self->warning("Can't find ".$release_database->dbname." on server: ".$self->param('host'));
+          else {
+            $self->warning("Can't find " . $release_database->dbname . " on server: " . $self->param('host'));
           }
         }
       }
       #compara databases
-      foreach my $compara_database (@{$gcdba->fetch_division_databases($division_name,$release_info)}){
-        push (@$division_databases,$compara_database);
+      foreach my $compara_database (@{$gcdba->fetch_division_databases($division_name, $release_info)}) {
+        push(@$division_databases, $compara_database);
       }
-      foreach my $division_database (uniq(@$division_databases)){
+      foreach my $division_database (uniq(@$division_databases)) {
+        if ($isGrch37 == 1) {
           $self->dataflow_output_id({
-          database=>$division_database,
-          output_dir => $base_output_dir.'/release-'.$dir_release.'/'.$division_short_name.'/mysql/',
+              database   => $db,
+              output_dir => $base_output_dir . '/grch37/release-' . $dir_release . '/mysql/',
           }, 1);
+
+        }
+        else {
+          $self->dataflow_output_id({
+              database   => $division_database,
+              output_dir => $base_output_dir . '/release-' . $dir_release . '/' . $division_short_name . '/mysql/',
+          }, 1);
+        }
       }
     }
   }
 }
 # Check if a database exist on the mysql server
 sub check_if_db_exists {
-  my ($self,$database_name)=@_;
-  my $database=$database_name->dbname;
+  my ($self, $database_name) = @_;
+  my $database = $database_name->dbname;
   my $host = $self->param('host');
   my $port = $self->param('port');
   my $pass = $self->param('password');
@@ -142,12 +161,12 @@ sub check_if_db_exists {
 # Get the directory release number for each division
 # E.g 97 for vertebrates and 44 for non-vertebrates
 sub directory_release {
-  my ($division,$release) = @_;
+  my ($division, $release) = @_;
   my $dir_release;
-  if ($division eq 'vertebrates'){
+  if ($division eq 'vertebrates') {
     $dir_release = $release->ensembl_version;
   }
-  else{
+  else {
     $dir_release = $release->ensembl_genomes_version;
   }
   return $dir_release;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/MySQLDumping_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/MySQLDumping_conf.pm
@@ -52,6 +52,7 @@ sub default_options {
       'release'         => $self->o('release'),
       ## 'DbDumpingFactory' parameters
       'database'        => [],
+      'isGrch37'        => 0
   }
 }
 
@@ -91,6 +92,7 @@ sub pipeline_analyses {
               password        => $self->o('pass'),
               host            => $self->o('host'),
               port            => $self->o('port'),
+              isGrch37        => $self->o('isGrch37')
           },
           -flow_into       => {
               1 => 'DatabaseDump',

--- a/modules/Bio/EnsEMBL/Production/Utils/MySQLDumping.sh
+++ b/modules/Bio/EnsEMBL/Production/Utils/MySQLDumping.sh
@@ -64,7 +64,7 @@ mysqldump --host=$host --user=$user --password=$password --port=$port ${IGNORED_
 for t in $(mysql -NBA --host=$host --user=$user --password=$password --port=$port -D $database -e "${query}")
 do
     echo "DUMPING TABLE: $database.$t"
-    mysql --host=$host --user=$user --password=$password --port=$port -e "SELECT * FROM ${database}.${t}" --quick --silent --raw --skip-column-names | sed '/NULL/ s//\\N/g' |  gzip -1nc > ${output_dir}/$database/$t.txt.gz
+    mysql --host=$host --max_allowed_packet=512M --user=$user --password=$password --port=$port -e "SELECT * FROM ${database}.${t}" --quick --silent --raw --skip-column-names | sed '/NULL/ s//\\N/g' |  gzip -1nc > ${output_dir}/$database/$t.txt.gz
 done
 
 echo "Creating CHECKSUM for $database"


### PR DESCRIPTION
- increased mx_packet_size to 512Mb
- changed DbDumpingFactory to accept isGrch37 flag
-

**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Added GRch37 dedicated FTP layout output for dump
Increased packet size because it causes failure for some Dbs.

## Use case

N/A

## Benefits

MySQL dumps Grch in the right place, and don't fail with reaching max allowed packet size

## Possible Drawbacks

Max packet_size may have an undesirable impact. 

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
