### PR TITLE
Added new step to sync the external_db data from the ensembl-producti…

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GeneTreeHighlighting_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GeneTreeHighlighting_conf.pm
@@ -46,9 +46,8 @@ sub default_options {
     antispecies  => [],
     meta_filters => {},
     production_db => 'ensembl_production',
-    production_host => 'mysql-ens-meta-prod-1-ensprod',
-    compara_db => '',
-    compara_host => 'mysql-ens-sta-3',
+    production_host => 'meta1',
+    compara_host => 'st3-w',
 
     ## Allow division of compara database to be explicitly specified
     compara_division => undef,


### PR DESCRIPTION
…on database to the compara database since this data is required by the pipeline.

**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

The Gene Tree Highlighting Pipeline require the external_db data from the production database to be in the compara database before running. Since we have stopped cronjobs to sync this table daily, we now need to sync it before running the pipeline.

## Use case

We need this table to be present and populated when running the Gene Tree Highlighting Pipeline.

## Benefits

The pipeline can now run without failures.

## Possible Drawbacks

We need mysql command in order to be able to run this pipeline. It won't be a problem for most people.

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
