### PR TITLE
Removing old VEP dumps hack now that we have a unified FTP layout

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/FtpChecker/CheckCoreFtp.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FtpChecker/CheckCoreFtp.pm
@@ -51,7 +51,7 @@ my $expected_files = {
 							 'README*',
 							 'CHECKSUMS*'
 						       ]},
-		      "vep" => {"dir" => "{division}/vep/{collection_dir}", "expected" =>[
+		      "vep" => {"dir" => "{division}/variation/vep/{collection_dir}", "expected" =>[
 							'{species}_vep*.tar.gz',
 							 'CHECKSUMS*'
 						       ]},
@@ -93,11 +93,6 @@ my $expected_files = {
 							 'README*',
 							 'CHECKSUMS*'
 						       ]},
-#		      "fasta_ncrna" => {"dir" => "{division}/fasta/{species_dir}/ncrna/", "expected" =>[
-#							'{species_uc}.*.fa.gz',
-#							 'README*',
-#							 'CHECKSUMS*'
-#						       ]},
 		      "fasta_dna" => {"dir" => "{division}/fasta/{species_dir}/dna/", "expected" =>[
 							'{species_uc}.*.fa.gz',
 							 'README*',

--- a/modules/Bio/EnsEMBL/Production/Pipeline/FtpChecker/CheckFtp.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FtpChecker/CheckFtp.pm
@@ -39,13 +39,6 @@ sub check_files {
   while( my($format) = each %$expected_files) { 
     for my $file (@{$expected_files->{$format}->{expected}}) {
       my $path =  _expand_str($base_path.'/'.$expected_files->{$format}->{dir}.'/'.$file, $vals);
-      if ($format eq "vep" and $vals->{division} eq ""){
-        $path = _expand_str($base_path.'/variation/'.$expected_files->{$format}->{dir}.'/'.$file, $vals);
-        $path =~ s/vep/VEP/;
-      }
-      else{
-        $path = _expand_str($base_path.'/'.$expected_files->{$format}->{dir}.'/'.$file, $vals);
-      }
       my @files = glob($path);
       if(scalar(@files) == 0) {
 	$self->{logger}->error("Could not find $path");


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

The VEP dumps used to be in /vep for non-vert and /variation/VEP for vert. There was a hack in place to work for all the divisions. Now we have a unified layout variation/vep. The code needs to be updated to work on the new layout.

## Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._

## Benefits

Pipeline would report non-issue otherwise.

## Possible Drawbacks

None
## Testing

- [ N] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
