### PR TITLE
Blat update

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/FASTA/BlatIndexer.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FASTA/BlatIndexer.pm
@@ -75,26 +75,6 @@ use File::stat;
 use Bio::EnsEMBL::Utils::IO qw/work_with_file/;
 use Bio::EnsEMBL::Utils::Exception qw/throw/;
 
-#A hash of species names and their port numbers. The latter is
-#needed to create the final file name.
-my $species_port = {
-  'lates_calcarifer'  => 30080,
-  'Homo_sapiens'          => 30001,
-  'Mus_musculus'          => 30002,
-  'Danio_rerio'           => 30003,
-  'Rattus_norvegicus'     => 30005,
-  'Gallus_gallus'         => 30010,
-  'Canis_familiaris'      => 30013,
-  'Bos_taurus'            => 30017,
-  'Oryctolagus_cuniculus' => 30025,
-  'Oryzias_latipes'       => 30026,
-  'Sus_scrofa'            => 30039,
-  'Meleagris_gallopavo'   => 30064,
-  'Anas_platyrhynchos'    => 30066,
-  'Ovis_aries'            => 30068,
-  'Oreochromis_niloticus' => 30072,
-  'Gadus_morhua'          => 30071,
-};
 
 sub param_defaults {
   my ($self) = @_;
@@ -180,24 +160,24 @@ sub decompress {
   return $target;
 }
 
-#Filename like 30001.Homo_sapiens.GRCh38.2bit
+# Create filename like 30001.Homo_sapiens.GRCh38.2bit
 sub target_filename {
   my ($self) = @_;
-
-  my ($name, $port, $assembly);
-  foreach my $species (keys $species_port) {
-    next if $species =! $self->web_name();
-    $name = $species;
-    $port = $species_port->{$species};
-    $assembly = $self->assembly();
-  }
-
+  my $blat_species = $self->param('blat_species');
+  my $species = $self->param('species');
+  my $name = $self->web_name();
+  my $assembly = $self->assembly();
+  my $port = $blat_species->{$species};
   return join(q{.}, $port, $name, $assembly, '2bit');
 }
 
 sub target_file {
   my ($self) = @_;
   my $target_dir = $self->target_dir();
+  my $release = $self->param('release');
+  my $division = $self->division();
+  # Remove release and division from the path as we don't want to sync these files to the FTP site.
+  $target_dir =~ s/release-${release}\/${division}//;
   my $target_filename = $self->target_filename();
   return File::Spec->catfile($target_dir, $target_filename);
   return;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/FASTA/BlatIndexer.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FASTA/BlatIndexer.pm
@@ -75,6 +75,27 @@ use File::stat;
 use Bio::EnsEMBL::Utils::IO qw/work_with_file/;
 use Bio::EnsEMBL::Utils::Exception qw/throw/;
 
+#A hash of species names and their port numbers. The latter is
+#needed to create the final file name.
+my $species_port = {
+  'lates_calcarifer'  => 30080,
+  'Homo_sapiens'          => 30001,
+  'Mus_musculus'          => 30002,
+  'Danio_rerio'           => 30003,
+  'Rattus_norvegicus'     => 30005,
+  'Gallus_gallus'         => 30010,
+  'Canis_familiaris'      => 30013,
+  'Bos_taurus'            => 30017,
+  'Oryctolagus_cuniculus' => 30025,
+  'Oryzias_latipes'       => 30026,
+  'Sus_scrofa'            => 30039,
+  'Meleagris_gallopavo'   => 30064,
+  'Anas_platyrhynchos'    => 30066,
+  'Ovis_aries'            => 30068,
+  'Oreochromis_niloticus' => 30072,
+  'Gadus_morhua'          => 30071,
+};
+
 sub param_defaults {
   my ($self) = @_;
   return {
@@ -159,12 +180,19 @@ sub decompress {
   return $target;
 }
 
-#Filename like Homo_sapiens.GRCh37.2bit
+#Filename like 30001.Homo_sapiens.GRCh38.2bit
 sub target_filename {
   my ($self) = @_;
-  my $name = $self->web_name();
-  my $assembly = $self->assembly();
-  return join(q{.}, $name, $assembly, '2bit');
+
+  my ($name, $port, $assembly);
+  foreach my $species (keys $species_port) {
+    next if $species =! $self->web_name();
+    $name = $species;
+    $port = $species_port->{$species};
+    $assembly = $self->assembly();
+  }
+
+  return join(q{.}, $port, $name, $assembly, '2bit');
 }
 
 sub target_file {

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_conf.pm
@@ -102,7 +102,29 @@ sub default_options {
 	   'ucsc' 		 => 1,
        ## rdf parameters
        'xref' => 1,
-       'config_file' => $self->o('ensembl_cvs_root_dir').'/VersioningService/conf/xref_LOD_mapping.json'
+       'config_file' => $self->o('ensembl_cvs_root_dir').'/VersioningService/conf/xref_LOD_mapping.json',
+
+       ## BLAT
+       # A list of vertebrates species for which we have Blast server running with their associated port number
+       # We use this hash to filter our species which we don't need BLAT data and to have the port number in the file name
+       'blat_species' => {
+        'lates_calcarifer'      => 30080,
+        'homo_sapiens'          => 30001,
+        'mus_musculus'          => 30002,
+        'danio_rerio'           => 30003,
+        'rattus_norvegicus'     => 30005,
+        'gallus_gallus'         => 30010,
+        'canis_familiaris'      => 30013,
+        'bos_taurus'            => 30017,
+        'oryctolagus_cuniculus' => 30025,
+        'oryzias_latipes'       => 30026,
+        'sus_scrofa'            => 30039,
+        'meleagris_gallopavo'   => 30064,
+        'anas_platyrhynchos_platyrhynchos'    => 30066,
+        'ovis_aries'            => 30068,
+        'oreochromis_niloticus' => 30072,
+        'gadus_morhua'          => 30071,
+       },
 
 	};
 }
@@ -482,6 +504,9 @@ sub pipeline_analyses {
     { -logic_name      => 'concat_fasta',
       -module          => 'Bio::EnsEMBL::Production::Pipeline::FASTA::ConcatFiles',
       -can_be_empty    => 1,
+      -parameters      => {
+        blat_species => $self->o('blat_species'),
+      },
       -max_retry_count => 5,
       -priority        => 5,
       -flow_into  	   => {

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_vertebrates_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_vertebrates_conf.pm
@@ -33,7 +33,8 @@ use warnings;
 use File::Spec;
 use Data::Dumper;
 use Bio::EnsEMBL::ApiVersion qw/software_version/;
-use base ('Bio::EnsEMBL::Production::Pipeline::PipeConfig::DumpCore_conf');     
+use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
+use base ('Bio::EnsEMBL::Production::Pipeline::PipeConfig::DumpCore_conf');
    
 sub default_options {
     my ($self) = @_;
@@ -81,6 +82,7 @@ sub pipeline_analyses {
           'index' => 'dna',
           skip => $self->o('skip_blat'),
           index_masked_files => $self->o('skip_blat_masking'),
+          blat_species => $self->o('blat_species'),
         },
         -can_be_empty => 1,
         -hive_capacity => 5,
@@ -124,16 +126,6 @@ sub pipeline_analyses {
         -hive_capacity => 5,
         -can_be_empty => 1,
       },
-
-      {
-          -logic_name        => 'ChecksumGeneratorBLAT',
-          -parameters => {
-                            dir => $self->o('ftp_dir')."/vertebrates/blat/dna/"
-          },
-          -wait_for => 'checksum_generator',
-          -module            => 'Bio::EnsEMBL::Production::Pipeline::Common::ChecksumGenerator',
-          -analysis_capacity => 10,
-      },
       {
           -logic_name        => 'ChecksumGeneratorBLASTGENE',
                     -parameters => {
@@ -162,9 +154,9 @@ sub tweak_analyses {
     my $analyses_by_name = shift;
 
     ## Extend this section to redefine portion some analysis
-    $analyses_by_name->{'concat_fasta'}->{'-flow_into'}   = { 1 => [qw/index_ncbiblastDNA index_BlatDNAIndex primary_assembly/] };
+    $analyses_by_name->{'concat_fasta'}->{'-flow_into'}   = { 1 => WHEN( '#blat_species#->{#species#}' => [qw/index_ncbiblastDNA index_BlatDNAIndex primary_assembly/], ELSE [qw/index_ncbiblastDNA primary_assembly/],)};
     $analyses_by_name->{'fasta_pep'}->{'-flow_into'} = { 2 => ['index_ncbiblastPEP'], 3 => ['index_ncbiblastGENE'] };
-    $analyses_by_name->{'job_factory'}->{'-flow_into'} = { '2' => 'backbone_job_pipeline', '1' => ['ChecksumGeneratorBLAT','ChecksumGeneratorBLASTGENE','ChecksumGeneratorBLASTGENOMIC'] };
+    $analyses_by_name->{'job_factory'}->{'-flow_into'} = { '2' => 'backbone_job_pipeline', '1' => ['ChecksumGeneratorBLASTGENE','ChecksumGeneratorBLASTGENOMIC'] };
 }
 
 


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

The Web team only have BLAT servers for 16 species and human GRCh37. Generating these files for all the species is not really useful since the files are not used by the Web team and external people cannot really use them too. This change only generate Blat files for the 16 species and add the VM port number at the start of the file name. More details here: https://www.ebi.ac.uk/panda/jira/browse/ENSPROD-597


## Use case

Generate BLAT files for the Web team

## Benefits

We will only update BLAT files if assembly has changed or is updated for a small subset of species

## Possible Drawbacks

None.

## Testing

- [ N ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
