### PR TITLE
Renaming variation.source.database meta key to match new name variati…

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Common/SpeciesFactory.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Common/SpeciesFactory.pm
@@ -170,7 +170,7 @@ sub has_variation {
     Bio::EnsEMBL::Registry->get_DBAdaptor( $species, 'variation' );
   my $has_variation;
   if (defined $dbva){
-    my $source_database = $dbva->get_MetaContainer->single_value_by_key('variation.source.database');
+    my $source_database = $dbva->get_MetaContainer->single_value_by_key('variation_source.database');
     if(defined($source_database)){
       $has_variation = $source_database == 1 ? 1 : 0;
     }


### PR DESCRIPTION
…on_source.database

**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

The Core API cannot deal with the meta key variation.source.database at the moment so the Variation team have renamed it to variation_source.database

## Use case

This allow us to know if a variation database contain data or if the data is coming from a VCF file (empty variation database)

## Benefits

Our pipeline will be able to process these databases properly by ignoring them.

## Possible Drawbacks

None
## Testing

- [ N] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
