### PR TITLE
Fix datachecks for variation statistics pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/VariationStatistics_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/VariationStatistics_conf.pm
@@ -111,7 +111,9 @@ sub pipeline_analyses {
       -module          => 'Bio::EnsEMBL::Production::Pipeline::Production::GenomeStats',
       -max_retry_count => 1,
       -hive_capacity   => 50,
-      -flow_into       => ['RunDataChecks'],
+      -flow_into       => {
+                            1 => { 'RunDataChecks' => {'group' => 'core'} }
+                          },
       -rc_name         => 'normal',
     },
 
@@ -121,6 +123,7 @@ sub pipeline_analyses {
       -parameters      => {
                             datacheck_names => ['DensitySNPs', 'GenomeStatistics', 'SNPCounts'],
                             history_file    => $self->o('history_file'),
+                            registry_file   => $self->o('registry_file'),
                             failures_fatal  => 1,
                           },
       -max_retry_count => 1,


### PR DESCRIPTION
## Description
Datachecks were being run on the variation dbs, not the core dbs. Need to override the 'variation' group that is being propagated from the SpeciesFactory.

## Benefits
Datachecks get run, rather than skipped.

## Possible Drawbacks
None.

## Testing
Test pipeline run successfully.
