### PR TITLE
lates_calcarifer should not be in the BLAT list

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_conf.pm
@@ -108,7 +108,6 @@ sub default_options {
        # A list of vertebrates species for which we have Blast server running with their associated port number
        # We use this hash to filter our species which we don't need BLAT data and to have the port number in the file name
        'blat_species' => {
-        'lates_calcarifer'      => 30080,
         'homo_sapiens'          => 30001,
         'mus_musculus'          => 30002,
         'danio_rerio'           => 30003,


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Lates_calcarifer should not be in the BLAT list since Web does not need it.

## Use case

We don't need to generate BLAT files for Lates_calcarifer

## Benefits

We don't need this file...

## Possible Drawbacks

None.

## Testing

- [ N ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
