### PR TITLE
Get correct name for previous release database

### DIFF
--- a/scripts/update_mapping_set.pl
+++ b/scripts/update_mapping_set.pl
@@ -358,7 +358,8 @@ sub get_previous_dbname {
     my $previous_dbname;
     $dbname =~ /(^([a-z]+_){2,3}[a-z0-9]+_)/;
     if (!$1) { throw("Database name $dbname is not in the right format"); }
-    my $previous_release_name = $1 . (--$release);
+    my $prev_release = $release - 1;
+    (my $previous_release_name = $dbname) =~ s/_$release\_/_$prev_release\_/;
     my $previous_sth = $dbh->prepare("show databases like \'%$previous_release_name%\'");
     $previous_sth->execute();
     ($previous_dbname) = $previous_sth->fetchrow_array() ;


### PR DESCRIPTION
The regex was not generating a valid name for the previous release's database; so the script did not think it needed to do any mapping, because it's logic told it that it had a database for a brand new species.
