### PR TITLE
apply_patches.pl: Update location of ontology schema

### DIFF
--- a/scripts/apply_patches.pl
+++ b/scripts/apply_patches.pl
@@ -62,7 +62,7 @@ my $patch_dirs = {
     variation     => "$opts->{basedir}/ensembl-variation/sql",
     funcgen       => "$opts->{basedir}/ensembl-funcgen/sql",
     compara       => "$opts->{basedir}/ensembl-compara/sql",
-    ontology      => "$opts->{basedir}/ols-ensembl-loader/sql",
+    ontology      => "$opts->{basedir}/ensembl-ontology-schema/sql",
     production    => "$opts->{basedir}/ensembl-production/sql" };
 
 while (my ($type, $dir) = each %$patch_dirs) {


### PR DESCRIPTION
## Description

Have the schema patcher look for ontology patches in _ensembl-ontology-schema_ rather than _ols-ensembl-loader_.

## Use case

During a recent discussion regarding the patching of test databases in _ensembl-rest_ it has been decided to hand the ontology schema from Production back to Infrastructure because said schema is much more closely tied with Core code than with OLS.

## Benefits

Production will not have to patch test databases in _ensembl-rest_ every release.

## Possible Drawbacks

None.

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
