### PR TITLE
Mysql dumps check 98

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,11 +42,12 @@ before_install:
 - cd ..
 
 install:
-- cpanm -v --installdeps --with-recommends --notest --cpanfile ensembl/cpanfile .
-- cpanm -v --installdeps --notest --cpanfile ensembl-hive/cpanfile .
+- cpanm --sudo -v --installdeps --with-recommends --notest --cpanfile ensembl/cpanfile .
+- cpanm --sudo -v --installdeps --notest --cpanfile ensembl-hive/cpanfile .
+- cpanm --sudo -v --installdeps --notest --cpanfile ensembl-datacheck/cpanfile .
 - export PERL5LIB=$PERL5LIB:$PWD/bioperl-live
-- cpanm -v --installdeps --notest .
-- cpanm -n Devel::Cover::Report::Coveralls
+- cpanm --sudo -v --installdeps --notest .
+- cpanm --sudo -n Devel::Cover::Report::Coveralls
 - cp travisci/MultiTestDB.conf.travisci  modules/t/MultiTestDB.conf
 - mysql -u root -h localhost -e 'GRANT ALL PRIVILEGES ON *.* TO "travis"@"%"'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: perl
 
+services:
+  - mysql
+
 perl:
   - '5.14'
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/DatabaseDumping/MySQLDumpsCheck.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/DatabaseDumping/MySQLDumpsCheck.pm
@@ -1,0 +1,63 @@
+=head1 LICENSE
+
+Copyright [2018-2019] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::Production::Pipeline::DatabaseDumping::MySQLDumpsCheck;
+
+use base ('Bio::EnsEMBL::Hive::Process');
+use warnings;
+use strict;
+use Bio::EnsEMBL::DBSQL::DBConnection;
+
+sub run {
+  my ($self) = @_;
+  my $database_name = $self->param_required('database');
+  my $dump_path = $self->param_required('output_dir');
+  my $table_list_sql = qq/SELECT TABLE_NAME FROM 
+                 information_schema.tables WHERE 
+                 table_schema = '$database_name'
+  /;
+  my $dbc = Bio::EnsEMBL::DBSQL::DBConnection->new(
+    -user   => $self->param('user'),
+    -host   => $self->param('host'),
+    -port   => $self->param('port'),
+    -pass => $self->param('password'),
+    -dbname => $database_name,
+    -driver => 'mysql',
+  );
+  my $helper = $dbc->sql_helper;
+  my $tables = $helper->execute(-SQL => $table_list_sql);
+  foreach (@$tables) {
+    my $table_name = $_->[0];
+    # Check that we have a mysql dump file for each of the database table
+    my $file = $dump_path."/".$database_name."/".$table_name.".txt.gz";
+    if (! -e $file){
+      die "$table_name.txt.gz is missing from $dump_path";
+    }
+  }
+  # Check that the table.sql file exists
+  if (! -e $dump_path."/".$database_name."/".$database_name.".sql.gz"){
+    die "$database_name.sql.gz table sql file missing from $dump_path";
+  }
+  # Check that the CHECKSUMS file exists
+  if (! -e $dump_path."/".$database_name."/CHECKSUMS"){
+    die "CHECKSUMS missing from $dump_path";
+  }
+  return;
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/DatabaseDumping/MySQLDumpsCheck.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/DatabaseDumping/MySQLDumpsCheck.pm
@@ -1,18 +1,28 @@
 =head1 LICENSE
 
-Copyright [2018-2019] EMBL-European Bioinformatics Institute
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2019] EMBL-European Bioinformatics Institute
 
-Licensed under the Apache License, Version 2.0 (the 'License');
+Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an 'AS IS' BASIS,
+distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+=head1 NAME
+
+ Bio::EnsEMBL::Production::Pipeline::DatabaseDumping::MySQLDumpsCheck;
+
+=head1 DESCRIPTION
+
+This module with check that we have a MySQL dump for all the tables of a database
+It will also check that we have generated the table.sql and CHECKSUMS files.
 
 =cut
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/MySQLDumping_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/MySQLDumping_conf.pm
@@ -112,6 +112,21 @@ sub pipeline_analyses {
               'base_dir' => $self->o('base_dir')
           },
           -rc_name           => 'default',
+          -analysis_capacity => 10,
+          -flow_into       => {
+              1 => 'DumpCheck',
+          }
+      },
+      {
+          -logic_name        => 'DumpCheck',
+          -module            => 'Bio::EnsEMBL::Production::Pipeline::DatabaseDumping::MySQLDumpsCheck',
+          -rc_name           => 'default',
+          -parameters        => {
+              'user'     => $self->o('user'),
+              'password' => $self->o('pass'),
+              'host'     => $self->o('host'),
+              'port'     => $self->o('port')
+          },
           -analysis_capacity => 10
       },
   ];

--- a/modules/Bio/EnsEMBL/Production/Search/VariationFetcher.pm
+++ b/modules/Bio/EnsEMBL/Production/Search/VariationFetcher.pm
@@ -225,7 +225,7 @@ sub fetch_structural_variations_callback {
      WHERE 
        v.is_evidence = 0
        AND v.structural_variation_id between ? AND ?
-       GROUP BY v.structural_variation_id/,
+       GROUP BY v.structural_variation_id,r.name,vf.seq_region_start,vf.seq_region_end/,
       -PARAMS       => [ $min, $max ],
       -USE_HASHREFS => 1,
       -CALLBACK     => sub {


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Added a new module to the MySQL dumping pipeline to make sure that we have a MySQL dump for each table of a database, also that we have the table.sql file and the CHECKSUMS. This happened a few times for release 97/44 so it's worth having this code in 98.

## Use case

Everytime we run the MySQL dumping pipeline, we need to check the output


## Benefits

We will be sure that all the MySQL dumps are complete.


## Possible Drawbacks

None
## Testing

- [ N ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
