### PR TITLE
Pass registry with pre-existing parameter name

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/VariationStatistics_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/VariationStatistics_conf.pm
@@ -121,6 +121,7 @@ sub pipeline_analyses {
       -parameters      => {
                             datacheck_names => ['DensitySNPs', 'GenomeStatistics', 'SNPCounts'],
                             history_file    => $self->o('history_file'),
+                            registry_file   => $self->o('registry'),
                             failures_fatal  => 1,
                           },
       -max_retry_count => 1,


### PR DESCRIPTION
Small fix, the datachecks run over core databases, but need to access variation data, so need a registry defined to find the variation db.