### PR TITLE
Fixed mysql dump .. -raw parameter for \n characters.

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Utils/MySQLDumping.sh
+++ b/modules/Bio/EnsEMBL/Production/Utils/MySQLDumping.sh
@@ -64,7 +64,7 @@ mysqldump --host=$host --user=$user --password=$password --port=$port ${IGNORED_
 for t in $(mysql -NBA --host=$host --user=$user --password=$password --port=$port -D $database -e "${query}")
 do
     echo "DUMPING TABLE: $database.$t"
-    mysql --host=$host --max_allowed_packet=512M --user=$user --password=$password --port=$port -e "SELECT * FROM ${database}.${t}" --quick --silent --raw --skip-column-names | sed '/NULL/ s//\\N/g' |  gzip -1nc > ${output_dir}/$database/$t.txt.gz
+    mysql --host=$host --max_allowed_packet=512M --user=$user --password=$password --port=$port -e "SELECT * FROM ${database}.${t}" --quick --silent --skip-column-names | sed '/NULL/ s//\\N/g' |  gzip -1nc > ${output_dir}/$database/$t.txt.gz
 done
 
 echo "Creating CHECKSUM for $database"


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Escape \n characters from dump

## Use case

MySQL dumps

## Benefits

no carriage return in the middle of the dumps

## Possible Drawbacks

May slow down the dump process.


## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
