### PR TITLE
FTP Dump config tweaks

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_conf.pm
@@ -149,12 +149,13 @@ sub pipeline_wide_parameters {
 sub resource_classes {
     my $self = shift;
     return {
-      'default'  	=> {'LSF' => '-q production-rh74 -n 4 -M 4000   -R "rusage[mem=4000]"'},
-      '15GB'      => {'LSF' => '-q production-rh74 -n 4 -M 15000   -R "rusage[mem=15000]"'},
-      '32GB'  	 	=> {'LSF' => '-q production-rh74 -n 4 -M 32000  -R "rusage[mem=32000]"'},
-      '64GB'  	 	=> {'LSF' => '-q production-rh74 -n 4 -M 64000  -R "rusage[mem=64000]"'},
-      '128GB'  	 	=> {'LSF' => '-q production-rh74 -n 4 -M 128000 -R "rusage[mem=128000]"'},
-      '256GB'  	 	=> {'LSF' => '-q production-rh74 -n 4 -M 256000 -R "rusage[mem=256000]"'},
+      'default'  	=> {'LSF' => '-q production-rh74 -M 4000   -R "rusage[mem=4000]"'},
+      '8GB'       => {'LSF' => '-q production-rh74 -M 8000   -R "rusage[mem=8000]"'},
+      '15GB'      => {'LSF' => '-q production-rh74 -M 15000  -R "rusage[mem=15000]"'},
+      '32GB'  	 	=> {'LSF' => '-q production-rh74 -M 32000  -R "rusage[mem=32000]"'},
+      '64GB'  	 	=> {'LSF' => '-q production-rh74 -M 64000  -R "rusage[mem=64000]"'},
+      '128GB'  	 	=> {'LSF' => '-q production-rh74 -M 128000 -R "rusage[mem=128000]"'},
+      '256GB'  	 	=> {'LSF' => '-q production-rh74 -M 256000 -R "rusage[mem=256000]"'},
 	}
 }
 
@@ -432,7 +433,7 @@ sub pipeline_analyses {
        },
       -can_be_empty    => 1,
       -max_retry_count => 1,
-      -hive_capacity   => 10,
+      -hive_capacity   => 20,
       -priority        => 5,
       -rc_name         => 'default',
     },
@@ -449,7 +450,7 @@ sub pipeline_analyses {
                   ELSE 'copy_dna',
               )},
       -max_retry_count => 1,
-      -hive_capacity   => 10,
+      -hive_capacity   => 20,
       -priority        => 5,
       -rc_name         => 'default',
     },
@@ -463,7 +464,7 @@ sub pipeline_analyses {
       -can_be_empty    => 1,
       -flow_into       => { 1 => 'concat_fasta' },
       -max_retry_count => 1,
-      -hive_capacity   => 10,
+      -hive_capacity   => 20,
       -priority        => 5,
       -rc_name         => 'default',
     },
@@ -471,7 +472,7 @@ sub pipeline_analyses {
       -logic_name => 'copy_dna',
       -module     => 'Bio::EnsEMBL::Production::Pipeline::FASTA::CopyDNA',
       -can_be_empty => 1,
-      -hive_capacity => 10,
+      -hive_capacity => 20,
       -priority        => 5,
       -parameters => {
         ftp_dir => $self->o('prev_rel_dir'),
@@ -526,7 +527,8 @@ sub pipeline_analyses {
           release => $self->o('ensembl_release'),
           config_file => $self->o('config_file'),
        },
-      -rc_name => 'default',
+  	  -hive_capacity  => 50,
+      -rc_name => '8GB',
       # Validate both output files
       -flow_into => { '-1' => 'rdf_15GB', 2 => ['validate_rdf'], }
     },
@@ -537,6 +539,7 @@ sub pipeline_analyses {
           release => $self->o('ensembl_release'),
           config_file => $self->o('config_file'),
        },
+  	  -hive_capacity  => 50,
       -rc_name => '15GB',
       # Validate both output files
       -flow_into => { '-1' => 'rdf_32GB', 2 => ['validate_rdf'], }
@@ -548,6 +551,7 @@ sub pipeline_analyses {
           release => $self->o('ensembl_release'),
           config_file => $self->o('config_file'),
        },
+  	  -hive_capacity  => 50,
       -rc_name => '32GB',
       # Validate both output files
       -flow_into => { '-1' => 'rdf_64GB', 2 => ['validate_rdf'], }
@@ -559,6 +563,7 @@ sub pipeline_analyses {
           release => $self->o('ensembl_release'),
           config_file => $self->o('config_file'),
        },
+  	  -hive_capacity  => 50,
       -rc_name => '64GB',
       # Validate both output files
       -flow_into => { 2 => ['validate_rdf'], }

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_vertebrates_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_vertebrates_conf.pm
@@ -83,7 +83,8 @@ sub pipeline_analyses {
           index_masked_files => $self->o('skip_blat_masking'),
         },
         -can_be_empty => 1,
-        -hive_capacity => 5,
+        -analysis_capacity => 10,
+        -priority => 5,
         -rc_name => 'default',
       },
 
@@ -96,7 +97,8 @@ sub pipeline_analyses {
                           skip               => $self->o('skip_ncbiblast'), 
                           index_masked_files => $self->o('skip_ncbiblast_masking'),
                         },
-       -hive_capacity => 10,
+       -analysis_capacity => 10,
+       -priority => 5,
        -can_be_empty  => 1,
        -rc_name 	   => 'default',     
       },  
@@ -109,7 +111,8 @@ sub pipeline_analyses {
                           program  => $self->o('ncbiblast_exe'), 
                           skip     => $self->o('skip_ncbiblast'),
         },
-        -hive_capacity => 5,
+        -analysis_capacity => 10,
+        -priority => 5,
         -can_be_empty  => 1,
       },
       
@@ -121,7 +124,8 @@ sub pipeline_analyses {
                           program  => $self->o('ncbiblast_exe'), 
                           skip     => $self->o('skip_ncbiblast'),
         },
-        -hive_capacity => 5,
+        -analysis_capacity => 10,
+        -priority => 5,
         -can_be_empty => 1,
       },
 
@@ -133,6 +137,7 @@ sub pipeline_analyses {
           -wait_for => 'checksum_generator',
           -module            => 'Bio::EnsEMBL::Production::Pipeline::Common::ChecksumGenerator',
           -analysis_capacity => 10,
+          -priority => 5,
       },
       {
           -logic_name        => 'ChecksumGeneratorBLASTGENE',
@@ -142,6 +147,7 @@ sub pipeline_analyses {
           -wait_for => 'checksum_generator',
           -module            => 'Bio::EnsEMBL::Production::Pipeline::Common::ChecksumGenerator',
           -analysis_capacity => 10,
+          -priority => 5,
       },
             {
           -logic_name        => 'ChecksumGeneratorBLASTGENOMIC',
@@ -151,6 +157,7 @@ sub pipeline_analyses {
           -wait_for => 'checksum_generator',
           -module            => 'Bio::EnsEMBL::Production::Pipeline::Common::ChecksumGenerator',
           -analysis_capacity => 10,
+          -priority => 5,
       },
 
 


### PR DESCRIPTION
Remove resource requirement for 4 cores - unnecessary, and makes it harder to get high-mem nodes. Bump up the sequence dumping capacity, tweak the Blast indexing (to enable jobs to start in good time), add capacity for RDF modules (otherwise it runs amok and eats all the db connections.
