### PR TITLE
We don't dump the MTMP_* mart temp table so we should not check if th…

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/DatabaseDumping/MySQLDumpsCheck.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/DatabaseDumping/MySQLDumpsCheck.pm
@@ -40,7 +40,7 @@ sub run {
   my $table_list_sql = qq/SELECT TABLE_NAME FROM 
                  information_schema.tables WHERE 
                  table_schema = '$database_name'
-                 AND TABLE_NAME not like 'MTMP%'
+                 AND TABLE_NAME not like 'MTMP_%'
   /;
   my $dbc = Bio::EnsEMBL::DBSQL::DBConnection->new(
     -user   => $self->param('user'),

--- a/modules/Bio/EnsEMBL/Production/Pipeline/DatabaseDumping/MySQLDumpsCheck.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/DatabaseDumping/MySQLDumpsCheck.pm
@@ -40,6 +40,7 @@ sub run {
   my $table_list_sql = qq/SELECT TABLE_NAME FROM 
                  information_schema.tables WHERE 
                  table_schema = '$database_name'
+                 AND TABLE_NAME not like 'MTMP%'
   /;
   my $dbc = Bio::EnsEMBL::DBSQL::DBConnection->new(
     -user   => $self->param('user'),


### PR DESCRIPTION
…ey exists

**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

We don't dump mart temporary MTMP* tables anymore so we should not check if a dump exist for them

## Use case

When we run the MySQL dumping pipeline, we now check that we have dumped all the expected tables. There is a bug at the moment as we check for MTMP* tables that we don't dump so we end up with false positive errors

## Benefits

Check won't fail anymore on MTMP tables

## Possible Drawbacks

None

## Testing

- [ N ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
