### PR TITLE
If we get an error from the mysql command, the script doesn't return …

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Utils/MySQLDumping.sh
+++ b/modules/Bio/EnsEMBL/Production/Utils/MySQLDumping.sh
@@ -61,7 +61,9 @@ echo "Dumping sql file for $database";
 
 mysqldump --host=$host --user=$user --password=$password --port=$port ${IGNORED_TABLES_STRING} ${cmd_line_options} -d $database | gzip > ${output_dir}/$database/$database.sql.gz
 
-for t in $(mysql -NBA --host=$host --user=$user --password=$password --port=$port -D $database -e "${query}")
+tables=$(mysql -NBA --host=$host --user=$user --password=$password --port=$port -D $database -e "${query}")
+
+for t in $tables
 do
     echo "DUMPING TABLE: $database.$t"
     mysql --host=$host --max_allowed_packet=512M --user=$user --password=$password --port=$port -e "SELECT * FROM ${database}.${t}" --quick --silent --skip-column-names | sed '/NULL/ s//\\N/g' |  gzip -1nc > ${output_dir}/$database/$t.txt.gz


### PR DESCRIPTION
…an error code of 1. This is because the mysql command is run inside a loop and the error get lost there. As a result, we don't dump any tables for this database. Moving the MySQL query outside the loop fix the issue

**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

If we get an error from the mysql command, the script doesn't return an error code of 1. This is because the mysql command is run inside a loop and the error get lost there. As a result, we don't dump any tables for this database. Moving the MySQL query outside the loop fix the issue.

## Use case

When we dump the MySQL databases at the end of the release. This affects all the species.

## Benefits

We won't get silent failures anymore

## Possible Drawbacks

None

## Testing

- [ N ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
