### PR TITLE
Adding mart temporary MTMP tables that exists for GRCh37 human and so…

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Utils/MySQLDumping.sh
+++ b/modules/Bio/EnsEMBL/Production/Utils/MySQLDumping.sh
@@ -42,6 +42,9 @@ MTMP_supporting_structural_variation
 MTMP_transcript_variation
 MTMP_variation_set_structural_variation
 MTMP_variation_set_variation
+MTMP_population_genotype
+MTMP_sample_genotype
+MTMP_variation_annotation
 )
 for TABLE in "${EXCLUDED_TABLES[@]}"
 do :


### PR DESCRIPTION
…me non vertebrates that we don't want to dump

**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

We are still dumping some mart MTMP for human GRCh37 and some non-vertebrates. These tables are huge and not really useful to users. 

## Use case

Human GRCh37 and some non-vert variation species

## Benefits

We won't dump these huge tables anymore, faster dumps and less space used.

## Possible Drawbacks

None

## Testing

- [ N] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
