### PR TITLE
MySQL dumps for the pan division should go under pan_ensembl and not …

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/DatabaseDumping/DbDumpingFactory.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/DatabaseDumping/DbDumpingFactory.pm
@@ -76,7 +76,12 @@ sub run {
             database   => $db,
             output_dir => $base_output_dir . '/grch37/release-' . $dir_release . '/mysql/',
         }, 1);
-
+      }
+      elsif ($division_short_name eq "pan") {
+          $self->dataflow_output_id({
+              database   => $db,
+              output_dir => $base_output_dir . '/release-' . $dir_release . '/' . 'pan_ensembl' . '/mysql/',
+          }, 1);
       }
       else {
         $self->dataflow_output_id({
@@ -136,6 +141,12 @@ sub run {
               output_dir => $base_output_dir . '/grch37/release-' . $dir_release . '/mysql/',
           }, 1);
 
+        }
+        elsif ($division_short_name eq "pan") {
+          $self->dataflow_output_id({
+              database   => $division_database,
+              output_dir => $base_output_dir . '/release-' . $dir_release . '/' . 'pan_ensembl' . '/mysql/',
+          }, 1);
         }
         else {
           $self->dataflow_output_id({


### PR DESCRIPTION
…pan on the FTP site

**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

MySQL dumps for the pan division should go under pan_ensembl and not pan.

## Use case

On the FTP the pan division dumps are stored under pan_ensembl

## Benefits

MySQL dumps for Pan will be in the correct location

## Possible Drawbacks

None

## Testing

- [ N ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
