### PR TITLE
Increased the max allowed packed since it failed for a vert species. …

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/MySQLDumping_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/MySQLDumping_conf.pm
@@ -135,12 +135,10 @@ sub pipeline_analyses {
 sub resource_classes {
   my $self = shift;
   return {
-      'default' => { 'LSF' => '-q production-rh74 -n 4 -M 4000   -R "rusage[mem=4000]"' },
-      '16GB'    => { 'LSF' => '-q production-rh74 -n 4 -M 16000  -R "rusage[mem=16000]"' },
-      '32GB'    => { 'LSF' => '-q production-rh74 -n 4 -M 32000  -R "rusage[mem=32000]"' },
-      '64GB'    => { 'LSF' => '-q production-rh74 -n 4 -M 64000  -R "rusage[mem=64000]"' },
-      '128GB'   => { 'LSF' => '-q production-rh74 -n 4 -M 128000 -R "rusage[mem=128000]"' },
-      '256GB'   => { 'LSF' => '-q production-rh74 -n 4 -M 256000 -R "rusage[mem=256000]"' },
+      'default' => { 'LSF' => '-q production-rh74 -M 4000   -R "rusage[mem=4000]"' },
+      '16GB'    => { 'LSF' => '-q production-rh74 -M 16000  -R "rusage[mem=16000]"' },
+      '32GB'    => { 'LSF' => '-q production-rh74 -M 32000  -R "rusage[mem=32000]"' },
+      '64GB'    => { 'LSF' => '-q production-rh74 -M 64000  -R "rusage[mem=64000]"' },
   }
 }
 1;

--- a/modules/Bio/EnsEMBL/Production/Utils/MySQLDumping.sh
+++ b/modules/Bio/EnsEMBL/Production/Utils/MySQLDumping.sh
@@ -69,7 +69,7 @@ tables=$(mysql -NBA --host=$host --user=$user --password=$password --port=$port 
 for t in $tables
 do
     echo "DUMPING TABLE: $database.$t"
-    mysql --host=$host --max_allowed_packet=512M --user=$user --password=$password --port=$port -e "SELECT * FROM ${database}.${t}" --quick --silent --skip-column-names | sed '/NULL/ s//\\N/g' |  gzip -1nc > ${output_dir}/$database/$t.txt.gz
+    mysql --host=$host --max_allowed_packet=1024M --user=$user --password=$password --port=$port -e "SELECT * FROM ${database}.${t}" --quick --silent --skip-column-names | sed '/NULL/ s//\\N/g' |  gzip -1nc > ${output_dir}/$database/$t.txt.gz
 done
 
 echo "Creating CHECKSUM for $database"


### PR DESCRIPTION
…Removed -n 4 options as it's not really needed here and will make getting onto the queue longer. Removed very high memory as we won't need it

**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

monodelphis_domestica_core_98_1 needed more packets, so increased the value from 500MB to 1GB.
Cleaned up the memory queues, removed very high memory and -n 4 since we don't need it and make harder to get onto queues.

## Use case

To be able to dump monodelphis_domestica_core_98_1 for 98

## Benefits

We can now dump monodelphis_domestica_core_98_1

## Possible Drawbacks

None.

## Testing

- [ N ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
