### PR TITLE
CHECKSUMS files should be group writable

### DIFF
--- a/scripts/ftp/checksums.pl
+++ b/scripts/ftp/checksums.pl
@@ -155,7 +155,7 @@ sub generate_checksums {
   }
   close $fh or die "Cannot close $checksum_file: $!";
 
-  chmod S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH, $checksum_file;
+  chmod S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH, $checksum_file;
 
   print STDERR "Finished writing the checksum file $checksum_file\n";
   return;


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

When we copy dumps from a release to another when nothing has changed. We have to then regenerate the CHECKSUMS since file names will have a different release number. The script to generate CHECKSUMS, create files which are not group writable, this is an issue if we need to update the files generated by someone gone in holiday. 

## Use case

After copying dumps from a release to another.

## Benefits

CHECKSUMS files will be writable by the whole teams

## Possible Drawbacks

None

## Testing

- [ N ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
