### PR TITLE
Updated Compara checks to match new changes from Compara for Plants a…

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/FtpChecker/CheckComparaFtp.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FtpChecker/CheckComparaFtp.pm
@@ -39,7 +39,8 @@ my $expected_files = {
 							  ]},
 		      "xml" => {"dir" => "{division}xml/ensembl-compara/homologies/", "expected" =>[
 						       'Compara.*.xml.gz',
-						       'Compara.*.phyloxml.xml.*.tar.gz',
+						       'Compara.*phyloxml.xml.tar',
+                   'Compara.*.orthoxml.xml.tar',
 						       'README.*',
 						       'MD5SUM*'
 						      ]},
@@ -57,6 +58,9 @@ sub run {
     $division = "";
   }elsif($species eq 'pan_homology') {
     $division = "pan_ensembl/";
+  }elsif($species eq 'bacteria'){
+    #Bacteria compara is only a subset of data, we don't generate dumps for this database
+    return;
   }else {
     $division = "$species/";
   }


### PR DESCRIPTION
…nd vertebrates, other division will change in the furture. Skipping compara dump check for Bacteria since the Compara database only contain a tiny set of data

**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Compara team have changed some of the xml.tar dumps for vert and plants so updating the check to match this (I believe other divisions will be updated in the future). Disabled Compara check on Bacteria since the compara db only contain a tiny set of data.

## Use case

For Compara dump checks plants, vert and Bacteria

## Benefits

The result from the check will be more accurate.

## Possible Drawbacks

Compara will fail for other divisions since the current dumps are not matching more recent version from Compara.

## Testing

- [ N ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
