### PR TITLE
Adding Pepstats datacheck to Protein Features pipeline...

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProteinFeatures_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProteinFeatures_conf.pm
@@ -905,7 +905,7 @@ sub pipeline_analyses {
       -logic_name        => 'RunDatachecks',
       -module            => 'Bio::EnsEMBL::DataCheck::Pipeline::RunDataChecks',
       -parameters        => {
-                              datacheck_names  => ['ForeignKeys'],
+                              datacheck_names  => ['ForeignKeys', 'PepstatsAttributes'],
                               datacheck_groups => ['protein_features'],
                               history_file     => $self->o('history_file'),
                               failures_fatal   => 1,


### PR DESCRIPTION
...because the datacheck that ensures that protein features do not extend beyond the end of the translation requires one of the Pepstats attributes.
