### PR TITLE
Adding SQL to cleanup orphan dependent_xref since it can happen in so…

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GPAD_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GPAD_conf.pm
@@ -199,6 +199,10 @@ sub pipeline_analyses {
       -analysis_capacity => 20,
       -parameters        => {
                               sql => [
+                                'DELETE dx.* FROM '.
+                                  'dependent_xref dx LEFT OUTER JOIN '.
+                                  'object_xref ox USING (object_xref_id) '.
+                                  'WHERE ox.object_xref_id IS NULL',
                                 'DELETE onx.* FROM '.
                                   'ontology_xref onx LEFT OUTER JOIN '.
                                   'object_xref ox USING (object_xref_id) '.


### PR DESCRIPTION
…me cases and it's more work to clean this up after the pipeline run

**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Some pipelines before the GPAD might create orphan dependent xrefs. Cleaning them up after the GPAD load is more work so it's easier if the pipeline automatically take care of it (we already are doing it in EG xrefs and protein features).

## Use case

When a pipeline has created orphan dependent xrefs before the GPAD load

## Benefits

We won't end up with Foreign key issues before handing over to Web.

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._

## Testing

- [ N ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
