### PR TITLE
Feature/deprecate basepair count

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Production/GeneCount.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Production/GeneCount.pm
@@ -21,6 +21,7 @@ package Bio::EnsEMBL::Production::Pipeline::Production::GeneCount;
 
 use strict;
 use warnings;
+use Bio::EnsEMBL::Utils::Exception qw( deprecate );
 use Bio::EnsEMBL::Utils::Scalar qw(assert_ref assert_integer wrap_array);
 
 
@@ -163,8 +164,10 @@ sub get_ref_length {
   return $ref_length;
 }
 
+# Deprecated. Please use get_ref_length(), i.e. the golden path, instead.
 sub get_total_length {
   my ($self) = @_;
+  deprecate('GeneCount::get_total_length() is deprecated due to inaccuracy and will be removed in e102. Use golden path (GeneCount::get_ref_length()) instead');
   my $species = $self->param('species');
   my @slices = @{ Bio::EnsEMBL::Registry->get_adaptor($species, 'core', 'slice')->fetch_all('seqlevel') };
   my $total_length = 0;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Production/StatsGenerator.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Production/StatsGenerator.pm
@@ -23,7 +23,7 @@ use strict;
 use warnings;
 
 use Bio::EnsEMBL::Attribute;
-use Bio::EnsEMBL::Utils::Exception qw/throw/;
+use Bio::EnsEMBL::Utils::Exception qw/deprecate throw/;
 
 use base qw/Bio::EnsEMBL::Production::Pipeline::Common::Base/;
 
@@ -214,7 +214,10 @@ sub store_statistics {
 }
 
 sub get_ref_length {}
-sub get_total_length {}
+# Deprecated. Please use get_ref_length(), i.e. the golden path, instead.
+sub get_total_length {
+  deprecate('StatsGenerator::get_total_length() is deprecated due to inaccuracy and will be removed in e102. Use golden path (StatsGenerator::get_ref_length()) instead');
+}
 
 
 

--- a/modules/t/production_pipeline.t
+++ b/modules/t/production_pipeline.t
@@ -261,11 +261,6 @@ and cs.species_id = 1 and cs.name != 'lrg'
 and sr.seq_region_id not in (select distinct seq_region_id from assembly_exception ae where ae.exc_type != 'par')";
 my $ref_length = $sql_helper->execute_single_result(-SQL => $ref_sql);
 is($ref_length, $genome_container->get_ref_length(), "Ref length is correct");
-my $total_sql = "select sum(length(sequence)) from dna
-join seq_region using (seq_region_id) join coord_system using (coord_system_id)
-where species_id = 1";
-my $total_length = $sql_helper->execute_single_result(-SQL => $total_sql);
-is($total_length, $genome_container->get_total_length(), "Total length is correct");
 
 # Check transcript counts
 my $transcript_sql = "select count(*) from transcript t, seq_region s


### PR DESCRIPTION
## Description

Deprecate Bio::EnsEMBL::Production::Pipeline::Production::GeneCount::get_total_length() and Bio::EnsEMBL::Production::Pipeline::Production::StatsGenerator::get_total_length().

## Use case

Part of ENSINT-283. Web should stop using it already in e99 but let us play it safely on our end and follow the standard deprecation procedure.

## Benefits

The first step towards removing a method known to provide incorrect information for certain species.

## Possible Drawbacks

Test coverage will drop slightly (but will of course improve again once get_total_length() has been removed).

## Testing

- [1] Have you added/modified unit tests to test the changes?
- [y] If so, do the tests pass?
- [2] Have you run the entire test suite and no regression was detected?
- [y] TravisCI passed on your branch

1) What I have done is _remove_ the test invoking deprecated code.
2) Technically speaking, no regression - but it might be worth pointing out that large parts of the test suite do not work with MariaDB 10.2, for instance because there is a text field in the variation test-DB schema that is 50,000 bytes long and MyISAM limits on such fields for the aforementioned server version is just under half that.

Dependencies
------------

N/A
