### PR TITLE
Fixed issues where checksum_generator analysis was trying to generate…

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Common/ChksumGenerator.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Common/ChksumGenerator.pm
@@ -107,13 +107,15 @@ sub get_dirs {
   }
   #Taking care of blast_fasta for non-vertebrates
   if ($self->division() ne "vertebrates"){
-    my $mc = $self->get_DBAdaptor()->get_MetaContainer();
-    if ( $mc->is_multispecies() == 1 ) {
-      my $collection_db = $1 if ( $mc->dbc->dbname() =~ /(.+)\_core/ );
-      push @dirs, File::Spec->catdir($base_path, 'blast_fasta', $self->division(), $collection_db, $species);
-    }
-    else{
-      push @dirs, File::Spec->catdir($base_path, 'blast_fasta', $self->division(), $species);
+    if (not $self->param('skip_convert_fasta')){
+      my $mc = $self->get_DBAdaptor()->get_MetaContainer();
+      if ( $mc->is_multispecies() == 1 ) {
+        my $collection_db = $1 if ( $mc->dbc->dbname() =~ /(.+)\_core/ );
+        push @dirs, File::Spec->catdir($base_path, 'blast_fasta', $self->division(), $collection_db, $species);
+      }
+      else{
+        push @dirs, File::Spec->catdir($base_path, 'blast_fasta', $self->division(), $species);
+      }
     }
   }
   # Taking care of fasta dumps because these have subdirectories fasta/dna,...

--- a/modules/Bio/EnsEMBL/Production/Pipeline/FASTA/BlatIndexer.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FASTA/BlatIndexer.pm
@@ -74,6 +74,7 @@ use File::Spec;
 use File::stat;
 use Bio::EnsEMBL::Utils::IO qw/work_with_file/;
 use Bio::EnsEMBL::Utils::Exception qw/throw/;
+use File::Path qw/mkpath/;
 
 
 sub param_defaults {
@@ -174,18 +175,25 @@ sub target_filename {
 sub target_file {
   my ($self) = @_;
   my $target_dir = $self->target_dir();
-  my $release = $self->param('release');
-  my $division = $self->division();
-  # Remove release and division from the path as we don't want to sync these files to the FTP site.
-  $target_dir =~ s/release-${release}\/${division}//;
   my $target_filename = $self->target_filename();
   return File::Spec->catfile($target_dir, $target_filename);
-  return;
 }
 
 sub target_dir {
   my ($self) = @_;
-  return $self->index_path('blat', $self->param('index'));
+  my $target_dir = $self->index_path('blat', $self->param('index'));
+  return $target_dir;
+}
+
+sub index_path {
+  my ( $self, $format, @extras ) = @_;
+  my $release = $self->param('release');
+  my $base_dir = $self->param('base_path');
+  # Remove release and division from the path as we don't want to sync these files to the FTP site.
+  $base_dir =~ s/release-${release}//;
+  my $dir = File::Spec->catdir( $base_dir, $format, @extras);
+  mkpath($dir);
+  return $dir;
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_conf.pm
@@ -121,11 +121,18 @@ sub default_options {
         'meleagris_gallopavo'   => 30064,
         'anas_platyrhynchos_platyrhynchos'    => 30066,
         'ovis_aries'            => 30068,
-        'oreochromis_niloticus' => 30072,
+        'oreochromis_niloticus' => 30073,
         'gadus_morhua'          => 30071,
        },
       # History file for storing record of datacheck run.
       history_file => undef,
+      ## Indexing parameters
+      'skip_blat'              => 0,
+      'skip_ncbiblast'         => 0,
+      'skip_blat_masking'      => 1,
+      'skip_ncbiblast_masking' => 0,
+      ## Indexing parameters
+      'skip_convert_fasta' => 0,
 
 	};
 }
@@ -226,7 +233,8 @@ sub pipeline_analyses {
     {  -logic_name => 'checksum_generator',
        -module     => 'Bio::EnsEMBL::Production::Pipeline::Common::ChksumGenerator',
        -parameters     => {
-                      dumps     => $pipeline_flow
+                      dumps     => $pipeline_flow,
+                      skip_convert_fasta => $self->o('skip_convert_fasta')
                   },
        -hive_capacity => 10,
        -rc_name       => 'default'

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_non_vertebrates_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_non_vertebrates_conf.pm
@@ -33,6 +33,7 @@ use warnings;
 use File::Spec;
 use Data::Dumper;
 use Bio::EnsEMBL::ApiVersion qw/software_version/;
+use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
 use base ('Bio::EnsEMBL::Production::Pipeline::PipeConfig::DumpCore_conf');     
    
 sub default_options {
@@ -47,6 +48,8 @@ sub default_options {
       'abinitio'        => 0,
       # Previous release FASTA DNA files location
       'prev_rel_dir' => '/nfs/ensemblgenomes/ftp/pub/',
+      ## Indexing parameters
+      'skip_convert_fasta' => 0,
       };
 }
 
@@ -57,19 +60,21 @@ sub pipeline_analyses {
     my $super_analyses   = $self->SUPER::pipeline_analyses;
 
    	my $pipeline_flow;
-        # Getting list of dumps from argument
-        my $dumps = $self->o('dumps');
-        # Checking if the list of dumps is an array
-        my @dumps = ( ref($dumps) eq 'ARRAY' ) ? @$dumps : ($dumps);
-        #Pipeline_flow will contain the dumps from the dumps list
-        if (scalar @dumps) {
-          $pipeline_flow  = $dumps;
-        }
-        # Else, we run all the dumps
-        else {
-          $pipeline_flow  = ['json','gtf', 'gff3', 'embl', 'genbank', 'assembly_chain_datacheck', 'tsv_uniprot', 'tsv_ena', 'tsv_metadata', 'tsv_refseq', 'tsv_entrez', 'rdf'];
-        }
-    
+    # Getting list of dumps from argument
+    my $dumps = $self->o('dumps');
+    # Checking if the list of dumps is an array
+    my @dumps = ( ref($dumps) eq 'ARRAY' ) ? @$dumps : ($dumps);
+    #Pipeline_flow will contain the dumps from the dumps list
+    if (scalar @dumps) {
+      $pipeline_flow  = $dumps;
+    }
+    # Else, we run all the dumps
+    else {
+      $pipeline_flow  = ['json','gtf', 'gff3', 'embl', 'fasta_dna','fasta_pep', 'genbank', 'assembly_chain_datacheck', 'tsv_uniprot', 'tsv_ena', 'tsv_metadata', 'tsv_refseq', 'tsv_entrez', 'rdf'];
+    }
+    if (not $self->o('skip_convert_fasta')){
+      @$pipeline_flow = grep {$_ ne 'fasta_dna' and $_ ne 'fasta_pep'} @$pipeline_flow;
+    }
     my %analyses_by_name = map {$_->{'-logic_name'} => $_} @$super_analyses;
     $self->tweak_analyses(\%analyses_by_name, $pipeline_flow);
     
@@ -94,14 +99,21 @@ sub tweak_analyses {
     ## Removed unused dataflow
     $analyses_by_name->{'concat_fasta'}->{'-flow_into'} = { };
     $analyses_by_name->{'primary_assembly'}->{'-wait_for'} = [];
-    $analyses_by_name->{'checksum_generator'}->{'-wait_for'} = ['convert_fasta'];
-    $analyses_by_name->{'backbone_job_pipeline'}->{'-flow_into'} = {
-                '1->A' => $pipeline_flow,
-                'A->1' => ['checksum_generator'],
-                '1->B' => ['fasta_dna','fasta_pep'],
-							  'B->1' => ['convert_fasta'],
-							 };   
-
+    if ($self->o('skip_convert_fasta')){
+      $analyses_by_name->{'backbone_job_pipeline'}->{'-flow_into'} = {
+                  '1->A' => $pipeline_flow,
+                  'A->1' => ['checksum_generator'],
+                };
+    }
+    else{
+      $analyses_by_name->{'backbone_job_pipeline'}->{'-flow_into'} = {
+                  '1->A' => $pipeline_flow,
+                  'A->1' => ['checksum_generator'],
+                  '1->B' => ['fasta_dna','fasta_pep'],
+                  'B->1' => ['convert_fasta'],
+                };
+      $analyses_by_name->{'checksum_generator'}->{'-wait_for'} = ['convert_fasta'];
+    }
     return;
  
 }


### PR DESCRIPTION
… CHECKSUMS for BLAST even when skip_blast option was on. Also fixed issues were convert_fasta for non-vert was running before FASTA dna and PEP were done. I introduced a new flag called skip_convert_fasta so that we don't generate the BLAST FASTA for non-vert when running the pre-dumps or when we don't want to run them. Updated the way skip_blat and skip_ncbiblast were working to only run the BLAST analysis if these flags are off. At the moment the flag is passed to these modules and then no file is generated which looks confusing. Re-worked the flow to make all this to work. Fixed bug introduced with previous commits regarding BLAT, which was creating an empty dir in the release directory. I overwrote the index_path sub for BLAT to make sure BLAT files are generated outside the release directory. Updated oreochromis_niloticus BLAT port number from 30072 to 30073 since there is an assembly update for this species and Web will need to setup a new machine for it.

**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Fixed issues where checksum_generator analysis was trying to generate CHECKSUMS for BLAST even when skip_blast option was on. Also fixed issues were convert_fasta for non-vert was running before FASTA dna and PEP were done. I introduced a new flag called skip_convert_fasta so that we don't generate the BLAST FASTA for non-vert when running the pre-dumps or when we don't want to run them. Updated the way skip_blat and skip_ncbiblast were working to only run the BLAST analysis if these flags are off. At the moment the flag is passed to these modules and then no file is generated which looks confusing. Re-worked the flow to make all this to work. Fixed bug introduced with previous commits regarding BLAT, which was creating an empty dir in the release directory. I overwrote the index_path sub for BLAT to make sure BLAT files are generated outside the release directory. Updated oreochromis_niloticus BLAT port number from 30072 to 30073 since there is an assembly update for this species and Web will need to setup a new machine for it.

## Use case

Mainly when running pipeline without BLAST and BLAT but also fixed BLAT issues.

## Benefits

Pipeline will be more configurable. 

## Possible Drawbacks

None
## Testing

- [ N ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
