### PR TITLE
Bugfix/99 null replacement in field

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Utils/MySQLDumping.sh
+++ b/modules/Bio/EnsEMBL/Production/Utils/MySQLDumping.sh
@@ -69,7 +69,7 @@ tables=$(mysql -NBA --host=$host --user=$user --password=$password --port=$port 
 for t in $tables
 do
     echo "DUMPING TABLE: $database.$t"
-    mysql --host=$host --max_allowed_packet=1024M --user=$user --password=$password --port=$port -e "SELECT * FROM ${database}.${t}" --quick --silent --skip-column-names | sed '/\tNULL/ s//\t\\N/g' |  gzip -1nc > ${output_dir}/$database/$t.txt.gz
+    mysql --host=$host --max_allowed_packet=1024M --user=$user --password=$password --port=$port -e "SELECT * FROM ${database}.${t}" --quick --silent --skip-column-names | sed -r -e 's/(^|\t)NULL($|\t)/\1\\N\2/g' -e 's/(^|\t)NULL($|\t)/\1\\N\2/g' |  gzip -1nc > ${output_dir}/$database/$t.txt.gz
 done
 
 echo "Creating CHECKSUM for $database"

--- a/modules/Bio/EnsEMBL/Production/Utils/MySQLDumping.sh
+++ b/modules/Bio/EnsEMBL/Production/Utils/MySQLDumping.sh
@@ -69,7 +69,7 @@ tables=$(mysql -NBA --host=$host --user=$user --password=$password --port=$port 
 for t in $tables
 do
     echo "DUMPING TABLE: $database.$t"
-    mysql --host=$host --max_allowed_packet=1024M --user=$user --password=$password --port=$port -e "SELECT * FROM ${database}.${t}" --quick --silent --skip-column-names | sed '/NULL/ s//\\N/g' |  gzip -1nc > ${output_dir}/$database/$t.txt.gz
+    mysql --host=$host --max_allowed_packet=1024M --user=$user --password=$password --port=$port -e "SELECT * FROM ${database}.${t}" --quick --silent --skip-column-names | sed '/\tNULL/ s//\t\\N/g' |  gzip -1nc > ${output_dir}/$database/$t.txt.gz
 done
 
 echo "Creating CHECKSUM for $database"


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**
## Description

Some database field contains the string "NULL" inside, hence they are replaced by \N with the subsequent **sed** command during tsv dumping. 
This improve the sed command to enable "NULL" content in fields.

## Use case

FTP MYSQL tsv dumping

## Benefits

TSV gzipped files won't have NULL text replace, only actual null values

## Possible Drawbacks

None

## Testing
On this dataset, the new sed command works fine:
1	1	0	0	funcgen	NULL	NULL	NULL	NULL	0	NULL
2	2007-11-Ensembl	0	0	otherfeatures	NULL	NULL	NULL	NULL	0	NULL
4	assembly.coverage_depth	0	0	cdna,core,otherfeatures,rnaseq,presite	At the end of the field we have a NULL	NULL	NULL	104991	0	2013-04-29 11:33:02
5	assembly.date	0	0	cdna,core,otherfeatures,rnaseq,presite	NULL first and followed by space	NULL	NULL	5132	0	2011-11-09 16:41:26
6	assembly.default	0	0	cdna,core,otherfeatures,rnaseq,vega,presite	NULL    first and followed by Tabulation	NULL	NULL	5132	0	2014-10-22 15:47:11
7	assembly.long_name	0	0	cdna,core,otherfeatures,rnaseq,vega,presite	Tabulation preceding    NULL with other text	NULL	NULL	5132	0	2014-10-22 15:49:44
8	assembly.mapping	0	0	cdna,core,otherfeatures,rnaseq,vega,presite	Text with NULL inside enclosed by spaces	NULL	NULL	NULL	0	NULL
9	assembly.mapping	0	0	cdna,core,otherfeatures,rnaseq,vega,presite	Text with   NULL    inside enclosed by tabs	NULL	NULL	NULL	0	NULL

Output is now:
1	1	0	0	funcgen	\N	\N	\N	\N	0	\N
2	2007-11-Ensembl	0	0	otherfeatures	\N	\N	\N	\N	0	\N
4	assembly.coverage_depth	0	0	cdna,core,otherfeatures,rnaseq,presite	At the end of the field we have a **NULL**	\N	\N	104991	0	2013-04-29 11:33:02
5	assembly.date	0	0	cdna,core,otherfeatures,rnaseq,presite	**NULL** first and followed by space	\N	\N	5132	0	2011-11-09 16:41:26
6	assembly.default	0	0	cdna,core,otherfeatures,rnaseq,vega,presite	**NULL**    first and followed by Tabulation	\N	\N	5132	0	2014-10-22 15:47:11
7	assembly.long_name	0	0	cdna,core,otherfeatures,rnaseq,vega,presite	Tabulation preceding    **NULL** with other text	\N	\N	5132	0	2014-10-22 15:49:44
8	assembly.mapping	0	0	cdna,core,otherfeatures,rnaseq,vega,presite	Text with **NULL** inside enclosed by spaces	\N	\N	\N	0	\N
9	assembly.mapping	0	0	cdna,core,otherfeatures,rnaseq,vega,presite	Text with   **NULL**    inside enclosed by tabs	\N	\N	\N	0	\N


Dependencies
------------
None
