### PR TITLE
Updated My6SQL dumping pipeline to add CHECKSUM separated step (allow…

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/MySQLDumping_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/MySQLDumping_conf.pm
@@ -114,6 +114,18 @@ sub pipeline_analyses {
           -rc_name           => 'default',
           -analysis_capacity => 10,
           -flow_into       => {
+              1 => 'DbCheckSum',
+          }
+      },
+      {
+          -logic_name        => 'DbCheckSum',
+          -parameters => {
+                dir => "#output_dir#/#database#"
+          },
+          -module            => 'Bio::EnsEMBL::Production::Pipeline::Common::ChecksumGenerator',
+          -analysis_capacity => 10,
+          -priority => 5,
+            -flow_into       => {
               1 => 'DumpCheck',
           }
       },

--- a/modules/Bio/EnsEMBL/Production/Utils/MySQLDumping.sh
+++ b/modules/Bio/EnsEMBL/Production/Utils/MySQLDumping.sh
@@ -72,8 +72,8 @@ do
     mysql --host=$host --max_allowed_packet=1024M --user=$user --password=$password --port=$port -e "SELECT * FROM ${database}.${t}" --quick --silent --skip-column-names | sed -r -e 's/(^|\t)NULL($|\t)/\1\\N\2/g' -e 's/(^|\t)NULL($|\t)/\1\\N\2/g' |  gzip -1nc > ${output_dir}/$database/$t.txt.gz
 done
 
-echo "Creating CHECKSUM for $database"
-find  -type f -name '*.gz' -printf '%P\n' | while read file; do
-    sum=$(sum $file)
-    echo -ne "$sum\t$file\n" >> CHECKSUMS
-done
+#echo "Creating CHECKSUM for $database"
+#find  -type f -name '*.gz' -printf '%P\n' | while read file; do
+#    sum=$(sum $file)
+#    echo -ne "$sum\t$file\n" >> CHECKSUMS
+#done


### PR DESCRIPTION
… to rerun it independently of the dumps)

**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Description

Some of the checksums generation fails during processing, since both dump and checksums are in the same step, when failed, we have to rerun dumps. 

## Use case
When a Check fails because CHECKSUMS have not been generated, only relaunch the failing CHECKSUM instead of all db dump. 

## Benefits

Avoid redump when not necessary

## Possible Drawbacks

None

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
