### PR TITLE
Need to dump DNA if there is a geneset update

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_conf.pm
@@ -477,7 +477,7 @@ sub pipeline_analyses {
       -can_be_empty    => 1,
       -flow_into       => {
                       1 => WHEN(
-                  '#new_assembly# >= 1' => 'dna',
+                  '#new_assembly# >= 1 || #new_genebuild# >= 1' => 'dna',
                   ELSE 'copy_dna',
               )},
       -max_retry_count => 1,


### PR DESCRIPTION
## Description
Need to dump DNA if there is a geneset update as well as in the case of assembly updates. This is because repeat annotation is re-done, so even though the DNA might not be changing, the softmaksing is. (This implicitly affects the BLAST dumps, because these masked files are used there.)

## Benefits
Softmasked FASTA DNA files, and therefore BLAST results, will be using the most recent repeat annotations.

## Possible Drawbacks
Possible wasted computation if a geneset is updated, but repeat annotation is not (this may sometimes be the case with non-vertebrates). But having more complicated logic is too not warranted, because updated genesets for existing assemblies is relatively rare for non-verts, so shouldn't be an issue in practice.

## Testing
No unit tests, but test pipeline looks OK.
