### PR TITLE
Prevent creation of tsv files if there is no data.

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileEna.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileEna.pm
@@ -78,6 +78,8 @@ sub _write_tsv {
     my $taxon_id   = $self->core_dba()->get_MetaContainer()->get_taxonomy_id();
     my $name       = $self->web_name();
 
+    my $xrefs_exist = 0;
+
     my $helper     = $self->core_dbc()->sql_helper();
     my $sql        = 'SELECT g.stable_id, t.stable_id, tr.stable_id, srs.synonym, NULL
                 	FROM coord_system cs
@@ -113,14 +115,19 @@ sub _write_tsv {
             $row->[6] =~ s/\.[0-9]+$// if (defined $row->[6]);
 	    print $fh join "\t", @$row;
 	    print $fh "\n";
+      $xrefs_exist = 1;
         }
     }
     close $fh;
 
-    $self->info( "Compressing ENA tsv dump for " . $self->param('species'));
-    my $unzip_out_file = $out_file;
-    `gzip -n $unzip_out_file`;
-
+    if ($xrefs_exist == 1) {
+      $self->info( "Compressing ENA tsv dump for " . $self->param('species'));
+      my $unzip_out_file = $out_file;
+      `gzip -n $unzip_out_file`;
+    } else {
+      # If we have no xrefs, delete the file (which will just have a header).
+      unlink $out_file  or die "failed to delete $out_file!";
+    }
 
 return;
 }
@@ -213,6 +220,7 @@ Stable ID to ENA Ac
 
 Provides mappings from Gene, Transcript and Translation stable identifiers to 
 ENA accessions.
+If there are no such mappings in the database, the file will not exist.
 
 File are named Species.assembly.release.ena.tsv.gz
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileMetadata.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileMetadata.pm
@@ -91,7 +91,7 @@ sub _make_karyotype_file {
 
     my $slices = $sa->fetch_all_karyotype();
     # If we don't have any slices (ie. chromosomes), don't make the file
-    return unless($slices);
+    return unless(scalar(@$slices));
  
     my $file = $self->_generate_file_name();
   


### PR DESCRIPTION
## Description
Many non-vertebrates do not have Entrez or RefSeq xrefs. In these cases, TSVs files are created with just a header line, which is confusing for users, and looks like something might have gone wrong with the dump. (This logic also applies to UniProt, but I think everything should have those anyway.)
A similar issue exists with ENA xrefs, which are generally available for non-vertebrates but not vertebrates.
And there was a bug in the karyotype dumping, which meant that empty files were created for that data.
https://www.ebi.ac.uk/panda/jira/browse/ENSPROD-4297

## Benefits
Remove uninformative files, hopefully reduce confusion.

## Possible Drawbacks
Any existing scripts may always assume the presence of a file. But there are probably very few (if any) such scripts in use, and they can be easily fixed. The README now states that the files will be absent if there are no xrefs.

## Testing
No unit tests, but a test pipelines covering the different scenarios ran successfully.
