### PR TITLE
External DB Type now not null field

### DIFF
--- a/sql/patch_98_99_b.sql
+++ b/sql/patch_98_99_b.sql
@@ -1,0 +1,30 @@
+-- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+-- Copyright [2016-2019] EMBL-European Bioinformatics Institute
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+# patch_98_99_b.sql
+#
+# Title: External db type not null.
+#
+# Description:
+#   Update master_external_db disallow NULL for `type` field.
+
+ALTER TABLE master_external_db 
+  MODIFY TYPE enum('ARRAY', 'ALT_TRANS', 'ALT_GENE', 'MISC', 'LIT', 'PRIMARY_DB_SYNONYM', 'ENSEMBL') NOT NULL;
+
+
+# Patch identifier
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_98_99_b.sql|schema_version');
+

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -195,7 +195,7 @@ CREATE TABLE master_external_db (
   status                    ENUM('KNOWNXREF','KNOWN','XREF','PRED','ORTH','PSEUDO') NOT NULL,
   priority                  INT(11) NOT NULL,
   db_display_name           VARCHAR(255) NOT NULL,
-  type                      ENUM('ARRAY','ALT_TRANS','ALT_GENE','MISC','LIT','PRIMARY_DB_SYNONYM','ENSEMBL') DEFAULT NULL,
+  type                      ENUM('ARRAY','ALT_TRANS','ALT_GENE','MISC','LIT','PRIMARY_DB_SYNONYM','ENSEMBL') NOT NULL,
   secondary_db_name         VARCHAR(255) DEFAULT NULL,
   secondary_db_table        VARCHAR(255) DEFAULT NULL,
   description               TEXT,


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

## Description

The XrefCategories HC (https://github.com/Ensembl/ensj-healthcheck/blob/release/98/src/org/ensembl/healthcheck/testcase/generic/XrefCategories.java) is making sure that external_db.type is not null but the schema allow null by default: https://github.com/Ensembl/ensembl-production/blob/release/98/sql/table.sql#L198

## Use case

Update controlled table 

## Benefits

Get rid of an obsolete HC

## Possible Drawbacks

None

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
