### PR TITLE
Adding new option skip_optimize to allow user to skip the optimizatio…

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Utils/CopyDatabase.pm
+++ b/modules/Bio/EnsEMBL/Production/Utils/CopyDatabase.pm
@@ -44,7 +44,7 @@ if(!Log::Log4perl->initialized()) {
 }
 
 sub copy_database {
-  my ($source_db_uri,$target_db_uri,$opt_only_tables,$opt_skip_tables,$update,$drop,$convert_innodb_to_myisam,$verbose) = @_;
+  my ($source_db_uri,$target_db_uri,$opt_only_tables,$opt_skip_tables,$update,$drop,$convert_innodb_to_myisam,$skip_optimize,$verbose) = @_;
 
   $logger->info("Pre-Copy Checks");
   # Path for MySQL dump
@@ -272,8 +272,10 @@ sub copy_database {
   }
 
   #Optimize target
-  $logger->info("Optimizing tables on target database");
-  optimize_tables($target_dbh,\@tables,$target_db);
+  if (not $skip_optimize){
+    $logger->info("Optimizing tables on target database");
+    optimize_tables($target_dbh,\@tables,$target_db);
+  }
 
   #disconnect from MySQL server
   $target_dbh->disconnect();

--- a/scripts/copy_database.pl
+++ b/scripts/copy_database.pl
@@ -28,7 +28,7 @@ my $opts = {};
 GetOptions( $opts,                 'source_db_uri=s',
             'target_db_uri=s',     'only_tables=s',
             'skip_tables=s',       'update|u',
-            'drop|d', 'convert_innodb|c', 'verbose' );
+            'drop|d', 'convert_innodb|c', 'skip_optimize|k', 'verbose' );
 
 if ( $opts->{verbose} ) {
   Log::Log4perl->easy_init($DEBUG);
@@ -40,9 +40,9 @@ else {
 my $logger = get_logger;
 
 if ( !defined $opts->{source_db_uri} || !defined $opts->{target_db_uri} ) {
-  croak "Usage: copy_database.pl -source_db_uri <mysql://user:password\@host:port/db_name> -target_db_uri <mysql://user:password\@host:port/db_name> [-only_tables=table1,table2] [-skip_tables=table1,table2] [-update] [-drop] [-convert_innodb] [-verbose]";
+  croak "Usage: copy_database.pl -source_db_uri <mysql://user:password\@host:port/db_name> -target_db_uri <mysql://user:password\@host:port/db_name> [-only_tables=table1,table2] [-skip_tables=table1,table2] [-update] [-drop] [-convert_innodb] [-skip_optimize] [-verbose]";
 }
 
 $logger->debug("Copying $opts->{source_db_uri} to $opts->{target_db_uri}");
 
-copy_database($opts->{source_db_uri}, $opts->{target_db_uri}, $opts->{only_tables}, $opts->{skip_tables}, $opts->{update}, $opts->{drop}, $opts->{convert_innodb}, $opts->{verbose});
+copy_database($opts->{source_db_uri}, $opts->{target_db_uri}, $opts->{only_tables}, $opts->{skip_tables}, $opts->{update}, $opts->{drop}, $opts->{convert_innodb}, $opts->{skip_optimize}, $opts->{verbose});


### PR DESCRIPTION
…n step when copying very large databases since this step can take days.
Also fixed a bug with hive job_progress table where the progress was deleted after the copy, moved the SQLs before doing the copy as these steps are only relevant when re-running a copy job.

**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

New option to allow user to skip the optimization step after the copy since this can take days on very large databases. 

## Use case

When copying very large databases, e.g when variation are making backups of the human database.

## Benefits

Time saving for some teams

## Possible Drawbacks

Database won't be optimize so it could be slower to query. This is fine when doing backups, by default we should always optimize a database after copy.

## Testing

- [ N ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
