### PR TITLE
Added Sed command to replace Windows \r chars by "nothing". hence cle…

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Utils/MySQLDumping.sh
+++ b/modules/Bio/EnsEMBL/Production/Utils/MySQLDumping.sh
@@ -69,11 +69,6 @@ tables=$(mysql -NBA --host=$host --user=$user --password=$password --port=$port 
 for t in $tables
 do
     echo "DUMPING TABLE: $database.$t"
-    mysql --host=$host --max_allowed_packet=1024M --user=$user --password=$password --port=$port -e "SELECT * FROM ${database}.${t}" --quick --silent --skip-column-names | sed -r -e 's/(^|\t)NULL($|\t)/\1\\N\2/g' -e 's/(^|\t)NULL($|\t)/\1\\N\2/g' |  gzip -1nc > ${output_dir}/$database/$t.txt.gz
+    mysql --host=$host --max_allowed_packet=1024M --user=$user --password=$password --port=$port -e "SELECT * FROM ${database}.${t}" --quick --silent --skip-column-names | sed -r -e 's/\r//g' -e 's/(^|\t)NULL($|\t)/\1\\N\2/g' -e 's/(^|\t)NULL($|\t)/\1\\N\2/g' |  gzip -1nc > ${output_dir}/$database/$t.txt.gz
 done
 
-#echo "Creating CHECKSUM for $database"
-#find  -type f -name '*.gz' -printf '%P\n' | while read file; do
-#    sum=$(sum $file)
-#    echo -ne "$sum\t$file\n" >> CHECKSUMS
-#done


### PR DESCRIPTION
…aning output from carriage returns in the middle of a line

**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

## Description

Some tables TSV dumps contains carriage returns not parsed by our mysql tsv dump script. 

## Use case

MySQL dumps / TSV output

## Benefits

No more truncated lines

## Possible Drawbacks

None, apart from slightly more time to execute, may be.

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
