### PR TITLE
Fix FASTA::ConcatFiles bgzip regex

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/FASTA/ConcatFiles.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FASTA/ConcatFiles.pm
@@ -149,7 +149,7 @@ sub bgzip_and_index_toplevel {
   $self->info('extracting fasta toplevel file');
   system("gunzip $target_bgzip_file")
     and $self->throw( sprintf('Cannot gunzip %s. RC %d', $target_bgzip_file, ($?>>8)));
-  $target_bgzip_file=~ s/\.gz//;
+  $target_bgzip_file=~ s/\.gz$//;
   $self->info('bgziping toplevel file');
   system("bgzip $target_bgzip_file")
     and $self->throw( sprintf('Cannot bgzip %s. RC %d', $target_bgzip_file, ($?>>8)));


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Add EOL anchor to the regex removing '.gz' from the gunzipped file name.

## Use case

When processing file names containing '.gz' in the middle of the filename

## Benefits

The pipeline task will support file names containing '.gz' not at the end of the name.

## Possible Drawbacks

Weird names (e.g. multiple '.gz' extensions or having '.gz' somewhere in the filename) will be parsed and won't fail. It would be nice to sanitise the name at some point. Probably best to sanitise it before recording it in the database but we should have some kind of warning raised at pipeline level in my opinion.

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [x] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------
N/A