### PR TITLE
Disabled SOLR reformat since nobody uses them at the moment. Disabled…

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/SearchDumps_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/SearchDumps_conf.pm
@@ -63,7 +63,8 @@ sub pipeline_wide_parameters {
 
 sub pipeline_analyses {
     my $self = shift;
-    my @variant_analyses = $self->o('dump_variant') == 1 ? [ 'VariantDumpFactory', 'StructuralVariantDumpFactory', 'DumpPhenotypesJson' ] : [ 'DumpPhenotypesJson' ] ;
+    #my @variant_analyses = $self->o('dump_variant') == 1 ? [ 'VariantDumpFactory', 'StructuralVariantDumpFactory', 'DumpPhenotypesJson' ] : [ 'DumpPhenotypesJson' ] ;
+    my @variant_analyses = [ 'VariantDumpFactory' ] if $self->o('dump_variant') == 1;
     my @regulation_analyses = $self->o('dump_regulation') == 1 ? [ 'RegulationDumpFactory', 'ProbeDumpFactory' ] : [ 'ProbeDumpFactory' ];
 
     return [
@@ -199,7 +200,7 @@ sub pipeline_analyses {
             -flow_into     => {
                 1 => [
                     'ReformatGenomeAdvancedSearch',
-                    'ReformatGenomeSolr',
+                    #'ReformatGenomeSolr',
                     'ReformatGenomeEBeye'
                 ],
                 -1 => 'DumpGenesJsonHighmem'
@@ -217,7 +218,7 @@ sub pipeline_analyses {
             -flow_into     => {
                 1 => [
                     'ReformatGenomeAdvancedSearch',
-                    'ReformatGenomeSolr',
+                    #'ReformatGenomeSolr',
                     'ReformatGenomeEBeye'
                 ]
             }
@@ -248,7 +249,8 @@ sub pipeline_analyses {
             -rc_name    => '1g',
             -flow_into  =>
                 {
-                    2 => ['ReformatRegulationSolr','ReformatRegulationAdvancedSearch'],
+                    #2 => ['ReformatRegulationSolr','ReformatRegulationAdvancedSearch'],
+                    2 => ['ReformatRegulationAdvancedSearch'],
                 }
         },
         {
@@ -285,7 +287,7 @@ sub pipeline_analyses {
             -flow_into  =>
                 {
                     1 => [
-                        'ReformatVariantsSolr',
+                        #'ReformatVariantsSolr',
                         'ReformatVariantsEBeye',
                         'ReformatVariantsAdvancedSearch'
                     ]
@@ -325,8 +327,8 @@ sub pipeline_analyses {
             -module     => 'Bio::EnsEMBL::Production::Pipeline::Search::DumpMerge',
             -parameters => { file_type => 'structuralvariants' },
             -rc_name    => '1g',
-            -flow_into  => {
-                1 => 'ReformatStructuralVariantsSolr' }
+           # -flow_into  => {
+           #     1 => 'ReformatStructuralVariantsSolr' }
         },
         {
             -logic_name    => 'DumpPhenotypesJson',
@@ -335,9 +337,9 @@ sub pipeline_analyses {
             -parameters    => {},
             -analysis_capacity => 10,
             -rc_name       => '1g',
-            -flow_into     => {
-                2 => 'ReformatPhenotypesSolr'
-            }
+            #-flow_into     => {
+            #    2 => 'ReformatPhenotypesSolr'
+            #}
         },
         {
             -logic_name => 'ProbeDumpFactory',
@@ -386,8 +388,10 @@ sub pipeline_analyses {
             -rc_name    => '1g',
             -flow_into  =>
                 {
-                    2 => ['ReformatProbesSolr','ReformatProbesAdvancedSearch'],
-                    3 => ['ReformatProbeSetsSolr','ReformatProbesetsAdvancedSearch'],
+                    #2 => ['ReformatProbesSolr','ReformatProbesAdvancedSearch'],
+                    #3 => ['ReformatProbeSetsSolr','ReformatProbesetsAdvancedSearch'],
+                    2 => ['ReformatProbesAdvancedSearch'],
+                    3 => ['ReformatProbesetsAdvancedSearch'],
                 }
         },
         {


### PR DESCRIPTION
… Structural Variants and Phenotype since only SOLR reformat uses them

**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

The SOLR dumps are not used by anyone at the moment so disabling them from the pipeline. Phenotype and Structural Variants dumps are only used by SOLR reformat. 

## Use case

When we run the pipeline for the release.

## Benefits

This will save 1 TB of disk space and avoid spending time reformatting these.

## Possible Drawbacks

None

## Testing

- [ N ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
