### PR TITLE
Removing code silently skipping blocks over 5000000 and increasing hi…

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/CoreStatistics_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/CoreStatistics_conf.pm
@@ -370,7 +370,7 @@ sub pipeline_analyses {
                           },
       -max_retry_count => 1,
       -hive_capacity   => 50,
-      -rc_name         => 'mem',
+      -rc_name         => 'mem_high',
     },
 
     {

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Production/PercentRepeat.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Production/PercentRepeat.pm
@@ -30,7 +30,6 @@ use warnings;
 
 sub get_density {
   my ($self, $block) = @_;
-  if ($block->length > 5000000) { return 0; }
   my $repeat_count = 0;
   my @repeats = @{ $block->get_all_RepeatFeatures() };
   @repeats = map { $_->[1] } sort { $a->[0] <=> $b->[0] } map { [$_->start, $_] } @repeats;


### PR DESCRIPTION
…ve memory for percentreapeat. This allows us to run the core stats pipeline on triticum_turgidum which has 3 chromosomes >750Mb

**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Removing code silently skipping blocks over 5000000 and increasing hive memory for percentreapeat. This allows us to run the core stats pipeline on triticum_turgidum which has 3 chromosomes >750Mb

## Use case

 triticum_turgidum has 3 chromosomes >750Mb which mean that the code was silently skipping those. The Datachecks then reported the missing percent repeat on them.

## Benefits

We can run the pipeline and have data for all the species.

## Possible Drawbacks

We need more memories

## Testing

- [ N ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
