### PR TITLE
Slight change to the logic of the DbFactory

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Common/DbFactory.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Common/DbFactory.pm
@@ -333,9 +333,8 @@ sub process_division {
         $db_division = $dba->get_MetaContainer->get_division();
       } else {
         my $dna_dba = $dba->dnadb();
-        if ($dna_dba->group eq 'core') {
-          $db_division = $dna_dba->get_MetaContainer->get_division();
-        } else {
+        $db_division = $dna_dba->get_MetaContainer->get_division();
+        unless ($db_division) {
           $self->throw("Could not retrieve DNA database for $dbname");
         }
       }


### PR DESCRIPTION
## Description
It wasn't quite working right for core-like dbs, it was making invalid assumptions about the meta_keys in those db_types.

## Use case
Using the module to iterate over corelike databases was raising an error, when everything was actually fine.

## Benefits
DbFactory handles corelike databases properly.

## Possible Drawbacks
None spring to mind.

## Testing
No unit tests for this module, but checked with test pipelines.
