### PR TITLE
[ENSCORESW-3347] update JGI data source

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_sources.json
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_sources.json
@@ -228,13 +228,13 @@
     {
       "name" : "cint_aniseed_v1",
       "parser" : "JGI_ProteinParser",
-      "file" : "ftp://ftp.jgi-psf.org/pub/JGI_data/Ciona/v1.0/ciona.prot.fasta.gz",
+      "file" : "ftp://ftp.ensembl.org/pub/misc/cint_jgi/v1/ciona.prot.fasta.gz",
       "priority" : 1
     },
     {
       "name" : "cint_jgi_v1",
       "parser" : "JGI_ProteinParser",
-      "file" : "ftp://ftp.jgi-psf.org/pub/JGI_data/Ciona/v1.0/ciona.prot.fasta.gz",
+      "file" : "ftp://ftp.ensembl.org/pub/misc/cint_jgi/v1/ciona.prot.fasta.gz",
       "priority" : 1
     },
     {


### PR DESCRIPTION

## Description

Update JGI data source to internal ftp copy.

## Use case

See https://www.ebi.ac.uk/panda/jira/browse/ENSCORESW-3347

## Benefits

We will now not depend on external download of a static file, that has become inaccessible and will need a login (which will require code changes to make it work) 

## Possible Drawbacks

If/when the data source files from JGI change, we will need to get a copy into our FTP server.
We would need to update the url anyways, so it's not much of an extra burden. 

## Testing

- [ ] Have you added/modified unit tests to test the changes?
no
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
