### PR TITLE
Related to ENSPROD-4305 and ENSPROD-4782. The first change is to only…

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/FASTA/CopyNCBIBlastDNA.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FASTA/CopyNCBIBlastDNA.pm
@@ -1,0 +1,114 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+=pod
+
+
+=head1 CONTACT
+
+  Please email comments or questions to the public Ensembl
+  developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
+
+  Questions may also be sent to the Ensembl help desk at
+  <http://www.ensembl.org/Help/Contact>.
+
+=head1 NAME
+
+Bio::EnsEMBL::Production::Pipeline::FASTA::CopyDNA
+
+=head1 DESCRIPTION
+
+Performs a find in the DNA dumps directory, for the given species, in the
+previous release FTP dump directory. Any files matching the normal gzipped
+fasta extension will be copied over to this release's directory.
+
+Previous release is defined as V<release-1>; override this class if your
+definition of the previous release is different. 
+
+Allowed parameters are:
+
+=over 8
+
+=item release - Needed to build the target path
+
+=item previous_release - Needed to build the source path
+
+=item ftp_dir - Current location of the FTP directory for the previous 
+                release. Should be the root i.e. the level I<release-XX> is in
+
+=item species - Species to work with
+
+=item base_path - The base of the dumps; reused files will be copied to here
+
+=back
+
+=cut
+
+package Bio::EnsEMBL::Production::Pipeline::FASTA::CopyNCBIBlastDNA;
+
+use strict;
+use warnings;
+
+use base qw/Bio::EnsEMBL::Production::Pipeline::FASTA::BlastIndexer/;
+
+use File::Copy;
+use File::Find;
+use File::Spec;
+
+sub fetch_input {
+  my ($self) = @_;
+  my @required = qw/release ftp_dir species/;
+  foreach my $key (@required) {
+    $self->throw("Need to define a $key parameter") unless $self->param($key);
+  }
+  my $release = $self->param('release');
+  my $prev_release = $release - 1;
+  $self->param('previous_release', $prev_release);
+  return;
+}
+
+sub run {
+  my ($self) = @_;
+  $DB::single = 1;
+  my $new_path = $self->target_dir();
+  my $files = $self->get_blast_files();
+  foreach my $file (@{$files}) {
+    $self->fine('copy %s to %s', $file, $new_path);
+    copy($file, $new_path) or $self->throw("Cannot copy $file to $new_path: $!");
+  }
+  return;
+}
+
+sub get_blast_files {
+  my ($self) = @_;
+  my $old_release = $self->param('previous_release');
+  my $release = $self->param('release');
+  my $species = ucfirst($self->param('species'));
+  my $base = $self->param('ftp_dir');
+  my $type = $self->param('type');
+  my $old_path = File::Spec->catdir($base, "release-$old_release", 'ncbi_blast', $type);
+  my $filter = sub {
+    my ($filename) = @_;
+    return ($filename =~ /$species\./) ? 1 : 0;
+  };
+  my $files = $self->find_files($old_path, $filter);
+  return $files;
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/FASTA/CopyNCBIBlastDNA.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FASTA/CopyNCBIBlastDNA.pm
@@ -30,13 +30,13 @@ limitations under the License.
 
 =head1 NAME
 
-Bio::EnsEMBL::Production::Pipeline::FASTA::CopyDNA
+Bio::EnsEMBL::Production::Pipeline::FASTA::CopyNCBIBlastDNA
 
 =head1 DESCRIPTION
 
-Performs a find in the DNA dumps directory, for the given species, in the
-previous release FTP dump directory. Any files matching the normal gzipped
-fasta extension will be copied over to this release's directory.
+Performs a find in the ncbi_blast dumps directory, for the given species, in the
+previous release FTP dump directory. Any files starting with the given species name
+will be copied over to this release's directory.
 
 Previous release is defined as V<release-1>; override this class if your
 definition of the previous release is different. 
@@ -55,6 +55,10 @@ Allowed parameters are:
 =item species - Species to work with
 
 =item base_path - The base of the dumps; reused files will be copied to here
+
+=item type - the ncbi_blast type. Here we only want to copy genomic data
+
+=item blast_dir - This is ncbi_blast at the moment. This information is used by BlastIndexer to create current dir
 
 =back
 
@@ -85,7 +89,6 @@ sub fetch_input {
 
 sub run {
   my ($self) = @_;
-  $DB::single = 1;
   my $new_path = $self->target_dir();
   my $files = $self->get_blast_files();
   foreach my $file (@{$files}) {

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_vertebrates_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_vertebrates_conf.pm
@@ -126,24 +126,36 @@ sub pipeline_analyses {
       },
       {
           -logic_name        => 'ChecksumGeneratorBLASTGENE',
-                    -parameters => {
+          -parameters => {
                             dir => $self->o('ftp_dir')."/vertebrates/ncbi_blast/genes/"
           },
           -module            => 'Bio::EnsEMBL::Production::Pipeline::Common::ChecksumGenerator',
+          -flow_into       => { '1' => 'ChecksumGeneratorBLASTGENOMIC', },
           -analysis_capacity => 10,
           -priority => 5,
       },
             {
           -logic_name        => 'ChecksumGeneratorBLASTGENOMIC',
-                    -parameters => {
+          -parameters => {
                             dir => $self->o('ftp_dir')."/vertebrates/ncbi_blast/genomic/"
           },
           -module            => 'Bio::EnsEMBL::Production::Pipeline::Common::ChecksumGenerator',
           -analysis_capacity => 10,
           -priority => 5,
       },
-
-
+      {
+          -logic_name        => 'copy_ncbiblastDNA',
+          -parameters => {
+                          ftp_dir => $self->o('prev_rel_dir'),
+                          dir => $self->o('ftp_dir')."/vertebrates/ncbi_blast/genomic/",
+                          release => $self->o('release'),
+                          type    => 'genomic',
+                          blast_dir => 'ncbi_blast',
+          },
+          -module            => 'Bio::EnsEMBL::Production::Pipeline::FASTA::CopyNCBIBlastDNA',
+          -analysis_capacity => 10,
+          -priority => 5,
+      },
     ];
 }
 
@@ -165,7 +177,8 @@ sub tweak_analyses {
           $analyses_by_name->{'concat_fasta'}->{'-flow_into'}   = { 1 => [qw/index_ncbiblastDNA primary_assembly/]};
         }
         $analyses_by_name->{'fasta_pep'}->{'-flow_into'} = { 2 => ['index_ncbiblastPEP'], 3 => ['index_ncbiblastGENE'] };
-        $analyses_by_name->{'checksum_generator'}->{'-flow_into'} = { '1' => ['ChecksumGeneratorBLASTGENE','ChecksumGeneratorBLASTGENOMIC'] };
+        $analyses_by_name->{'job_factory'}->{'-flow_into'} = { '2->A' => ['backbone_job_pipeline'], 'A->1' => 'ChecksumGeneratorBLASTGENE', };
+        $analyses_by_name->{'copy_dna'}->{'-flow_into'} = { 1 => ['copy_ncbiblastDNA']};
     }
 }
 


### PR DESCRIPTION
… run checksum for NCBI blast genomic and gene only once since all the species share the same ncbi_blast directory. In the current pipeline a species is dumped and then the checksum is regenerated each time, which is time consuming and doesn't make sense. The second change is related to a request from the Webteam to have all the ncbi_blast files for all the species available every release instead of only for new species or species that have been updated. The new module copy_ncbiblastDNA works a bit like the copy_dna module, it finds last release files and copy them to this release directory.

**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Related to ENSPROD-4305 and ENSPROD-4782. The first change is to only run checksum for NCBI blast genomic and gene only once since all the species share the same ncbi_blast directory. In the current pipeline a species is dumped and then the checksum is regenerated each time, which is time consuming and doesn't make sense. The second change is related to a request from the Webteam to have all the ncbi_blast files for all the species available every release instead of only for new species or species that have been updated. The new module copy_ncbiblastDNA works a bit like the copy_dna module, it finds last release files and copy them to this release directory.

## Use case

When we run the pipeline for vertebrates

## Benefits

We wont waste ressources recomputing the ncbi_blast checksum for nothing. ncbi_blast will now match what the Webteam is expecting.

## Possible Drawbacks

Having all the ncbi_blast for all the species every release will consume more disk space.

## Testing

- [ N ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
