### PR TITLE
DumpCore_conf.pm: use a local copy of xref_LOD_mapping.json

### DIFF
--- a/conf/xref_LOD_mapping.json
+++ b/conf/xref_LOD_mapping.json
@@ -1,0 +1,1690 @@
+{
+  "mappings": [
+    {
+      "db_name": "ArrayExpress",
+      "example_id": "ENSG00000265094",
+      "ignore": true,
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "ArrayExpress"
+    },
+    {
+      "db_name": "Allergome",
+      "id_namespace": "allergome",
+      "description": "Repository of data related to all IgE-binding compounds, aka allergens",
+      "bidirectional": false,
+      "feature_type": "annotation"
+    },
+    {
+      "db_name": "BaylorCollege",
+      "example_id": "NCRNA_8378",
+      "ignore": true,
+      "bidirectional": false,
+      "feature_type": "transcript",
+      "ensembl_db_name": "BaylorCollege"
+    },
+    {
+      "db_name": "BindingDB",
+      "id_namespace": "bindindDB",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "BindingDB"
+    },
+    {
+      "db_name": "BioCyc",
+      "id_namespace": "biocyc",
+      "description": "Collection of pathway/genome databases",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "BioCyc"
+    },
+    {
+      "db_name": "BioGRID",
+      "example_id": "59420",
+      "id_namespace": "biogrid",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "BioGRID"
+    },
+    {
+      "db_name": "BRENDA",
+      "id_namespace":"brenda",
+      "description": "Enzyme functional data collection",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "BRENDA"
+    },
+    {
+      "db_name": "CADRE",
+      "example_id": "AFUA_3G01196",
+      "ignore": true,
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "CADRE"
+    },
+    {
+      "db_name": "CAZy",
+      "example_id": "GT10",
+      "id_namespace": "cazy",
+      "description": "Carbohydrate enzyme database",
+      "bidirectional": false,
+      "feature_type": "annotation"
+    },
+    {
+      "db_name": "cda",
+      "description": "Candida Genome Database",
+      "example_id": "CAL0000001",
+      "id_namespace": "cgd",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "CGD"
+    },
+    {
+      "db_name": "cdd",
+      "description": "Conserved Domain Database",
+      "id_namespace": "cdd",
+      "bidirectional": false,
+      "feature_type": "annotation"
+    },
+    {
+      "db_name": "CCDS",
+      "example_id": "CCDS10469",
+      "id_namespace": "ccds",
+      "bidirectional": false,
+      "feature_type": "gene",
+      "ensembl_db_name": "CCDS"
+    },
+    {
+      "db_name": "ChEBI",
+      "id_namespace": "chebi",
+      "canonical_LOD": "http://purl.obolibrary.org/obo/CHEBI/",
+      "description": "Chemical Entities of Biological Interest ontology",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "ChEBI"
+    },
+    {
+      "db_name": "ChEMBL",
+      "example_id": "CHEMBL1075166",
+      "id_namespace": "chembl.target",
+      "canonical_LOD": "http://rdf.ebi.ac.uk/resource/chembl/target/",
+      "URI_type": "http://rdf.ebi.ac.uk/terms/chembl#SingleProtein",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "ChEMBL"
+    },
+    {
+      "db_name": "Clone_based_ensembl_gene",
+      "example_id": "AL162430.1",
+      "ignore": true,
+      "description": "Source of gene names fabricated by us to ensure all genes and transcripts have a display name, even if we haven't imported any",
+      "bidirectional": true,
+      "feature_type": "gene",
+      "priority": 10,
+      "ensembl_db_name": "Clone_based_ensembl_gene"
+    },
+    {
+      "db_name": "Clone_based_ensembl_transcript",
+      "ignore":true,
+      "description": "Source of gene names fabricated by us to ensure all genes and transcripts have a display name, even if we haven't imported any",
+      "bidirectional": true,
+      "feature_type": "transcript",
+      "priority": 10,
+      "ensembl_db_name": "Clone_based_ensembl_transcript"
+    },
+    {
+      "db_name": "Clone_based_vega_gene",
+      "ignore":true,
+      "description": "Retired source of gene names from Havana project. DB no longer available",
+      "bidirectional": true,
+      "feature_type": "gene",
+      "ensembl_db_name": "Clone_based_vega_gene"
+    },
+    {
+      "db_name": "Clone_based_vega_transcript",
+      "ignore":true,
+      "description": "Retired source of transcript names from Havana project. DB no longer available",
+      "bidirectional": true,
+      "feature_type": "transcript",
+      "ensembl_db_name": "Clone_based_vega_transcript"
+    },
+    {
+      "db_name": "Conoserver",
+      "id_namespace": "conoserver",
+      "description": "Conopeptide resource",
+      "bidirectional": false,
+      "feature_type": "translation"
+    },
+    {
+      "db_name": "CTD",
+      "description": "Gene part of the Comparative Toxicogenomics Database",
+      "id_namespace": "ctd.gene",
+      "bidirectional": true,
+      "feature_type": "gene"
+    },
+    {
+      "db_name": "DisProt",
+      "id_namespace": "disprot",
+      "description": "Database of protein disorder",
+      "bidirectional": false,
+      "feature_type": "translation",
+      "ensembl_db_name": "DisProt"
+    },
+    {
+      "db_name": "DBASS3",
+      "example_id": "80",
+      "ignore": true,
+      "bidirectional": false,
+      "feature_type": "gene",
+      "ensembl_db_name": "DBASS3"
+    },
+    {
+      "db_name": "DBASS",
+      "example_id": "80",
+      "ignore": true,
+      "bidirectional": false,
+      "feature_type": "gene",
+      "ensembl_db_name": "DBASS5"
+    },
+    {
+      "db_name": "Drugbank",
+      "description": "DrugBank database",
+      "id_namespace": "drugbank",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "DrugBank"
+    },
+    {
+      "db_name": "dictybase",
+      "id_namespace": "dictybase",
+      "description": "Dicybase Gene, see dictybase.org",
+      "example_id": "DDB_G0267522",
+      "bidirectional": false,
+      "feature_type": "translation",
+      "ensembl_db_name": "dictyBase"
+    },
+    {
+      "db_name": "DIP",
+      "description": "Database of Interacting Proteins",
+      "id_namespace": "dip",
+      "bidirectional": false,
+      "feature_type": "translation",
+      "ensembl_db_name": "DIP"
+    },
+    {
+      "db_name": "doi",
+      "description": "Digital Object Identifier System",
+      "example_id": "doi:10.1038/nbt1156",
+      "id_namespace": "doi",
+      "canonical_LOD": "https://dx.doi.org/",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "DOI"
+    },
+    {
+      "db_name": "ensembl",
+      "example_id": "ENSG00000265094",
+      "id_namespace": "ensembl",
+      "canonical_LOD": "http://rdf.ebi.ac.uk/resource/ensembl/",
+      "bidirectional": true,
+      "feature_type": "gene"
+    },
+    {
+      "db_name": "ensembl_transcript",
+      "example_id": "ENST00000266557",
+      "id_namespace": "ensembl",
+      "canonical_LOD": "http://rdf.ebi.ac.uk/resource/ensembl.transcript/",
+      "bidirectional": true,
+      "feature_type": "transcript"
+    },
+    {
+      "db_name": "ensembl_protein",
+      "example_id": "ENSP00000014214",
+      "id_namespace": "ensembl",
+      "canonical_LOD": "http://rdf.ebi.ac.uk/resource/ensembl.protein/",
+      "bidirectional": true,
+      "feature_type": "translation"
+    },
+    {
+      "db_name": "ensemblbacteria",
+      "canonical_LOD": "http://rdf.ebi.ac.uk/resource/ensembl/",
+      "id_namespace": "ensembl.bacteria",
+      "bidirectional": true,
+      "feature_type": "annotation"
+    },
+    {
+      "db_name": "ensemblmetazoa",
+      "canonical_LOD": "http://rdf.ebi.ac.uk/resource/ensembl/",
+      "id_namespace": "ensembl.metazoa",
+      "bidirectional": true,
+      "feature_type": "annotation",
+      "ensembl_db_name": "Ensembl_Metazoa"
+    },
+    {
+      "db_name": "ensemblplants",
+      "canonical_LOD": "http://rdf.ebi.ac.uk/resource/ensembl/",
+      "id_namespace": "ensembl.plants",
+      "bidirectional": true,
+      "feature_type": "annotation",
+      "ensembl_db_name": "Ensembl_Plants"
+    },
+    {
+      "db_name": "ensemblprotists",
+      "canonical_LOD": "http://rdf.ebi.ac.uk/resource/ensembl/",
+      "id_namespace": "ensembl.protists",
+      "bidirectional": true,
+      "feature_type": "annotation",
+      "ensembl_db_name": "Ensembl_Protists"
+    },
+    {
+      "db_name": "ensemblfungi",
+      "canonical_LOD": "http://rdf.ebi.ac.uk/resource/ensembl/",
+      "id_namespace": "ensembl.fungi",
+      "bidirectional": true,
+      "feature_type": "annotation",
+      "ensembl_db_name": "Ensembl_Fungi"
+    },
+    {
+      "db_name": "EC",
+      "Decription": "Enzyme nomenclature",
+      "example_id": "2.7.11.23",
+      "id_namespace": "ec-code",
+      "EDAM_type": "data_1011",
+      "EDAM_term": "EC number",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "EC_NUMBER"
+    },
+    {
+      "db_name": "EC_NUMBER",
+      "Decription": "Enzyme nomenclature, long form",
+      "example_id": "2.7.11.23",
+      "id_namespace": "ec-code",
+      "EDAM_type": "data_1011",
+      "EDAM_term": "EC number",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "EC_NUMBER"
+    },
+    {
+      "db_name": "eggNOG",
+      "id_namespace": "eggnog",
+      "bidirectional": false,
+      "feature_type": "annotation"
+    },
+    {
+      "db_name": "EMBL",
+      "example_id": "AABR06092040",
+      "id_namespace": "ena.embl",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "EMBL"
+    },
+    {
+      "db_name": "EMBL_predicted",
+      "example_id": "AAHF01000010",
+      "id_namespace": "ena.embl",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "EMBL_predicted"
+    },
+    {
+      "db_name": "ENA_TRANSCRIPT",
+      "example_id": "AFUA_3G01196",
+      "ignore": true,
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "ENA_TRANSCRIPT"
+    },
+    {
+      "db_name": "Ens_Hs_transcript",
+      "example_id": "ENST00000266557",
+      "ignore": true,
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "Ens_Hs_transcript"
+    },
+    {
+      "db_name": "ENS_LRG_gene",
+      "example_id": "LRG_357",
+      "id_namespace": "lrg",
+      "bidirectional": true,
+      "feature_type": "gene",
+      "ensembl_db_name": "ENS_LRG_gene"
+    },
+    {
+      "db_name": "ENS_LRG_transcript",
+      "example_id": "LRG_357t1",
+      "id_namespace": "lrg",
+      "bidirectional": true,
+      "feature_type": "transcript",
+      "ensembl_db_name": "ENS_LRG_transcript"
+    },
+    {
+      "db_name": "lrg",
+      "example_id": "LRG_357",
+      "id_namespace": "lrg",
+      "bidirectional": true,
+      "feature_type": "gene",
+      "ensembl_db_name": "LRG"
+    },
+    {
+      "db_name": "EntrezGene",
+      "example_id": "100125760",
+      "id_namespace": "ncbigene",
+      "URI_type": "http://purl.obolibrary.org/obo/SO_0000704",
+      "bidirectional": true,
+      "feature_type": "gene",
+      "priority": 60,
+      "ensembl_db_name": "EntrezGene"
+    },
+    {
+      "db_name": "NCBIGene",
+      "example_id": "100125760",
+      "id_namespace": "ncbigene",
+      "URI_type": "http://purl.obolibrary.org/obo/SO_0000704",
+      "bidirectional": true,
+      "feature_type": "gene",
+      "priority": 60,
+      "ensembl_db_name": "EntrezGene"
+    },
+    {
+      "db_name": "GeneID",
+      "example_id": "100125760",
+      "id_namespace": "ncbigene",
+      "URI_type": "http://purl.obolibrary.org/obo/SO_0000704",
+      "bidirectional": true,
+      "feature_type": "gene",
+      "priority": 60,
+      "ensembl_db_name": "GeneID"
+    },
+    {
+      "db_name": "EntrezGene_trans_name",
+      "example_id": "CTD-2297D10.2-001",
+      "ignore": true,
+      "bidirectional": true,
+      "feature_type": "translation",
+      "ensembl_db_name": "EntrezGene_trans_name"
+    },
+    {
+      "db_name": "EPD",
+      "example_id": "11050",
+      "id_namespace": "epd",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "EPD"
+    },
+    {
+      "db_name": "ExpressionAtlas",
+      "id_namespace": "gxa.gene",
+      "bidirectional": true,
+      "feature_type": "gene"
+    },
+    {
+      "db_name": "Fantom",
+      "ignore": true,
+      "bidirectional": false,
+      "feature_type": "annotation"
+    },
+    {
+      "db_name": "flybase_annotation_id",
+      "example_id": "FBan0011023",
+      "ignore": true,
+      "id_namespace": "flybase",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "flybase_annotation_id"
+    },
+    {
+      "db_name": "flybase",
+      "id_namespace": "flybase",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "flybase_symbol"
+    },
+    {
+      "db_name": "flybase_gene_id",
+      "example_id": "FBgn0031208",
+      "id_namespace": "flybase",
+      "bidirectional": true,
+      "feature_type": "gene",
+      "ensembl_db_name": "flybase_gene_id"
+    },
+    {
+      "db_name": "flybase_transcript_id",
+      "example_id": "FBtr0300689",
+      "id_namespace": "flybase",
+      "bidirectional": true,
+      "feature_type": "transcript",
+      "ensembl_db_name": "flybase_transcript_id"
+    },
+    {
+      "db_name": "flybase_translation_id",
+      "example_id": "FBpp0289913",
+      "id_namespace": "flybase",
+      "bidirectional": true,
+      "feature_type": "translation",
+      "ensembl_db_name": "flybase_translation_id"
+    },
+    {
+      "db_name": "FlyBaseCGID_gene",
+      "example_id": "CG11023",
+      "id_namespace": "flybase",
+      "ignore": true,
+      "bidirectional": true,
+      "feature_type": "gene",
+      "ensembl_db_name": "FlyBaseCGID_gene"
+    },
+    {
+      "db_name": "FlyBaseCGID_transcript",
+      "example_id": "CG11023-RB",
+      "id_namespace": "flybase",
+      "ignore": true,
+      "bidirectional": true,
+      "feature_type": "transcript",
+      "ensembl_db_name": "FlyBaseCGID_transcript"
+    },
+    {
+      "db_name": "FlyBaseCGID_translation",
+      "example_id": "CG11023-PB",
+      "id_namespace": "flybase",
+      "ignore": true,
+      "bidirectional": true,
+      "feature_type": "translation",
+      "ensembl_db_name": "FlyBaseCGID_translation"
+    },
+    {
+      "db_name": "FlyBaseName_gene",
+      "example_id": "FBgn0031208",
+      "id_namespace": "flybase",
+      "bidirectional": true,
+      "feature_type": "gene",
+      "ensembl_db_name": "FlyBaseName_gene"
+    },
+    {
+      "db_name": "FlyBaseName_transcript",
+      "example_id": "FBtr0300689",
+      "id_namespace": "flybase",
+      "bidirectional": true,
+      "feature_type": "transcript",
+      "ensembl_db_name": "FlyBaseName_transcript"
+    },
+    {
+      "db_name": "FlyBaseName_translation",
+      "example_id": "FBpp0289913",
+      "id_namespace": "flybase",
+      "bidirectional": true,
+      "feature_type": "translation",
+      "ensembl_db_name": "FlyBaseName_translation"
+    },
+    {
+      "db_name": "FlyReactome",
+      "example_id": "101824",
+      "ignore": true,
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "FlyReactome"
+    },
+    {
+      "db_name": "GeneCards",
+      "id_namespace": "genecards",
+      "description": "Human gene database of related transcriptomic, genetic, proteomic, functional and disease information",
+      "example_id": "ABL1",
+      "bidirectional": false,
+      "feature_type": "gene"
+    },
+    {
+      "db_name": "GeneDB",
+      "id_namespace": "genedb",
+      "example_id": "Cj1536c",
+      "bidirectional": true,
+      "feature_type": "gene",
+      "ensembl_db_name": "GeneDB"
+    },
+    {
+      "db_name": "GeneTree",
+      "example_id": "ENSGT00800000124088",
+      "id_namespace": "genetree",
+      "bidirectional": false,
+      "feature_type": "annotation"
+    },
+    {
+      "db_name": "GeneWiki",
+      "description": "Gene Wiki is different to WikiGene",
+      "id_namespace": "genewiki",
+      "bidirectional": false,
+      "feature_type": "gene"
+    },
+    {
+      "db_name": "GenomeRNAi",
+      "example_id": "33155",
+      "ignore": true,
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "GenomeRNAi"
+    },
+    {
+      "db_name": "Genoscope_pred_gene",
+      "example_id": "GSTENG10001827001",
+      "ignore": true,
+      "bidirectional": false,
+      "feature_type": "gene",
+      "ensembl_db_name": "Genoscope_pred_gene"
+    },
+    {
+      "db_name": "Genoscope_pred_translation",
+      "example_id": "GSTENT10001827001",
+      "ignore": true,
+      "bidirectional": false,
+      "feature_type": "translation",
+      "ensembl_db_name": "Genoscope_pred_translation"
+    },
+    {
+      "db_name": "GO",
+      "example_id": "GO:0000166",
+      "id_namespace": "go",
+      "URI_type": "http://purl.obolibrary.org/obo/",
+      "regex": "/GO:/GO_/",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "GO"
+    },
+    {
+      "db_name": "GO_to_gene",
+      "example_id": "GO:0016246",
+      "id_namespace": "go",
+      "URI_type": "http://purl.obolibrary.org/obo/",
+      "regex": "/GO:/GO_/",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "GO_to_gene"
+    },
+    {
+      "db_name": "goslim_goa",
+      "example_id": "GO:0003674",
+      "id_namespace": "go",
+      "URI_type": "http://purl.obolibrary.org/obo/",
+      "regex": "/GO:/GO_/",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "goslim_goa"
+    },
+    {
+      "db_name": "Gramene_MarkersDB_EST",
+      "example_id": "DT479660",
+      "ignore": true,
+      "description": "While several identifiers.org paths are possible for Gramene, external sources are not sufficiently explicit to choose the right one",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "Gramene_MarkersDB_EST"
+    },
+    {
+      "db_name": "Gramene_MarkersDB_mRNA",
+      "example_id": "XM_002305109",
+      "ignore": true,
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "Gramene_MarkersDB_mRNA"
+    },
+    {
+      "db_name": "Gramene_Pathway",
+      "example_id": "6.3.2.12",
+      "ignore": true,
+      "bidirectional": false,
+      "feature_type": "annotation"
+    },
+    {
+      "db_name": "HAMAP",
+      "example_id": "MF_00367",
+      "id_namespace": "hamap",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "HAMAP"
+    },
+    {
+      "db_name": "HGNC",
+      "example_id": "HGNC:13598",
+      "id_namespace": "hgnc",
+      "bidirectional": true,
+      "feature_type": "gene",
+      "priority": 100,
+      "ensembl_db_name": "HGNC"
+    },
+    {
+      "db_name": "HGNC_trans_name",
+      "example_id": "CCRN4L (2 of 2)-201",
+      "ignore": true,
+      "feature_type": "transcript",
+      "ensembl_db_name": "HGNC_trans_name"
+    },
+    {
+      "db_name": "HOGENOM",
+      "example_id": "HOG000113686",
+      "id_namespace": "hogenom",
+      "description": "Gene families by phylogeny",
+      "bidirectional": false,
+      "feature_type": "annotation"
+    },
+    {
+      "db_name": "HOVERGEN",
+      "id_namespace":"hovergen",
+      "description":"Database of homologous vertebrate genes",
+      "bidirectional": false,
+      "feature_type": "annotation"
+    },
+    {
+      "db_name": "HPA",
+      "example_id": "CD36",
+      "ignore": true,
+      "description" : "Human Protein Atlas. IDs can be Ensembl-like",
+      "id_namespace": "hpa",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "HPA"
+    },
+    {
+      "db_name": "IKMCs_ES_cells_available",
+      "ignore": true,
+      "bidirectional": false,
+      "feature_type": "annotation"
+    },
+    {
+      "db_name": "IKMCs_Mice_available",
+      "ignore": true,
+      "bidirectional": false,
+      "feature_type": "annotation"
+    },
+    {
+      "db_name": "IKMCs_No_products_available_yet",
+      "ignore": true,
+      "bidirectional": false,
+      "feature_type": "annotation"
+    },
+    {
+      "db_name": "IKMCs_Vector_available",
+      "ignore": true,
+      "bidirectional": false,
+      "feature_type": "annotation"
+    },
+    {
+      "db_name": "IntAct",
+      "id_namespace": "intact",
+      "example_id": "EBI-2307691",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "IntAct"
+    },
+    {
+      "db_name": "InteractiveFly",
+      "example_id": "cytoskel/lethl2g1.htm",
+      "ignore": true,
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "InteractiveFly"
+    },
+    {
+      "db_name": "Interpro",
+      "example_id": "IPR003653",
+      "id_namespace": "interpro",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "Interpro"
+    },
+    {
+      "db_name": "IPI",
+      "example_id": "IPI00867334",
+      "ignore": true,
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "IPI"
+    },
+    {
+      "db_name": "IRGSPv1_GENE",
+      "example_id": "OS11G0599200",
+      "ignore": true,
+      "bidirectional": true,
+      "feature_type": "gene",
+      "ensembl_db_name": "IRGSPv1_GENE"
+    },
+    {
+      "db_name": "IRGSPv1_TRANSCRIPT",
+      "example_id": "OS11T0599200-01",
+      "bidirectional": false,
+      "feature_type": "transcript",
+      "ensembl_db_name": "IRGSPv1_TRANSCRIPT"
+    },
+    {
+      "db_name": "JGI",
+      "description": "Joint Genome Institute, describing Ciona Intestinalis protein sequences",
+      "feature_type": "protein"
+    },
+    {
+      "db_name": "KEGG",
+      "example_id": "00450+2.1.1.-",
+      "ignore": true,
+      "id_namespace": "kegg.genes",
+      "bidirectional": true,
+      "feature_type": "gene",
+      "ensembl_db_name": "KEGG"
+    },
+    {
+      "db_name": "leproma",
+      "example_id": "ML",
+      "id_namespace": "myco.lepra",
+      "description": "MycoBrowser leprae",
+      "bidirectional": false,
+      "feature_type": "annotation"
+    },
+    {
+      "db_name": "MEROPS",
+      "example_id": "C12.001",
+      "id_namespace": "merops",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "MEROPS"
+    },
+    {
+      "db_name": "MetaCyc",
+      "example_id": "PWY-7248",
+      "ignore": true,
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "MetaCyc"
+    },
+    {
+      "db_name": "MGI",
+      "example_id": "MGI:102478",
+      "description": "Mouse genome database (MGD) is an authority on rodent genes",
+      "id_namespace": "mgi",
+      "bidirectional": true,
+      "feature_type": "gene",
+      "priority": 100,
+      "ensembl_db_name": "MGI"
+    },
+    {
+      "db_name": "MGI_trans_name",
+      "ignore": true,
+      "bidirectional": true,
+      "feature_type": "transcript",
+      "ensembl_db_name": "MGI_trans_name"
+    },
+    {
+      "db_name": "MIM",
+      "example_id": "602349",
+      "ignore": true,
+      "id_namespace": "omim",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "MIM_GENE"
+    },
+    {
+      "db_name": "MIM_GENE",
+      "example_id": "602349",
+      "ignore": true,
+      "id_namespace": "omim",
+      "bidirectional": true,
+      "feature_type": "gene",
+      "ensembl_db_name": "MIM_GENE"
+    },
+    {
+      "db_name": "MIM_MORBID",
+      "example_id": "615122",
+      "ignore": true,
+      "id_namespace": "omim",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "MIM_MORBID"
+    },
+    {
+      "db_name": "mim2gene",
+      "description": "MIM data describing the MIM gene entries and their relationships with other resources",
+      "example_id": "615122",
+      "id_namespace": "omim",
+      "ignore": true,
+      "bidirectional": false,
+      "feature_type": "gene",
+      "ensembl_db_name": "MIM_GENE"
+    },
+    {
+      "db_name": "mint",
+      "id_namespace": "mint",
+      "description": "Molecular INTeraction database",
+      "example_id": "MINT-79",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "MINT"
+    },
+    {
+      "db_name": "miRBase",
+      "example_id": "MI0000866",
+      "id_namespace": "mirbase",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "priority": 100,
+      "ensembl_db_name": "miRBase"
+    },
+    {
+      "db_name": "miRBase mature sequence",
+      "example_id": "MIMAT0005480",
+      "id_namespace": "mirbase.mature",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "miRBase"
+    },
+    {
+      "db_name": "miRBase_gene_name",
+      "example_id": "dre-let-7a-1.1",
+      "ignore": true,
+      "bidirectional": true,
+      "feature_type": "gene",
+      "priority": 100
+    },
+    {
+      "db_name": "miRBase_trans_name",
+      "ignore": true,
+      "bidirectional": false,
+      "feature_type": "transcript",
+      "ensembl_db_name": "miRBase_trans_name"
+    },
+    {
+      "db_name": "MitoDrome",
+      "example_id": "MTDROME11455",
+      "ignore": true,
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "MitoDrome"
+    },
+    {
+      "db_name": "NASC_GENE_ID",
+      "example_id": "AT3G18710",
+      "ignore": true,
+      "bidirectional": true,
+      "feature_type": "gene",
+      "ensembl_db_name": "NASC_GENE_ID"
+    },
+    {
+      "db_name": "ncbi taxonomy",
+      "canonical_LOD": "http://purl.obolibrary.org/obo/NCBITaxon/",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "NCBI_TAXONOMY"
+    },
+    {
+      "db_name": "nextProt",
+      "id_namespace": "nextprot",
+      "bidirectional": false,
+      "feature_type": "annotation"
+    },
+    {
+      "db_name": "OMA",
+      "Description": "OMA Group collection",
+      "example_id": "ICHKMQS",
+      "id_namespace": "oma.grp",
+      "bidirectional": false,
+      "feature_type": "annotation"
+    },
+    {
+      "db_name": "OrthoDB",
+      "example_id": "EOG7N63M9",
+      "id_namespace": "orthodb",
+      "bidirectional": false,
+      "feature_type": "annotation"
+    },
+    {
+      "db_name": "Orphanet",
+      "id_namespace": "orphanet",
+      "description": "Reference portal for rare diseases and orphan drugs",
+      "bidirectional": false,
+      "feature_type": "annotation"
+    },
+    {
+      "db_name": "OTTG",
+      "example_id": "OTTDARG00000029138",
+      "description": "Havana gene",
+      "ignore": true,
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "OTTG"
+    },
+    {
+      "db_name": "OTTT",
+      "ignore": true,
+      "description": "Havana transcript",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "OTTT"
+    },
+    {
+      "db_name": "PaxDB",
+      "id_namespace": "paxdb.protein",
+      "description": "Absolute protein abundance levels across different organisms",
+      "bidirectional": false,
+      "feature_type": "translation"
+    },
+    {
+      "db_name": "PDB",
+      "example_id": "1AU7",
+      "id_namespace": "pdb",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "PDB"
+    },
+    {
+      "db_name": "PDBsum",
+      "example_id": "1AU7",
+      "id_namespace": "pdb",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "PDBsum"
+    },
+    {
+      "db_name":"PANTHER",
+      "example_id":"PTHR12929",
+      "id_namespace":"panther.family",
+      "bidirectional": false,
+      "feature_type": "annotation"
+    },
+    {
+      "db_name": "PeptideAtlas",
+      "id_namespace":"peptideatlas",
+      "description": "Publicy accessible peptides identified in tandem mass spectrometry proteomics",
+      "bidirectional": false,
+      "feature_type": "annotation"
+    },
+    {
+      "db_name": "Peroxibase",
+      "id_namespace": "peroxibase",
+      "bidirectional": false,
+      "feature_type": "annotation"
+    },
+    {
+      "db_name": "PFam",
+      "example_id": "PF01040",
+      "id_namespace": "pfam",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "PFAM"
+    },
+    {
+      "db_name": "PHI",
+      "example_id": "PHI:2322",
+      "ignore": true,
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "PHI"
+    },
+    {
+      "db_name": "PhosphoSite",
+      "id_namespace": "phosphosite.protein",
+      "description": "Phosphorylation sites",
+      "bidirectional": false,
+      "feature_type": "annotation"
+    },
+    {
+      "db_name": "PhylomeDB",
+      "id_namespace": "phylomedb",
+      "bidirectional": false,
+      "feature_type": "annotation"
+    },
+    {
+      "db_name": "PIRSF",
+      "example_id": "PIRSF005355",
+      "id_namespace": "pirsf",
+      "bidirectional": false,
+      "feature_type": "annotation"
+    },
+    {
+      "db_name": "PlantGDB_PUT",
+      "example_id": "PUT-157a-Populus_trichocarpa-7958",
+      "ignore": true,
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "PlantGDB_PUT"
+    },
+    {
+      "db_name": "PO",
+      "example_id": "PO:0001185",
+      "id_namespace": "po",
+      "canonical_LOD": "http://purl.obolibrary.org/obo/",
+      "regex": "/PO:/PO_/",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "PO"
+    },
+    {
+      "db_name": "pombase",
+      "id_namespace": "pombase",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "PomBase_Gene_Name"
+    },
+    {
+      "db_name": "PRIDE",
+      "example_id": "Q7M3C1",
+      "id_namespace": "pride",
+      "bidirectional": true,
+      "feature_type": "annotation",
+      "ensembl_db_name": "PRIDE"
+    },
+    {
+      "db_name": "ProDom",
+      "id_namespace": "prodom",
+      "example_id": "PD10000",
+      "description": "Protein Domain families database",
+      "bidirectional": false,
+      "feature_type": "annotation"
+    },
+    {
+      "db_name": "PROSITE",
+      "example_id": "PS00107",
+      "id_namespace": "prosite",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "ProSite"
+    },
+    {
+      "db_name": "protein_id",
+      "example_id": "AAC51247",
+      "id_namespace": "insdc",
+      "URI_type": "http://rdf.ebi.ac.uk/resource/ensembl/NucleotideSequenceDatabase",
+      "bidirectional": false,
+      "feature_type": "translation",
+      "ensembl_db_name": "protein_id"
+    },
+    {
+      "db_name": "protein_id_predicted",
+      "example_id": "CAF91510",
+      "id_namespace": "insdc",
+      "URI_type": "http://rdf.ebi.ac.uk/resource/ensembl/NucleotideSequenceDatabase",
+      "bidirectional": false,
+      "feature_type": "translation",
+      "ensembl_db_name": "protein_id_predicted"
+    },
+    {
+      "db_name": "proteinmodelportal",
+      "id_namespace": "pmp",
+      "bidirectional": false,
+      "feature_type": "annotation"
+    },
+    {
+      "db_name": "PUBMED",
+      "example_id": "10366627",
+      "id_namespace": "pubmed",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "PUBMED"
+    },
+    {
+      "db_name": "Reactome",
+      "example_id": "REACT_71",
+      "id_namespace": "reactome",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "Reactome"
+    },
+    {
+      "db_name": "Rebase",
+      "description": "Restriction enzyme database",
+      "id_namespace": "rebase",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "REBASE"
+    },
+    { 
+      "db_name": "RefSeq",
+      "example_id": "XP_002919412.1",
+      "id_namespace": "refseq",
+      "bidirectional": true,
+      "feature_type": "annotation",
+      "ensembl_db_name": "RefSeq"
+    },
+    {
+      "db_name": "RefSeq_dna",
+      "example_id": "NM_001179183",
+      "id_namespace": "refseq",
+      "bidirectional": true,
+      "feature_type": "transcript",
+      "ensembl_db_name": "RefSeq_dna"
+    },
+    {
+      "db_name": "RefSeq_dna_predicted",
+      "example_id": "XM_001481536",
+      "id_namespace": "refseq",
+      "bidirectional": true,
+      "feature_type": "transcript",
+      "ensembl_db_name": "RefSeq_dna_predicted"
+    },
+    {
+      "db_name": "RefSeq_genomic",
+      "example_id": "NG_002398",
+      "id_namespace": "refseq",
+      "bidirectional": true,
+      "feature_type": "gene",
+      "ensembl_db_name": "RefSeq_genomic"
+    },
+    {
+      "db_name": "RefSeq_mRNA",
+      "example_id": "NM_001105043",
+      "id_namespace": "refseq",
+      "bidirectional": true,
+      "feature_type": "transcript",
+      "ensembl_db_name": "RefSeq_mRNA"
+    },
+    {
+      "db_name": "RefSeq_mRNA_predicted",
+      "example_id": "XM_001084245",
+      "id_namespace": "refseq",
+      "bidirectional": true,
+      "feature_type": "transcript",
+      "ensembl_db_name": "RefSeq_mRNA_predicted"
+    },
+    {
+      "db_name": "RefSeq_ncRNA",
+      "example_id": "NR_022451",
+      "id_namespace": "refseq",
+      "bidirectional": true,
+      "feature_type": "transcript",
+      "ensembl_db_name": "RefSeq_ncRNA"
+    },
+    {
+      "db_name": "RefSeq_ncRNA_predicted",
+      "example_id": "XR_009777",
+      "id_namespace": "refseq",
+      "bidirectional": true,
+      "feature_type": "transcript",
+      "ensembl_db_name": "RefSeq_ncRNA_predicted"
+    },
+    {
+      "db_name": "RefSeq_peptide",
+      "example_id": "NP_001006336",
+      "id_namespace": "refseq",
+      "bidirectional": true,
+      "feature_type": "translation",
+      "ensembl_db_name": "RefSeq_peptide"
+    },
+    {
+      "db_name": "RefSeq_peptide_predicted",
+      "example_id": "XP_001107329",
+      "id_namespace": "refseq",
+      "bidirectional": true,
+      "feature_type": "translation",
+      "ensembl_db_name": "RefSeq_peptide_predicted"
+    },
+    {
+      "db_name": "RefSeq_rna",
+      "example_id": "NR_001535",
+      "id_namespace": "refseq",
+      "bidirectional": true,
+      "feature_type": "transcript",
+      "ensembl_db_name": "RefSeq_rna"
+    },
+    {
+      "db_name": "RefSeq_rna_predicted",
+      "example_id": "XR_078437",
+      "id_namespace": "refseq",
+      "bidirectional": true,
+      "feature_type": "transcript",
+      "ensembl_db_name": "RefSeq_rna_predicted"
+    },
+    {
+      "db_name": "RNAcentral",
+      "example_id": "URS0000597BED_10116",
+      "feature_type": "annotation",
+      "id_namespace": "rnacentral",
+      "ensembl_db_name": "RNAcentral"
+    },
+    {
+      "db_name": "RFAM",
+      "example_id": "RF00001",
+      "id_namespace": "rfam",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "priority": 20,
+      "ensembl_db_name": "RFAM"
+    },
+    {
+      "db_name": "RFAM_gene_name",
+      "example_id": "5S_rRNA.420",
+      "ignore": true,
+      "bidirectional": true,
+      "feature_type": "gene",
+      "ensembl_db_name": "RFAM_gene_name"
+    },
+    {
+      "db_name": "RFAM_trans_name",
+      "ignore": true,
+      "bidirectional": false,
+      "feature_type": "transcript",
+      "ensembl_db_name": "RFAM_trans_name"
+    },
+    {
+      "db_name": "RGD",
+      "example_id": "6486239",
+      "id_namespace": "rgd",
+      "bidirectional": true,
+      "feature_type": "gene",
+      "priority": 100,
+      "ensembl_db_name": "RGD"
+    },
+    {
+      "db_name": "RGD_trans_name",
+      "example_id": "Ppm1n-201",
+      "ignore": true,
+      "bidirectional": true,
+      "feature_type": "transcript",
+      "ensembl_db_name": "RGD_trans_name"
+    },
+    {
+      "db_name": "Rhea",
+      "example_id": "NCRNA_8378",
+      "description": "Manually annotated reaction database",
+      "ignore": "rhea",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "Rhea"
+    },
+    {
+      "db_name": "RNAMMER",
+      "example_id": "8s_rRNA",
+      "ignore": true,
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "RNAMMER"
+    },
+    {
+      "db_name": "SGD",
+      "example_id": "S0002776",
+      "id_namespace": "sgd",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "SGD"
+    },
+    {
+      "db_name": "SGD_GENE",
+      "example_id": "S000001097",
+      "id_namespace": "sgd",
+      "bidirectional": true,
+      "feature_type": "gene",
+      "ensembl_db_name": "SGD_GENE"
+    },
+    {
+      "db_name": "SGD_TRANSCRIPT",
+      "example_id": "S000001097",
+      "id_namespace": "sgd",
+      "bidirectional": true,
+      "feature_type": "transcript",
+      "ensembl_db_name": "SGD_TRANSCRIPT"
+    },
+    {
+      "db_name": "SMART",
+      "description": "The Simple Modular Architecture Research Tool",
+      "example_id": "SM00990",
+      "id_namespace": "smart",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "SMART"
+    },
+    {
+      "db_name": "STRING",
+      "description": "Search Tool for Retrieval of Interacting Genes/Proteins. identifiers.org cannot resolve these as-is",
+      "example_id": "9646.ENSAMEP00000015321",
+      "id_namespace": "string",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "STRING"
+    },
+    {
+      "db_name": "shares_CDS_and_UTR_with_OTTT",
+      "ignore": true,
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "shares_CDS_and_UTR_with_OTTT"
+    },
+    {
+      "db_name": "shares_CDS_with_OTTT",
+      "ignore": true,
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "shares_CDS_with_OTTT"
+    },
+    {
+      "db_name": "SUPFAM",
+      "description": "Superfamily provides structural, functional and evolutionary information for proteins from all completely sequenced genomes, and large sequence collections such as UniProt.",
+      "example_id":"SSF53335",
+      "id_namespace":"supfam",
+      "bidirectional": false,
+      "feature_type": "annotation"
+    },
+    {
+      "db_name": "SwissLipids",
+      "id_namespace": "swisslipid",
+      "bidirectional": false,
+      "feature_type": "annotation"
+    },
+    {
+      "db_name": "swissprot",
+      "example_id": "A0MH06",
+      "description": "Unfussy version of Uniprot/SWISSPROT below",
+      "id_namespace": "uniprot",
+      "canonical_LOD": "http://purl.uniprot.org/uniprot/",
+      "URI_type": "http://purl.uniprot.org/core/Reviewed_Protein",
+      "bidirectional": true,
+      "feature_type": "translation",
+      "ensembl_db_name": "Uniprot/SWISSPROT"
+    },
+    {
+      "db_name": "TAIR_LOCUS",
+      "example_id": "AT3G18710",
+      "id_namespace": "tair.locus",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "TAIR_LOCUS"
+    },
+    {
+      "db_name": "TAIR_LOCUS_MODEL",
+      "example_id": "AT3G18710.1",
+      "id_namespace": "tair.locus",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "TAIR_LOCUS_MODEL"
+    },
+    {
+      "db_name": "TAIR_SYMBOL",
+      "example_id": "ATA7",
+      "ignore": true,
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "TAIR_SYMBOL"
+    },
+    {
+      "db_name": "TAIR_TRANSLATION",
+      "example_id": "AT3G18710",
+      "ignore": true,
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "TAIR_TRANSLATION"
+    },
+    {
+      "db_name": "TCDB",
+      "description": "Transport Classification Database",
+      "id_namespace": "tcdb",
+      "bidirectional": false,
+      "feature_type": "annotation"
+    },
+    {
+      "db_name": "TIGRFAMS",
+      "example_id": "TIGR02866",
+      "id_namespace": "tigrfam",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "TIGR_ID"
+    },
+    {
+      "db_name": "TIGR_GeneIndex",
+      "example_id": "TC60870",
+      "ignore": true,
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "TIGR_GeneIndex"
+    },
+    {
+      "db_name": "TIGR_LOCUS",
+      "example_id": "LOC_Os11g38650.1",
+      "ignore": true,
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "TIGR_LOCUS"
+    },
+    {
+      "db_name": "TransFac",
+      "example_id": "T01396",
+      "ignore": true,
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "TransFac"
+    },
+    {
+      "db_name": "TreeFam",
+      "example_id": "TF101088",
+      "id_namespace": "treefam",
+      "bidirectional": false,
+      "feature_type": "annotation"
+    },
+    {
+      "db_name": "Tuberculist",
+      "description" : "MycoBrowser tuberculosis",
+      "id_namespace" : "myco.tuber",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "TubercuList"
+    },
+    {
+      "db_name": "UCSC",
+      "ignore": true,
+      "bidirectional": false,
+      "feature_type": "gene",
+      "ensembl_db_name": "UCSC"
+    },
+    {
+      "db_name": "UniGene",
+      "example_id": "Acr.9311",
+      "id_namespace": "unigene",
+      "bidirectional": false,
+      "feature_type": "gene",
+      "ensembl_db_name": "UniGene"
+    },
+    {
+      "db_name": "UniParc",
+      "example_id": "UPI00000008FF",
+      "id_namespace": "uniparc",
+      "canonical_LOD": "http://purl.uniprot.org/uniparc/",
+      "URI_type": "http://purl.uniprot.org/core/Sequence",
+      "bidirectional": true,
+      "feature_type": "translation",
+      "ensembl_db_name": "UniParc"
+    },
+    {
+      "db_name": "UniPathway",
+      "example_id": "UPA00545",
+      "id_namespace": "unipathway",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "UniPathway"
+    },
+    {
+      "db_name": "Uniprot/SPTREMBL",
+      "example_id": "A4D9Z1",
+      "id_namespace": "uniprot",
+      "canonical_LOD": "http://purl.uniprot.org/uniprot/",
+      "URI_type": "http://purl.uniprot.org/core/Protein",
+      "bidirectional": true,
+      "feature_type": "translation",
+      "ensembl_db_name": "Uniprot/SPTREMBL"
+    },
+    {
+      "db_name": "Uniprot/SPTREMBL_predicted",
+      "example_id": "Q4T6H2",
+      "id_namespace": "uniprot",
+      "canonical_LOD": "http://purl.uniprot.org/uniprot/",
+      "URI_type": "http://purl.uniprot.org/core/Protein",
+      "bidirectional": true,
+      "feature_type": "translation",
+      "ensembl_db_name": "Uniprot/SPTREMBL"
+    },
+    {
+      "db_name": "Trembl",
+      "example_id": "A4D9Z1",
+      "id_namespace": "uniprot",
+      "canonical_LOD": "http://purl.uniprot.org/uniprot/",
+      "URI_type": "http://purl.uniprot.org/core/Protein",
+      "bidirectional": true,
+      "feature_type": "translation",
+      "ensembl_db_name": "Uniprot/SPTREMBL"
+    },
+    {
+      "db_name": "Uniprot/SWISSPROT_predicted",
+      "id_namespace": "uniprot",
+      "canonical_LOD": "http://purl.uniprot.org/uniprot/",
+      "URI_type": "http://purl.uniprot.org/core/Reviewed_Protein",
+      "bidirectional": true,
+      "feature_type": "translation",
+      "ensembl_db_name": "Uniprot/SWISSPROT"
+    },
+    {
+      "db_name": "Uniprot_gn",
+      "canonical_LOD": "http://purl.uniprot.org/uniprot/",
+      "id_namespace" : "uniprot",
+      "bidirectional": true,
+      "feature_type": "annotation",
+      "ensembl_db_name": "Uniprot_gn"
+    },
+    {
+      "db_name": "Uniprot_gn_trans_name",
+      "ignore": true,
+      "canonical_LOD": "http://purl.uniprot.org/uniprot/",
+      "id_namespace" : "uniprot",
+      "bidirectional": true,
+      "feature_type": "annotation",
+      "ensembl_db_name": "Uniprot_gn_trans_name"
+    },
+    {
+      "db_name": "Uniprot/SWISSPROT",
+      "example_id": "A0MH06",
+      "id_namespace": "uniprot",
+      "canonical_LOD": "http://purl.uniprot.org/uniprot/",
+      "URI_type": "http://purl.uniprot.org/core/Reviewed_Protein",
+      "bidirectional": true,
+      "feature_type": "translation",
+      "ensembl_db_name": "Uniprot/SWISSPROT"
+    },
+    {
+      "db_name": "Vega_gene",
+      "example_id": "OTTDARG00000029138",
+      "ignore": true,
+      "bidirectional": true,
+      "feature_type": "gene",
+      "ensembl_db_name": "Vega_gene"
+    },
+    {
+      "db_name": "Vega_transcript",
+      "ignore": true,
+      "bidirectional": true,
+      "feature_type": "transcript",
+      "ensembl_db_name": "Vega_transcript"
+    },
+    {
+      "db_name": "Vega_translation",
+      "ignore": true,
+      "bidirectional": true,
+      "feature_type": "translation",
+      "ensembl_db_name": "Vega_translation"
+    },
+    {
+      "db_name": "VGNC",
+      "description": "Chimp naming consortium",
+      "bidirectional": true,
+      "feature_type": "gene",
+      "ensembl_db_name": "VGNC"
+    },
+    {
+      "db_name": "WikiGene",
+      "example_id": "100125760",
+      "id_namespace": "wikigenes",
+      "bidirectional": true,
+      "feature_type": "gene",
+      "ensembl_db_name": "WikiGene"
+    },
+    {
+      "db_name": "wormbase",
+      "example_id": "WBGene00022613",
+      "id_namespace": "wormbase",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "wombase_id"
+    },
+    {
+      "db_name": "wormbase_gene",
+      "example_id": "WBGene00022613",
+      "id_namespace": "wormbase",
+      "bidirectional": true,
+      "feature_type": "gene",
+      "ensembl_db_name": "wormbase_gene"
+    },
+    {
+      "db_name": "wormbase_gseqname",
+      "example_id": "WBGene00022613",
+      "id_namespace": "wormbase",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "wormbase_gseqname"
+    },
+    {
+      "db_name": "wormbase_locus",
+      "example_id": "WBGene00022613",
+      "id_namespace": "wormbase",
+      "bidirectional": false,
+      "feature_type": "annotation",
+      "ensembl_db_name": "wormbase_locus"
+    },
+    {
+      "db_name": "wormbase_transcript",
+      "example_id": "ZC449.3a.1",
+      "ignore": true,
+      "id_namespace": "wormbase",
+      "bidirectional": true,
+      "feature_type": "transcript",
+      "ensembl_db_name": "wormbase_transcript"
+    },
+    {
+      "db_name": "wormpep_id",
+      "example_id": "CE29622",
+      "id_namespace": "wormbase",
+      "ignore": true,
+      "bidirectional": true,
+      "feature_type": "translation",
+      "ensembl_db_name": "wormpep_id"
+    },
+    {
+      "db_name": "Xenbase",
+      "example_id": "XB-GENE-5753086",
+      "id_namespace": "xenbase",
+      "bidirectional": true,
+      "feature_type": "gene",
+      "ensembl_db_name": "Xenbase"
+    },
+    {
+      "db_name": "Xenbase_trans_name",
+      "example_id": "golt1b-201",
+      "ignore": true,
+      "id_namespace": "xenbase",
+      "bidirectional": true,
+      "feature_type": "translation",
+      "ensembl_db_name": "Xenbase_trans_name"
+    },
+    {
+      "db_name": "ZFIN_ID",
+      "example_id": "ZDB-GENE-040718-36",
+      "id_namespace": "zfin",
+      "bidirectional": true,
+      "feature_type": "gene",
+      "priority": 100,
+      "ensembl_db_name": "ZFIN_ID"
+    },
+    {
+      "db_name": "zfin",
+      "id_namespace": "zfin",
+      "bidirectional": true,
+      "feature_type": "gene",
+      "priority": 100,
+      "ensembl_db_name": "ZFIN_ID"
+    },
+    {
+      "db_name": "ZFIN_ID_trans_name",
+      "example_id": "hvcn1-201",
+      "ignore": true,
+      "bidirectional": true,
+      "feature_type": "transcript",
+      "ensembl_db_name": "ZFIN_ID_trans_name"
+    }
+  ]
+}

--- a/conf/xref_LOD_schema.json
+++ b/conf/xref_LOD_schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Xref config schema",
+  "type": "object",
+  "required": ["mappings"],
+  "properties": {
+    "mappings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["db_name","feature_type"]
+      },
+      "properties": {
+        "db_name": {
+          "description": "The name string describing a bioinformatics data repository",
+          "type": "string"
+        },
+        "canonical_LOD": {
+          "description": "A URI root that describes the semantic/RDF namespace of data from this resource",
+          "type": "string"
+        },
+        "id_namespace": {
+          "description": "Append to http://identifiers.org/ to use their link resolver to reach the original resource",
+          "type": "string"
+        },
+        "feature_type": {
+          "description": "What type of entity is the accession labeling? gene, transcript, translation, annotation",
+          "type": "string",
+          "enum": ["gene","transcript","translation","annotation"]
+        },
+        "example_id": {
+          "description": "Sample ID from that resource",
+          "type": "string"
+        },
+        "URI_type": {
+          "description": "A more formal definition of what kind of entity is described by the accession",
+          "type": "string"
+        },
+        "ignore": {
+          "description": "A vestigial flag describing whether a source is significant or not. Probably should be repurposed to show sources whose links we wish to overlook, e.g. links back to Ensembl",
+          "type": "boolean"
+        },
+        "bidirectional": {
+          "description": "Vestigial mechanism for determining whether to allow queries both in and out of this source. Intended to constrain xref islands to single feature types. Largely taken care of now by feature_type field",
+          "type": "boolean"
+        },
+        "priority": {
+          "description": "A score weighting used to determine which sources to use for naming. High score means to favour this source over others. No score means ignore this source and do not use it for names or descriptions",
+          "type": "integer"
+        },
+        "ensembl_db_name": {
+          "description": "The db_name used by Ensembl to refer to this resource. Required for mapping back into old xref schema",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_conf.pm
@@ -102,7 +102,7 @@ sub default_options {
 	   'ucsc' 		 => 1,
        ## rdf parameters
        'xref' => 1,
-       'config_file' => $self->o('ensembl_cvs_root_dir').'/VersioningService/conf/xref_LOD_mapping.json',
+       'config_file' => $self->o('ensembl_cvs_root_dir') . '/ensembl-production/conf/xref_LOD_mapping.json',
 
        ## BLAT
        # A list of vertebrates species for which we have Blast server running with their associated port number


### PR DESCRIPTION
## Description

Make DumpCore_conf.pm use a local copy of xref_LOD_mapping.json

## Use case

The file in question used to come from VersioningService, which repository is now being phased out.

## Benefits

Do not depend on a deprecated repository. Indeed, reduce the number of external dependencies by one.

## Possible Drawbacks

* A new top-level directory _conf_ has been created to hold the file in question.
* The schema of xref_LOD_mapping.json conforms to JSON Schema draft-07 rather than the current draft/2019-09 (draft-08 in the old nomenclature) due to the fact the validation tools I know do not support the latter yet.

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

Should make the whole ensembl-production no longer depend on VersioningService.
