### PR TITLE
Extending taxons to include two new fishes callorhinchus_milii and er…

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GeneNameDescProjection_vertebrates_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GeneNameDescProjection_vertebrates_conf.pm
@@ -96,7 +96,7 @@ sub default_options {
       },
       {
         source                 => 'homo_sapiens',
-        taxons                 => ['Actinopterygii','Cyclostomata','Coelacanthimorpha','Chondrichthyes'],
+        taxons                 => ['Actinopterygii','Cyclostomata','Chondrichthyes'],
         antispecies            => ['homo_sapiens'],
         gene_name_source       => ['HGNC'],
         project_trans_names    => 1,
@@ -153,7 +153,7 @@ sub default_options {
       },
       {
         source                 => 'homo_sapiens',
-        taxons                 => ['Actinopterygii','Cyclostomata','Coelacanthimorpha','Chondrichthyes'],
+        taxons                 => ['Actinopterygii','Cyclostomata','Chondrichthyes'],
         antispecies            => ['homo_sapiens'],
         gene_name_source       => ['HGNC'],
         gene_desc_rules        => [], 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GeneNameDescProjection_vertebrates_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GeneNameDescProjection_vertebrates_conf.pm
@@ -88,7 +88,7 @@ sub default_options {
       },
       {
         source                 => 'danio_rerio',
-        taxons                 => ['Neopterygii','Cyclostomata','Coelacanthimorpha'],
+        taxons                 => ['Actinopterygii','Cyclostomata','Coelacanthimorpha','Chondrichthyes'],
         antispecies            => ['danio_rerio'],
         gene_name_source       => ['ZFIN_ID'],
         project_trans_names    => 1,
@@ -96,7 +96,7 @@ sub default_options {
       },
       {
         source                 => 'homo_sapiens',
-        taxons                 => ['Neopterygii','Cyclostomata'],
+        taxons                 => ['Actinopterygii','Cyclostomata','Coelacanthimorpha','Chondrichthyes'],
         antispecies            => ['homo_sapiens'],
         gene_name_source       => ['HGNC'],
         project_trans_names    => 1,
@@ -145,7 +145,7 @@ sub default_options {
       },
       {
         source                 => 'danio_rerio',
-        taxons                 => ['Neopterygii','Cyclostomata','Coelacanthimorpha'],
+        taxons                 => ['Actinopterygii','Cyclostomata','Coelacanthimorpha','Chondrichthyes'],
         antispecies            => ['danio_rerio'],
         gene_name_source       => ['ZFIN_ID'],
         gene_desc_rules        => [], 
@@ -153,7 +153,7 @@ sub default_options {
       },
       {
         source                 => 'homo_sapiens',
-        taxons                 => ['Neopterygii','Cyclostomata'],
+        taxons                 => ['Actinopterygii','Cyclostomata','Coelacanthimorpha','Chondrichthyes'],
         antispecies            => ['homo_sapiens'],
         gene_name_source       => ['HGNC'],
         gene_desc_rules        => [], 


### PR DESCRIPTION
…petoichthys_calabaricus in the projections

**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

callorhinchus_milii and erpetoichthys_calabaricus are outside the taxons that we currently project to. Updated config to include these fish in the taxon range that we project to.

## Use case

When we run projections for the release.

## Benefits

These fishes will have gene names from Zebrafish and Human

## Possible Drawbacks

None

## Testing

- [ N ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
