### PR TITLE
Protein feature memory

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProteinFeatures_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProteinFeatures_conf.pm
@@ -649,6 +649,7 @@ sub pipeline_analyses {
       -flow_into         => {
                                '1' => ['StoreProteinFeatures'],
                               '-1' => ['InterProScanLookup_HighMem'],
+                              '-2' => ['InterProScanLookup_HighMem'],
                             },
     },
 
@@ -734,7 +735,7 @@ sub pipeline_analyses {
       -rc_name           => '8GB_4CPU',
       -flow_into         => {
                                '1' => ['StoreProteinFeatures'],
-                              '-1' => ['InterProScanLocal_HighMem'],
+                               '0' => ['InterProScanLocal_HighMem'],
                             },
     },
 
@@ -753,7 +754,7 @@ sub pipeline_analyses {
         interproscan_applications => '#interproscan_local_applications#',
         run_interproscan          => $self->o('run_interproscan'),
       },
-      -rc_name           => '16GB_4CPU',
+      -rc_name           => '32GB_4CPU',
       -flow_into         => {
                                '1' => ['StoreProteinFeatures'],
                             },
@@ -930,6 +931,7 @@ sub resource_classes {
     '4Gb_mem_4Gb_tmp' => {'LSF' => '-q production-rh74 -M 4000 -R "rusage[mem=4000,scratch=4000]"'},
     '8Gb_mem_4Gb_tmp' => {'LSF' => '-q production-rh74 -M 8000 -R "rusage[mem=8000,scratch=4000]"'},
     '16Gb_mem_4Gb_tmp' => {'LSF' => '-q production-rh74 -M 16000 -R "rusage[mem=16000,scratch=4000]"'},
+    '32Gb_mem_4Gb_tmp' => {'LSF' => '-q production-rh74 -M 32000 -R "rusage[mem=32000,scratch=4000]"'},
   }
 }
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProteinFeatures_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProteinFeatures_conf.pm
@@ -645,7 +645,7 @@ sub pipeline_analyses {
         interproscan_applications => '#interproscan_lookup_applications#',
         run_interproscan          => $self->o('run_interproscan'),
       },
-      -rc_name           => '8Gb_mem_4Gb_tmp',
+      -rc_name           => '4GB',
       -flow_into         => {
                                '1' => ['StoreProteinFeatures'],
                               '-1' => ['InterProScanLookup_HighMem'],
@@ -667,7 +667,7 @@ sub pipeline_analyses {
         interproscan_applications => '#interproscan_lookup_applications#',
         run_interproscan          => $self->o('run_interproscan'),
       },
-      -rc_name           => '16Gb_mem_4Gb_tmp',
+      -rc_name           => '16GB',
       -flow_into         => {
                                '1' => ['StoreProteinFeatures'],
                             },
@@ -688,7 +688,7 @@ sub pipeline_analyses {
         interproscan_applications => '#interproscan_nolookup_applications#',
         run_interproscan          => $self->o('run_interproscan'),
       },
-      -rc_name           => '8GB_4CPU',
+      -rc_name           => '4GB_4CPU',
       -flow_into         => {
                                '1' => ['StoreProteinFeatures'],
                               '-1' => ['InterProScanNoLookup_HighMem'],
@@ -731,7 +731,7 @@ sub pipeline_analyses {
         interproscan_applications => '#interproscan_local_applications#',
         run_interproscan          => $self->o('run_interproscan'),
       },
-      -rc_name           => '8GB_4CPU',
+      -rc_name           => '4GB_4CPU',
       -flow_into         => {
                                '1' => ['StoreProteinFeatures'],
                                '0' => ['InterProScanLocal_HighMem'],
@@ -922,15 +922,12 @@ sub resource_classes {
 
   return {
     %{$self->SUPER::resource_classes},
-    '4GB' => {'LSF' => '-q production-rh74 -M 4000 -R "rusage[mem=4000]"'},
-    '8GB' => {'LSF' => '-q production-rh74 -M 8000 -R "rusage[mem=8000]"'},
+    '4GB'  => {'LSF' => '-q production-rh74 -M 4000  -R "rusage[mem=4000]"'},
+    '8GB'  => {'LSF' => '-q production-rh74 -M 8000  -R "rusage[mem=8000]"'},
+    '16GB' => {'LSF' => '-q production-rh74 -M 16000 -R "rusage[mem=16000]"'},
     '4GB_4CPU' => {'LSF' => '-q production-rh74 -n 4 -M 4000 -R "rusage[mem=4000,scratch=4000]"'},
-    '8GB_4CPU' => {'LSF' => '-q production-rh74 -n 4 -M 8000 -R "rusage[mem=8000,scratch=4000]"'},
     '16GB_4CPU' => {'LSF' => '-q production-rh74 -n 4 -M 16000 -R "rusage[mem=16000,scratch=4000]"'},
-    '4Gb_mem_4Gb_tmp' => {'LSF' => '-q production-rh74 -M 4000 -R "rusage[mem=4000,scratch=4000]"'},
-    '8Gb_mem_4Gb_tmp' => {'LSF' => '-q production-rh74 -M 8000 -R "rusage[mem=8000,scratch=4000]"'},
-    '16Gb_mem_4Gb_tmp' => {'LSF' => '-q production-rh74 -M 16000 -R "rusage[mem=16000,scratch=4000]"'},
-    '32Gb_mem_4Gb_tmp' => {'LSF' => '-q production-rh74 -M 32000 -R "rusage[mem=32000,scratch=4000]"'},
+    '32GB_4CPU' => {'LSF' => '-q production-rh74 -n 4 -M 32000 -R "rusage[mem=32000,scratch=4000]"'},
   }
 }
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProteinFeatures_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProteinFeatures_conf.pm
@@ -649,7 +649,6 @@ sub pipeline_analyses {
       -flow_into         => {
                                '1' => ['StoreProteinFeatures'],
                               '-1' => ['InterProScanLookup_HighMem'],
-                              '-2' => ['InterProScanLookup_HighMem'],
                             },
     },
 


### PR DESCRIPTION
## Description
Protein features pipeline was failing for a handful of jobs. It seems like super-long protein sequences were causing the Panther analysis to gobble up memory - but the failure was only sporadically registered as a memory issue, so wasn't always picked up by hive's MEMLIMIT detection. And in any case, the "high_mem" analysis was not high enough.

## Benefits
Pipeline should run without manual intervention, and should no longer be an assault on Marc's sanity.

## Possible Drawbacks
Nothing that I can think of...