### PR TITLE
Add the ability to run datachecks as part of the bulk SQL pipeline.

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/BulkSQL_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/BulkSQL_conf.pm
@@ -134,6 +134,7 @@ sub pipeline_analyses {
       -analysis_capacity => 10,
       -max_retry_count   => 0,
       -parameters        => {
+                              registry_file      => $self->o('registry'),
                               history_file       => $self->o('history_file'),
                               output_dir         => $self->o('output_dir'),
                               config_file        => $self->o('config_file'),


### PR DESCRIPTION
## Description
Optionally run datacheck(s) after executing SQL on databases.

## Use case
Sometimes we want to apply SQL statements to databases on the staging servers; it's handy to be able to subsequently run datachecks, to confirm that we've not broken anything, within the same pipeline.

## Benefits
More easily identify if SQL statements a) fix what they are supposed to be fixing, b) don't break anything.

## Possible Drawbacks
Not aware of anything.

## Testing
No unit tests, ran pipeline with datachecks when updating funcgen web_data with SQL, all worked fine.
