### PR TITLE
removed aniseed xref for ciona from xrefsources json

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_sources.json
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_sources.json
@@ -226,12 +226,6 @@
       "priority" : 1
     },
     {
-      "name" : "cint_aniseed_v1",
-      "parser" : "JGI_ProteinParser",
-      "file" : "ftp://ftp.ensembl.org/pub/misc/cint_jgi/v1/ciona.prot.fasta.gz",
-      "priority" : 1
-    },
-    {
       "name" : "cint_jgi_v1",
       "parser" : "JGI_ProteinParser",
       "file" : "ftp://ftp.ensembl.org/pub/misc/cint_jgi/v1/ciona.prot.fasta.gz",


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

As descriibed in https://www.ebi.ac.uk/panda/jira/browse/ENSINT-412

## Use case

Remove xrefs which do not link out to external source

## Benefits

For new runs of ciona, this xref will not be computed

## Possible Drawbacks

The data needs to be deleted from earlier versions using sql scripts

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- No
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

Changes made only in config json file
