### PR TITLE
Because dog was renamed from canis_familiaris to canis_lupus_familiar…

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_conf.pm
@@ -113,7 +113,7 @@ sub default_options {
         'danio_rerio'           => 30003,
         'rattus_norvegicus'     => 30005,
         'gallus_gallus'         => 30010,
-        'canis_lupus_familiaris' => 30013,
+        'canis_lupus_familiaris' => 30014,
         'bos_taurus'            => 30017,
         'oryctolagus_cuniculus' => 30025,
         'oryzias_latipes'       => 30026,


### PR DESCRIPTION
…is, the BLAT port name need to change in order to support archive BLAT and current BLAT

**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Because dog was renamed from canis_familiaris to canis_lupus_familiaris, the BLAT port name need to change in order to support archive BLAT and current BLAT

## Use case

We need this to generate the dumps for release 100

## Benefits

We will have a new port for dog

## Possible Drawbacks

None.

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
