### PR TITLE
We need to use the displayable value from the production db, rather t…

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Common/AnalysisSetup.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Common/AnalysisSetup.pm
@@ -179,7 +179,7 @@ sub production_updates {
 
     # Load generic, non-species-specific, analyses
     my $sth = $dbh->prepare(
-     'SELECT ad.description, ad.display_label, 1, wd.data '.
+     'SELECT ad.description, ad.display_label, ad.displayable, wd.data '.
      'FROM analysis_description ad '.
      'LEFT OUTER JOIN web_data wd ON ad.web_data_id = wd.web_data_id '.
      'WHERE ad.is_current = 1 '.


### PR DESCRIPTION
## Description
We need to use the displayable value from the production db, rather than a hard-coded value of 1.

## Benefits
Core dbs will be consistent with production db.

## Possible Drawbacks
None
