### PR TITLE
Prod db sync pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Utils/ProductionDbUpdater.pm
+++ b/modules/Bio/EnsEMBL/Production/Utils/ProductionDbUpdater.pm
@@ -135,12 +135,12 @@ sub update_controlled_table {
           if (
               join(
                 '',
-                map { $mdata->{$row_id}{$_} || '' } @{ $tables->{$table}{cols} }
+                map { defined $mdata->{$row_id}{$_} ? $mdata->{$row_id}{$_} : 'undef' } @{ $tables->{$table}{cols} }
               )
               ne
               join(
                 '',
-                map { $data->{$row_id}{$_} || '' } @{ $tables->{$table}{cols} }
+                map { defined $data->{$row_id}{$_} ? $data->{$row_id}{$_} : 'undef' } @{ $tables->{$table}{cols} }
               )
             )
           {


### PR DESCRIPTION
## Description
 One of the analysis_description datachecks is advisory, so do not want the pipeline to fail if it fails. Instead, have a separate datacheck run, and report any failures via email. Also, take advantage of new datacheck group for analysis_descriptions.

Also included is a bug fix for the controlled table update, to explicitly deal with undef values, so as to distinguish between empty strings and NULLs in the database (which is necessary when determining if the data has changed).

## Benefits
Advisory datacheck failures don't cause the pipeline to fail.

## Possible Drawbacks
None

## Testing
Test pipelines run.
