### PR TITLE
Fix for RDF dumping losing connection

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/RDF/RDFDump.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/RDF/RDFDump.pm
@@ -78,6 +78,7 @@ sub run {
   };
   my $hive_dbc = $self->dbc;
   $hive_dbc->disconnect_if_idle() if defined $hive_dbc;
+  $dba->dbc->disconnect_if_idle();
 
   my $slices = $self->get_Slices(undef, ($species eq 'homo_sapiens')?1:0);
   #


### PR DESCRIPTION
## Description
Add disconnectt_when_idle command for RDF dumping, which was losing the DB connection because it spends so long generating vast amounts of data...

## Use case
RDF dump jobs were failing after running for hours, due to a lost DB connection.

## Benefits
Jobs don't fail!

## Possible Drawbacks
None I'm aware of.

## Testing
Tested on dumps for release 100 - half a dozen failures without the fix, none after it. (Could be coincidence, of course, but hard to fully test without significant effort.)
