### PR TITLE
The VEP directory contains files and directories for the collection d…

### DIFF
--- a/scripts/ftp/checksums.pl
+++ b/scripts/ftp/checksums.pl
@@ -66,6 +66,11 @@ sub run {
       remove_checksums($dir, $contents);
       generate_checksums($dir, $contents);
     }
+    elsif(directory_contents($contents)){
+      print STDERR "Directory is not a leaf but we have files in it; will generate checksums\n";
+      remove_checksums($dir, $contents);
+      generate_checksums($dir, $contents);
+    }
   }
   print STDERR "Done\n";
   return;
@@ -135,6 +140,11 @@ sub remove_file {
 sub leaf_directory {
   my ($contents) = @_;
   return (scalar(@{$contents->{dirs}}) == 0) ? 1 : 0;
+}
+
+sub directory_contents {
+  my ($contents) = @_;
+  return (scalar(@{$contents->{files}}) != 0) ? 1 : 0;
 }
 
 sub generate_checksums {


### PR DESCRIPTION
…atabases, as a result the script skip the main VEP directory and goes into the collection directories to generate CHECKSUMS. This fix check if the main directory contains files and create a checksum for them.

**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

The VEP directory contains files and directories for the collection databases, as a result the script skip the main VEP directory and goes into the collection directories to generate CHECKSUMS. This fix check if the main directory contains files and create a checksum for them.

## Use case

When re-generating checksums after copying dumps from previous release

## Benefits

Checksums won't be missing anymore

## Possible Drawbacks

If this is run in the main division directory, we might create a checksum for the metadata dumps, not sure it's a bad thing.

## Testing

- [ N ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
