### PR TITLE
Add SampleData_vertebrates_conf

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/SampleData_vertebrates_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/SampleData_vertebrates_conf.pm
@@ -40,19 +40,6 @@ package Bio::EnsEMBL::Production::Pipeline::PipeConfig::SampleData_vertebrates_c
 use strict;
 use warnings;
 use base ('Bio::EnsEMBL::Production::Pipeline::PipeConfig::SampleData_conf');
-use Bio::EnsEMBL::ApiVersion qw/software_version/;
-use Bio::EnsEMBL::Hive::Version 2.5;
-use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
-
-
-=head2 default_options
-
- Description: It returns a hashref containing the default options for HiveGeneric_conf
- Returntype : Hashref
- Exceptions : None
-
-
-=cut
 
 sub default_options {
     my ($self) = @_;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/SampleData_vertebrates_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/SampleData_vertebrates_conf.pm
@@ -1,0 +1,68 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 CONTACT
+
+Please email comments or questions to the public Ensembl
+developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
+
+Questions may also be sent to the Ensembl help desk at
+<http://www.ensembl.org/Help/Contact>.
+
+=head1 NAME
+
+Bio::EnsEMBL::Production::Pipeline::PipeConfig::SampleData_vertebrates_conf
+
+=head1 SYNOPSIS
+
+
+=head1 DESCRIPTION
+
+
+=cut
+
+package Bio::EnsEMBL::Production::Pipeline::PipeConfig::SampleData_vertebrates_conf;
+
+use strict;
+use warnings;
+use base ('Bio::EnsEMBL::Production::Pipeline::PipeConfig::SampleData_conf');
+use Bio::EnsEMBL::ApiVersion qw/software_version/;
+use Bio::EnsEMBL::Hive::Version 2.5;
+use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
+
+
+=head2 default_options
+
+ Description: It returns a hashref containing the default options for HiveGeneric_conf
+ Returntype : Hashref
+ Exceptions : None
+
+
+=cut
+
+sub default_options {
+    my ($self) = @_;
+
+    return {
+        # inherit other stuff from the base class
+        %{ $self->SUPER::default_options() },
+	    # species with curated sample genes
+        antispecies   => ['homo_sapiens'],
+    };
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/SampleData_vertebrates_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/SampleData_vertebrates_conf.pm
@@ -48,7 +48,13 @@ sub default_options {
         # inherit other stuff from the base class
         %{ $self->SUPER::default_options() },
 	    # species with curated sample genes
-        antispecies   => ['homo_sapiens'],
+        antispecies => ['homo_sapiens',
+                        'danio_rerio',
+                        'equus_caballus',
+                        'bos_taurus',
+                        'ovis_aries',
+                        'sus_scrofa',
+                        'mus_musculus']
     };
 }
 


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Add `SampleData_vertebrates_conf` for specific configuration of Sample Data Pipeline for Vertebrates. In particular this adds the `antispecies` parameter for excluding species from the pipeline (default value: homo_sapiens). 

## Use case

Sample Data Pipeline's step `GenerateSampleData` is failing on homo_sapiens, but it shouldn't be ran on that database in the first place as the sample data is manually curated.

## Benefits

Being able to exclude species with the `antispecies` parameter and add further

## Possible Drawbacks

Change SOPs to use `SampleData_vertebrates_conf` instead of `SampleData_conf`

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [x] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
