### PR TITLE
Run GPAD pipeline datachecks at database-level

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GPAD_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GPAD_conf.pm
@@ -142,7 +142,7 @@ sub pipeline_analyses {
                             },
       -flow_into         => {
                               '2->A' => ['BackupTables'],
-                              'A->2' => ['SpeciesFactory'],
+                              'A->2' => ['LoadAndDatacheck'],
                             }
     },
     {
@@ -198,6 +198,14 @@ sub pipeline_analyses {
                             },
     },
     {
+       -logic_name       => 'LoadAndDatacheck',
+       -module           => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+       -flow_into        => {
+                              '1->A' => ['SpeciesFactory'],
+                              'A->1' => ['RunXrefDatacheck'],
+                            },
+    },
+    {
       -logic_name        => 'SpeciesFactory',
       -module            => 'Bio::EnsEMBL::Production::Pipeline::Common::DbAwareSpeciesFactory',
       -max_retry_count   => 1,
@@ -231,11 +239,15 @@ sub pipeline_analyses {
                               delete_existing => $self->o('delete_existing'),
                               logic_name      => $self->o('logic_name')
                             },
-      -flow_into         => {
+      -rc_name           => '4GB'
+    },
+    {
+       -logic_name       => 'RunXrefDatacheck',
+       -module           => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+       -flow_into        => {
                               '1->A' => ['RunXrefCriticalDatacheck'],
                               'A->1' => ['RunXrefAdvisoryDatacheck']
                             },
-      -rc_name           => '4GB'
     },
     {
       -logic_name        => 'RunXrefCriticalDatacheck',

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GPAD_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GPAD_conf.pm
@@ -254,7 +254,6 @@ sub pipeline_analyses {
       -module            => 'Bio::EnsEMBL::DataCheck::Pipeline::RunDataChecks',
       -max_retry_count   => 1,
       -analysis_capacity => 10,
-      -batch_size        => 10,
       -parameters        => {
                               datacheck_names  => ['ForeignKeys'],
                               datacheck_groups => ['xref'],


### PR DESCRIPTION
## Description
Datachecks are most efficient when they are run at the database level, rather than the species level. This only makes a big difference for collection databases. It can save quite a lot of time, because some datachecks have the 'per_db' flag set, meaning that they only need to be run once, regardless of how many species there are in the database.

## Use case
In the GPAD load pipeline, the datachecks were run following a SpeciesFactory, so all datachecks were being run for every species. This has two consequences: 1) it's wasteful, because some complicated/long-running datachecks (e.g. ForeignKeys) are run unnecessarily, and 2) spurious errors can occur, because the datachecks are potentially being run for some species while db updates are occuring for other species, and failures can appear due to transient partial loads of data.

## Benefits
Faster datacheck runs, no spurious failures.

## Possible Drawbacks
Pipeline config is a bit more complicated, needed two additional dummy modules to control the semaphores.

## Testing
Pipeline initialised to verify correct structure. 
