### PR TITLE
pipeline_name parameter for datacheck notification

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GPAD_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GPAD_conf.pm
@@ -290,7 +290,8 @@ sub pipeline_analyses {
       -max_retry_count   => 1,
       -analysis_capacity => 10,
       -parameters        => {
-                              email => $self->o('email'),
+                              email         => $self->o('email'),
+                              pipeline_name => $self->o('pipeline_name'),
                             },
     },
     {

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GeneNameDescProjection_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GeneNameDescProjection_conf.pm
@@ -363,7 +363,8 @@ sub pipeline_analyses {
       -analysis_capacity => 10,
       -max_retry_count   => 1,
       -parameters        => {
-                              email => $self->o('email'),
+                              email         => $self->o('email'),
+                              pipeline_name => $self->o('pipeline_name'),
                             },
     },
     {

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProductionDBSync_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProductionDBSync_conf.pm
@@ -250,7 +250,8 @@ sub pipeline_analyses {
       -analysis_capacity => 10,
       -max_retry_count   => 1,
       -parameters        => {
-                              email => $self->o('email'),
+                              email         => $self->o('email'),
+                              pipeline_name => $self->o('pipeline_name'),
                             },
       -rc_name           => 'normal',
    },

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/Xref_update_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/Xref_update_conf.pm
@@ -289,7 +289,8 @@ sub pipeline_analyses {
             -analysis_capacity => 10,
             -max_retry_count   => 1,
             -parameters        => {
-                                    email => $self->o('email'),
+                                    email         => $self->o('email'),
+                                    pipeline_name => $self->o('pipeline_name'),
                                   },
           },
           {


### PR DESCRIPTION
## Description
The datacheck email notification module assumes that the pipeline_name will be available, in order to be displayed in the subject line (https://github.com/Ensembl/ensembl-datacheck/pull/239).

## Benefits
Modification to datacheck repo's EmailNotify module will work as intended.

## Possible Drawbacks
None.