### PR TITLE
list of xref sources used for sars_cov_2 annotation

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/sars_cov_2_sources.json
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/sars_cov_2_sources.json
@@ -1,0 +1,37 @@
+[
+    {
+      "name" : "EntrezGene",
+      "parser" : "EntrezGeneParser",
+      "file" : "ftp://ftp.ncbi.nlm.nih.gov/gene/DATA/gene_info.gz",
+      "priority" : 1
+    },
+    {
+      "name" : "RefSeq_peptide",
+      "parser" : "RefSeqGPFFParser",
+      "file" : "https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/009/858/895/GCF_009858895.2_ASM985889v3/GCF_009858895.2_ASM985889v3_protein.gpff.gz",
+      "method" : "--bestn 1",
+      "query_cutoff" : 99,
+      "target_cutoff" : 99,
+      "release" : "ftp://ftp.ncbi.nih.gov/refseq/release/release-notes/RefSeq-release*.txt",
+      "priority" : 2
+    },
+    {
+      "name" : "Uniprot/SPTREMBL",
+      "parser" : "UniProtParser",
+      "file" : "Database",
+      "db" : "checksum",
+      "method" : "--bestn 1",
+      "query_cutoff" : 99,
+      "target_cutoff" : 99,
+      "priority" : 1
+    },
+    {
+      "name" : "Uniprot/SWISSPROT",
+      "parser" : "UniProtParser",
+      "file" : "ftp://ftp.uniprot.org/pub/databases/uniprot/pre_release/covid-19.dat",
+      "method" : "--bestn 1",
+      "query_cutoff" : 99,
+      "target_cutoff" : 99,
+      "priority" : 1
+    }
+]


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

_Using one or more sentences, describe in detail the proposed changes._
List of sources used for sars_cov_2 xref pipeline run

## Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._
ensures we keep track of the sources used and avoids over-writing existing configuration which is optimised for vertebrate species

## Benefits

_If applicable, describe the advantages the changes will have._
a single configuration file when updating virus xref mappings

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
some sars_cov_2 specific configuration was also added to the ensembl repository in the xref-mapping section, both changes will need to be used for optimal xref mapping
