### PR TITLE
[ENSCOMPARASW-3527] Allow division-prefixed Ancestral sequences Registry entries

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Common/DbFactory.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Common/DbFactory.pm
@@ -123,7 +123,7 @@ sub run {
 
   if ($run_all) {
     foreach my $dba (@$all_dbas) {
-      unless ($dba->species eq 'Ancestral sequences') {
+      unless ($dba->species =~ /Ancestral sequences/) {
         $self->add_species($dba, \%dbs);
       }
     }

--- a/modules/Bio/EnsEMBL/Production/Pipeline/FtpChecker/CheckCoreFtp.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FtpChecker/CheckCoreFtp.pm
@@ -109,7 +109,7 @@ my $expected_files = {
 sub run {
   my ($self) = @_;
   my $species = $self->param('species');
-  if ( $species ne "Ancestral sequences" ) {
+  if ( $species !~ /Ancestral sequences/ ) {
     Log::Log4perl->easy_init($DEBUG);
     $self->{logger} = get_logger();
     my $base_path = $self->param('base_path');

--- a/modules/Bio/EnsEMBL/Production/Pipeline/FtpChecker/CheckVariationFtp.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FtpChecker/CheckVariationFtp.pm
@@ -51,7 +51,7 @@ my $expected_files = {
 sub run {
   my ($self) = @_;
   my $species = $self->param('species');
-  if ( $species ne "Ancestral sequences" ) {
+  if ( $species !~ /Ancestral sequences/ ) {
     Log::Log4perl->easy_init($DEBUG);
     $self->{logger} = get_logger();
     my $base_path = $self->param('base_path');

--- a/modules/Bio/EnsEMBL/Production/Pipeline/JSON/DumpGenomeJson.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/JSON/DumpGenomeJson.pm
@@ -61,7 +61,7 @@ sub param_defaults {
 sub run {
   my ($self) = @_;
   print $self->param('species');
-  if ( $self->param('species') ne "Ancestral sequences" ) {
+  if ( $self->param('species') !~ /Ancestral sequences/ ) {
     $self->write_json();
   }
   return;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Search/DumpGenesJson.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Search/DumpGenesJson.pm
@@ -40,7 +40,7 @@ use Log::Log4perl qw/:easy/;
 sub dump {
   my ($self, $species, $type) = @_;
   $self->{logger} = get_logger();
-  if ($species ne "Ancestral sequences") {
+  if ($species !~ /Ancestral sequences/) {
 
     my $compara = $self->param('compara');
     if (!defined $compara) {
@@ -78,7 +78,7 @@ sub dump {
     $self->{logger}->info("Completed dumping $species $type");
     $dba->dbc()->disconnect_if_idle(1);
     $self->dataflow_output_id($output, 1);
-  } ## end if ( $species ne "Ancestral sequences")
+  } ## end if ( $species !~ /Ancestral sequences/)
   return;
 } ## end sub dump
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Search/DumpGenomeJson.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Search/DumpGenomeJson.pm
@@ -41,7 +41,7 @@ use Log::Log4perl qw/:easy/;
 
 sub dump {
 	my ( $self, $species ) = @_;
-	if ( $species ne "Ancestral sequences" ) {
+	if ( $species !~ /Ancestral sequences/ ) {
 		my $compara = $self->param('compara');
 		if ( !defined $compara ) {
 			$compara = $self->division();
@@ -83,7 +83,7 @@ sub dump {
 		  if ( Bio::EnsEMBL::Registry->get_DBAdaptor( $species, 'funcgen' ) )
 		  ;
 
-	} ## end if ( $species ne "Ancestral sequences")
+	} ## end if ( $species !~ /Ancestral sequences/)
 	return;
 } ## end sub dump
 

--- a/scripts/datafiles/build_datafile_ftp_directory.pl
+++ b/scripts/datafiles/build_datafile_ftp_directory.pl
@@ -464,7 +464,7 @@ sub _get_dbs {
 
   while(my $dba = shift @{$dbas}) {
     next if $dba->species() eq 'multi';
-    next if lc($dba->species()) eq 'ancestral sequences';
+    next if lc($dba->species()) =~ /ancestral sequences/;
     next if $dba->dbc()->dbname() =~ /^.+_userdata$/xms;
     
     my $type = $dba->get_MetaContainer()->single_value_by_key('schema_type');

--- a/scripts/datafiles/check_datafiles.pl
+++ b/scripts/datafiles/check_datafiles.pl
@@ -293,7 +293,7 @@ sub _get_core_like_dbs {
   my @final_dbas;
   while(my $dba = shift @{$dbas}) {
     next if $dba->species() eq 'multi';
-    next if lc($dba->species()) eq 'ancestral sequences';
+    next if lc($dba->species()) =~ /ancestral sequences/;
     next if $dba->dbc()->dbname() =~ /^.+_userdata$/xms;
 
     my $type = $dba->get_MetaContainer()->single_value_by_key('schema_type');

--- a/scripts/datafiles/sizes.pl
+++ b/scripts/datafiles/sizes.pl
@@ -169,7 +169,7 @@ sub _get_core_like_dbs {
   my @final_dbas;
   while(my $dba = shift @{$dbas}) {
     next if $dba->species() eq 'multi';
-    next if lc($dba->species()) eq 'ancestral sequences';
+    next if lc($dba->species()) =~ /ancestral sequences/;
     next if $dba->dbc()->dbname() =~ /^.+_userdata$/xms;
     
     my $type = $dba->get_MetaContainer()->single_value_by_key('schema_type');


### PR DESCRIPTION
## Use case

See ENSWEB-5706 and related tickets for more information. The REST server sees all MySQL servers (Vertebrates and non-Vertebrates), which contain in total two ancestral databases, but the current Registry model only allows one. The Compara API then fails because it is not able to access the other one

## Description

I am proposing to register the ancestral databases with their division name, preventing a clash between the Plants and Vertebrates databases. The change is being made in the Core repository, and ensembl-production has to be updated because several modules compare the registry name to "Ancestral sequences", which will now be "Plants Ancestral sequences" for Plants.

Two questions:
1. Do you still maintain this branch (`release/100`) ? I can make the PR onto `release/101` instead
2. Do you have a mechanism to merge this onto the more recent branches ?

Anyway, the later branches should be reviewed because there could be new modules that check the registry name and need to be updated.

:warning: _Do not merge until *all* these related pull-requests have been approved !_: Ensembl/ensembl#488, Ensembl/ensembl-compara#197

Equivalent pull-requests: #432 for `release/101` and #433 for `master`

## Benefits

Production code will still work on the NV server, and will also work of all databases are mixed together (physically or via a Registry configuration file).

## Possible Drawbacks

None

## Testing

- [ ] Have you added/modified unit tests to test the changes?

No

- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?

All good

- [ ] TravisCI passed on your branch

Yes, once the branch for all the `git clone` is forced to be `release/100`, see https://travis-ci.org/github/Ensembl/ensembl-production/builds/695944537
