### PR TITLE
dbname parameter added to syncDB pipeline to sync controll tables and…

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProductionDBSync_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProductionDBSync_conf.pm
@@ -43,6 +43,7 @@ sub default_options {
     species      => [],
     antispecies  => [],
     division     => [],
+    dbname       => [],
     run_all      => 0,
     meta_filters => {},
 
@@ -107,6 +108,7 @@ sub pipeline_analyses {
                               species      => $self->o('species'),
                               antispecies  => $self->o('antispecies'),
                               division     => $self->o('division'),
+                              dbname       => $self->o('dbname'),
                               run_all      => $self->o('run_all'),
                               meta_filters => $self->o('meta_filters'),
                             },


### PR DESCRIPTION
 SyncDB pipeline to sync a named database, rather than using species/division parameters. 