### PR TITLE
Add biotype datacheck to prod db sync pipeline.

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProductionDBSync_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProductionDBSync_conf.pm
@@ -207,6 +207,7 @@ sub pipeline_analyses {
                                 'ControlledTablesCore',
                                 'ControlledTablesVariation',
                                 'ForeignKeys',
+                                'GeneBiotypes',
                               ],
                               registry_file   => $self->o('registry'),
                               history_file    => $self->o('history_file'),


### PR DESCRIPTION
## Description
We missed a problem with an update to the biotype table which was not reflected in the gene and transcript tables. There's already a datacheck for that, but we weren't using it - now we are.

## Benefits
Catch errors immediately.

## Possible Drawbacks
None.
