### PR TITLE
Fixed the Dumps Genes / Genomes for covid-19 (no compara db available…

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/JSON/DumpGenomeJson.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/JSON/DumpGenomeJson.pm
@@ -32,132 +32,132 @@ use Bio::EnsEMBL::DBSQL::DBAdaptor;
 use Bio::EnsEMBL::Production::Pipeline::JSON::JsonRemodeller;
 
 sub fetch_input {
-  my ($self) = @_;
+    my ($self) = @_;
 
-  $self->param( 'dba', $self->core_dba() );
+    $self->param('dba', $self->core_dba());
 
-  my $tax_dba =
-    Bio::EnsEMBL::Registry->get_DBAdaptor( "multi", "taxonomy" );
-  my $onto_dba =
-    Bio::EnsEMBL::Registry->get_DBAdaptor( "multi", "ontology" );
-  $self->param( 'metadata_dba',
-                Bio::EnsEMBL::Registry->get_DBAdaptor(
-                                                     "multi", "metadata"
-                ) );
+    my $tax_dba =
+        Bio::EnsEMBL::Registry->get_DBAdaptor("multi", "taxonomy");
+    my $onto_dba =
+        Bio::EnsEMBL::Registry->get_DBAdaptor("multi", "ontology");
+    $self->param('metadata_dba',
+        Bio::EnsEMBL::Registry->get_DBAdaptor(
+            "multi", "metadata"
+        ));
 
-  $self->param(
-          'remodeller',
-          Bio::EnsEMBL::Production::Pipeline::JSON::JsonRemodeller->new(
-                                              -taxonomy_dba => $tax_dba,
-                                              -ontology_dba => $onto_dba
-          ) );
-  return;
+    $self->param(
+        'remodeller',
+        Bio::EnsEMBL::Production::Pipeline::JSON::JsonRemodeller->new(
+            -taxonomy_dba => $tax_dba,
+            -ontology_dba => $onto_dba
+        ));
+    return;
 }
 
 sub param_defaults {
-  return {};
+    return {};
 }
 
 sub run {
-  my ($self) = @_;
-  print $self->param('species');
-  if ( $self->param('species') !~ /Ancestral sequences/ ) {
-    $self->write_json();
-  }
-  return;
+    my ($self) = @_;
+    print $self->param('species');
+    if ($self->param('species') !~ /Ancestral sequences/) {
+        $self->write_json();
+    }
+    return;
 }
 
 sub write_json {
-  my ($self) = @_;
-  my $sub_dir = $self->create_dir('json');
-  $self->info(
-          "Processing " . $self->production_name() . " into $sub_dir" );
-  my $dba = $self->core_dba();
-  my $exporter =
-    Bio::EnsEMBL::Production::DBSQL::BulkFetcher->new(
-                                            -LEVEL => 'protein_feature',
-                                            -LOAD_EXONS => 1,
-                                            -LOAD_XREFS => 1 );
+    my ($self) = @_;
+    my $sub_dir = $self->create_dir('json');
+    $self->info(
+        "Processing " . $self->production_name() . " into $sub_dir");
+    my $dba = $self->core_dba();
+    my $exporter =
+        Bio::EnsEMBL::Production::DBSQL::BulkFetcher->new(
+            -LEVEL      => 'protein_feature',
+            -LOAD_EXONS => 1,
+            -LOAD_XREFS => 1);
 
-  # work out compara division
-  my $compara_name = $self->division();
-  if ( !defined $compara_name || $compara_name eq 'vertebrates' ) {
-    $compara_name = 'multi';
-  }
-  if ( $compara_name eq 'bacteria' ) {
-    $compara_name = 'pan_homology';
-  }
-  # get genome
-  my $genome_dba =
-    $self->param('metadata_dba')->get_GenomeInfoAdaptor();
-  if ( $compara_name ne 'multi' ) {
-    $genome_dba->set_ensembl_genomes_release();
-  }
-  my $mds = $genome_dba->fetch_by_name( $self->production_name() );
-  my $md;
-  my $division='Ensembl'.ucfirst($self->division());
-  foreach my $genome (@{$mds}){
-    $md = $genome if ($genome->division() eq $division);
-  }
-  die "Could not find genome " . $self->production_name()
-    if !defined $md;
+    # work out compara division
+    my $compara_name = $self->division();
+    if (!defined $compara_name || $compara_name eq 'vertebrates') {
+        $compara_name = 'multi';
+    }
+    if ($compara_name eq 'bacteria') {
+        $compara_name = 'pan_homology';
+    }
+    # get genome
+    my $genome_dba =
+        $self->param('metadata_dba')->get_GenomeInfoAdaptor();
+    if ($compara_name ne 'multi') {
+        $genome_dba->set_ensembl_genomes_release();
+    }
+    my $mds = $genome_dba->fetch_by_name($self->production_name());
+    my $md;
+    my $division = 'Ensembl' . ucfirst($self->division());
+    foreach my $genome (@{$mds}) {
+        $md = $genome if ($genome->division() eq $division);
+    }
+    die "Could not find genome " . $self->production_name()
+        if !defined $md;
 
-  my $genome = {
-            id           => $md->name(),
-            dbname       => $md->dbname(),
-            species_id   => $md->species_id(),
-            division     => $md->division(),
-            genebuild    => $md->genebuild(),
-            is_reference => $md->is_reference() == 1 ? "true" : "false",
-            organism     => {
-                      name                => $md->name(),
-                      display_name        => $md->display_name(),
-                      scientific_name     => $md->scientific_name(),
-                      strain              => $md->strain(),
-                      serotype            => $md->serotype(),
-                      taxonomy_id         => $md->taxonomy_id(),
-                      species_taxonomy_id => $md->species_taxonomy_id(),
-                      aliases             => $md->aliases() },
-            assembly => { name      => $md->assembly_name(),
-                          accession => $md->assembly_accession(),
-                          level     => $md->assembly_level() } };
+    my $genome = {
+        id           => $md->name(),
+        dbname       => $md->dbname(),
+        species_id   => $md->species_id(),
+        division     => $md->division(),
+        genebuild    => $md->genebuild(),
+        is_reference => $md->is_reference() == 1 ? "true" : "false",
+        organism     => {
+            name                => $md->name(),
+            display_name        => $md->display_name(),
+            scientific_name     => $md->scientific_name(),
+            strain              => $md->strain(),
+            serotype            => $md->serotype(),
+            taxonomy_id         => $md->taxonomy_id(),
+            species_taxonomy_id => $md->species_taxonomy_id(),
+            aliases             => $md->aliases() },
+        assembly     => { name => $md->assembly_name(),
+            accession          => $md->assembly_accession(),
+            level              => $md->assembly_level() } };
 
-  $genome_dba->dbc()->disconnect_if_idle();
-  $self->info("Exporting genes");
-  $genome->{genes} = $exporter->export_genes($dba);
-  # add compara
-  $self->info("Trying to find compara for '$compara_name'");
-  print "Looking for $compara_name\n";
-  my $compara =
-    Bio::EnsEMBL::Registry->get_DBAdaptor( $compara_name, 'compara' );
-  if ( !defined $compara ) {
-    die "No compara!\n";
-  }
-  if ( defined $compara ) {
-    $self->info( "Adding " . $compara->species() . " compara" );
-    $exporter->add_compara( $self->production_name(),
-                            $genome->{genes}, $compara );
-    $compara->dbc()->disconnect_if_idle();
-  }
-  # remodel
-  my $remodeller = $self->param('remodeller');
-  my $hive_dbc = $self->dbc;
-  $hive_dbc->disconnect_if_idle() if defined $hive_dbc;
-  if ( defined $remodeller ) {
-    $self->info("Remodelling genes");
-    $remodeller->remodel_genome($genome);
-    $remodeller->disconnect();
-  }
-  $dba->dbc()->disconnect_if_idle();
-  my $json_file_path =
-    $sub_dir . '/' . $self->production_name() . '.json';
-  $self->info("Writing to $json_file_path");
-  open my $json_file, '>', $json_file_path or
-    throw "Could not open $json_file_path for writing";
-  print $json_file encode_json($genome);
-  close $json_file;
-  $self->info("Write complete");
-  return;
+    $genome_dba->dbc()->disconnect_if_idle();
+    $self->info("Exporting genes");
+    $genome->{genes} = $exporter->export_genes($dba);
+    # add compara
+    $self->info("Trying to find compara for '$compara_name'");
+    my $compara = eval {
+        Bio::EnsEMBL::Registry->get_DBAdaptor($compara_name, 'compara')
+    };
+    if (defined $compara) {
+        $self->info("Adding " . $compara->species() . " compara");
+        $exporter->add_compara($self->production_name(),
+            $genome->{genes}, $compara);
+        $compara->dbc()->disconnect_if_idle();
+    }
+    else {
+        $self->warning("Compara '$compara_name' not found ");
+    };
+    # remodel
+    my $remodeller = $self->param('remodeller');
+    my $hive_dbc = $self->dbc;
+    $hive_dbc->disconnect_if_idle() if defined $hive_dbc;
+    if (defined $remodeller) {
+        $self->info("Remodelling genes");
+        $remodeller->remodel_genome($genome);
+        $remodeller->disconnect();
+    }
+    $dba->dbc()->disconnect_if_idle();
+    my $json_file_path =
+        $sub_dir . '/' . $self->production_name() . '.json';
+    $self->info("Writing to $json_file_path");
+    open my $json_file, '>', $json_file_path or
+        throw "Could not open $json_file_path for writing";
+    print $json_file encode_json($genome);
+    close $json_file;
+    $self->info("Write complete");
+    return;
 } ## end sub write_json
 
 1;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/SearchDumps_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/SearchDumps_conf.pm
@@ -41,18 +41,19 @@ sub default_options {
     my $self = shift;
     return {
         %{$self->SUPER::default_options()},
-        species         => [],
-        division        => [],
-        antispecies     => [],
-        run_all         => 0, #always run every species
-        use_pan_compara => 0, 
-        variant_length  => 1000000,
-        probe_length    => 100000,
+        species           => [],
+        division          => [],
+        antispecies       => [],
+        run_all           => 0, #always run every species
+        use_pan_compara   => 0,
+        variant_length    => 1000000,
+        probe_length      => 100000,
         regulatory_length => 100000,
-        dump_variant    => 1,
-        dump_regulation => 1,
-        release => software_version()
-	};
+        dump_variant      => 1,
+        dump_regulation   => 1,
+        resource_class    => '32g',
+        release           => software_version()
+    };
 }
 
 sub pipeline_wide_parameters {
@@ -78,10 +79,10 @@ sub pipeline_analyses {
                 division             => $self->o('division'),
                 run_all              => $self->o('run_all') },
             -rc_name    => '4g',
-	    -flow_into  => {
-                        '2->A' => [ 'DumpGenomeJson' ],
-                        'A->1' => [ 'WrapGenomeEBeye' ]
-                        }
+            -flow_into  => {
+                '2->A' => [ 'DumpGenomeJson' ],
+                'A->1' => [ 'WrapGenomeEBeye' ]
+            }
         },
         {
             -logic_name => 'WrapGenomeEBeye',
@@ -89,23 +90,23 @@ sub pipeline_analyses {
                 'Bio::EnsEMBL::Production::Pipeline::Search::WrapGenomeEBeye',
             -rc_name    => '1g',
             -parameters =>
-                        {
-                        division        => $self->o('division'),
-                        release         => $self->o('release'),
-                        },
-            -flow_into => 'ValidateXMLFileWrappedGenomesEBeye'
+                {
+                    division => $self->o('division'),
+                    release  => $self->o('release'),
+                },
+            -flow_into  => 'ValidateXMLFileWrappedGenomesEBeye'
         },
         {
-            -logic_name    => 'DumpGenomeJson',
-            -module        =>
+            -logic_name        => 'DumpGenomeJson',
+            -module            =>
                 'Bio::EnsEMBL::Production::Pipeline::Search::DumpGenomeJson',
-            -parameters    => {},
+            -parameters        => {},
             -analysis_capacity => 10,
-            -rc_name       => '1g',
-            -flow_into     => {
+            -rc_name           => '1g',
+            -flow_into         => {
                 2 => [ 'DumpGenesJson' ],
                 7 => [ 'DumpGenesJson' ],
-                4 => @variant_analyses, 
+                4 => @variant_analyses,
                 6 => @regulation_analyses,
             }
         },
@@ -115,15 +116,15 @@ sub pipeline_analyses {
                 'Bio::EnsEMBL::Production::Pipeline::Search::ValidateXMLFileEBeye',
             -rc_name    => '1g',
             -parameters =>
-                        {
-                        division        => $self->o('division'),
-                        release         => $self->o('release'),
-                        },
-            -flow_into  => 
-                        {
-                	1 => ['CompressEBeyeXMLFile'], 
-		       	2 => [ '?accu_name=genome_files&accu_address={species}&accu_input_variable=genome_valid_file']
-                        },
+                {
+                    division => $self->o('division'),
+                    release  => $self->o('release'),
+                },
+            -flow_into  =>
+                {
+                    1 => [ 'CompressEBeyeXMLFile' ],
+                    2 => [ '?accu_name=genome_files&accu_address={species}&accu_input_variable=genome_valid_file' ]
+                },
         },
         {
             -logic_name => 'ValidateXMLFileVariantEBeye',
@@ -131,14 +132,14 @@ sub pipeline_analyses {
                 'Bio::EnsEMBL::Production::Pipeline::Search::ValidateXMLFileEBeye',
             -rc_name    => '1g',
             -parameters =>
-                        {
-                        division        => $self->o('division'),
-                        release         => $self->o('release'),
-                        },
+                {
+                    division => $self->o('division'),
+                    release  => $self->o('release'),
+                },
             -flow_into  =>
-                        {
-                          1 => ['CompressVariantEBeyeXMLFile'],
-                        },
+                {
+                    1 => [ 'CompressVariantEBeyeXMLFile' ],
+                },
         },
         {
             -logic_name => 'ValidateXMLFileWrappedGenomesEBeye',
@@ -146,77 +147,77 @@ sub pipeline_analyses {
                 'Bio::EnsEMBL::Production::Pipeline::Search::ValidateXMLFileEBeye',
             -rc_name    => '1g',
             -parameters =>
-                        {
-                        division        => $self->o('division'),
-                        release         => $self->o('release'),
-                        },
-            -flow_into  =>
-                        {
-                          1 => ['CompressWrappedGenomesEBeyeXMLFile']
-                    },
-        },
-        {
-             -logic_name => 'CompressEBeyeXMLFile',
-             -module =>
-                'Bio::EnsEMBL::Production::Pipeline::Search::CompressEBeyeXMLFile',
-             -parameters =>
-                        {
-                        division        => $self->o('division'),
-                        release         => $self->o('release'),
-                        },
-             -analysis_capacity => 4,
-             -rc_name    => '1g'
-        },
-        {
-             -logic_name => 'CompressWrappedGenomesEBeyeXMLFile',
-             -module =>
-                'Bio::EnsEMBL::Production::Pipeline::Search::CompressEBeyeXMLFile',
-             -parameters =>
-                        {
-                        division        => $self->o('division'),
-                        release         => $self->o('release'),
-                        },
-             -analysis_capacity => 4,
-        },
                 {
-             -logic_name => 'CompressVariantEBeyeXMLFile',
-             -module =>
-                'Bio::EnsEMBL::Production::Pipeline::Search::CompressEBeyeXMLFile',
-             -parameters =>
-                        {
-                        division        => $self->o('division'),
-                        release         => $self->o('release'),
-                        },
-             -analysis_capacity => 4,
+                    division => $self->o('division'),
+                    release  => $self->o('release'),
+                },
+            -flow_into  =>
+                {
+                    1 => [ 'CompressWrappedGenomesEBeyeXMLFile' ]
+                },
         },
         {
-            -logic_name    => 'DumpGenesJson',
-            -module        =>
+            -logic_name        => 'CompressEBeyeXMLFile',
+            -module            =>
+                'Bio::EnsEMBL::Production::Pipeline::Search::CompressEBeyeXMLFile',
+            -parameters        =>
+                {
+                    division => $self->o('division'),
+                    release  => $self->o('release'),
+                },
+            -analysis_capacity => 4,
+            -rc_name           => '1g'
+        },
+        {
+            -logic_name        => 'CompressWrappedGenomesEBeyeXMLFile',
+            -module            =>
+                'Bio::EnsEMBL::Production::Pipeline::Search::CompressEBeyeXMLFile',
+            -parameters        =>
+                {
+                    division => $self->o('division'),
+                    release  => $self->o('release'),
+                },
+            -analysis_capacity => 4,
+        },
+        {
+            -logic_name        => 'CompressVariantEBeyeXMLFile',
+            -module            =>
+                'Bio::EnsEMBL::Production::Pipeline::Search::CompressEBeyeXMLFile',
+            -parameters        =>
+                {
+                    division => $self->o('division'),
+                    release  => $self->o('release'),
+                },
+            -analysis_capacity => 4,
+        },
+        {
+            -logic_name        => 'DumpGenesJson',
+            -module            =>
                 'Bio::EnsEMBL::Production::Pipeline::Search::DumpGenesJson',
-            -parameters    => {
+            -parameters        => {
                 use_pan_compara => $self->o('use_pan_compara')
             },
             -analysis_capacity => 10,
-            -rc_name       => '32g',
-            -flow_into     => {
-                1 => [
+            -rc_name           => $self->o('resource_class'),
+            -flow_into         => {
+                1  => [
                     'ReformatGenomeAdvancedSearch',
                     #'ReformatGenomeSolr',
                     'ReformatGenomeEBeye'
                 ],
                 -1 => 'DumpGenesJsonHighmem'
-             }
+            }
         },
         {
-            -logic_name    => 'DumpGenesJsonHighmem',
-            -module        =>
+            -logic_name        => 'DumpGenesJsonHighmem',
+            -module            =>
                 'Bio::EnsEMBL::Production::Pipeline::Search::DumpGenesJson',
-            -parameters    => {
+            -parameters        => {
                 use_pan_compara => $self->o('use_pan_compara')
             },
             -analysis_capacity => 10,
-            -rc_name       => '100g',
-            -flow_into     => {
+            -rc_name           => '100g',
+            -flow_into         => {
                 1 => [
                     'ReformatGenomeAdvancedSearch',
                     #'ReformatGenomeSolr',
@@ -225,13 +226,13 @@ sub pipeline_analyses {
             }
         },
         {
-            -logic_name    => 'DumpRegulationJson',
-            -module        =>
+            -logic_name        => 'DumpRegulationJson',
+            -module            =>
                 'Bio::EnsEMBL::Production::Pipeline::Search::DumpRegulationJson',
-            -parameters    => {},
+            -parameters        => {},
             -analysis_capacity => 10,
-            -rc_name       => '32g',
-            -flow_into     => {
+            -rc_name           => $self->o('resource_class'),
+            -flow_into         => {
                 2 => [
                     '?accu_name=motifs_dump_file&accu_address=[]',
                     '?accu_name=regulatory_features_dump_file&accu_address=[]',
@@ -251,7 +252,7 @@ sub pipeline_analyses {
             -flow_into  =>
                 {
                     #2 => ['ReformatRegulationSolr','ReformatRegulationAdvancedSearch'],
-                    2 => ['ReformatRegulationAdvancedSearch'],
+                    2 => [ 'ReformatRegulationAdvancedSearch' ],
                 }
         },
         {
@@ -267,12 +268,12 @@ sub pipeline_analyses {
                 { '2->A' => 'DumpVariantJson', 'A->1' => 'VariantDumpMerge' }
         },
         {
-            -logic_name    => 'DumpVariantJson',
+            -logic_name        => 'DumpVariantJson',
             -analysis_capacity => 20,
-            -module        =>
+            -module            =>
                 'Bio::EnsEMBL::Production::Pipeline::Search::DumpVariantJson',
-            -rc_name       => '32g',
-            -flow_into     => {
+            -rc_name           => $self->o('resource_class'),
+            -flow_into         => {
                 2 => [
                     '?accu_name=dump_file&accu_address=[]',
                     '?accu_name=species'
@@ -310,12 +311,12 @@ sub pipeline_analyses {
             }
         },
         {
-            -logic_name    => 'DumpStructuralVariantJson',
+            -logic_name        => 'DumpStructuralVariantJson',
             -analysis_capacity => 10,
-            -module        =>
+            -module            =>
                 'Bio::EnsEMBL::Production::Pipeline::Search::DumpStructuralVariantJson',
-            -rc_name       => '32g',
-            -flow_into     => {
+            -rc_name           => $self->o('resource_class'),
+            -flow_into         => {
                 2 => [
                     '?accu_name=dump_file&accu_address=[]',
                     '?accu_name=species'
@@ -328,16 +329,16 @@ sub pipeline_analyses {
             -module     => 'Bio::EnsEMBL::Production::Pipeline::Search::DumpMerge',
             -parameters => { file_type => 'structuralvariants' },
             -rc_name    => '1g',
-           # -flow_into  => {
-           #     1 => 'ReformatStructuralVariantsSolr' }
+            # -flow_into  => {
+            #     1 => 'ReformatStructuralVariantsSolr' }
         },
         {
-            -logic_name    => 'DumpPhenotypesJson',
-            -module        =>
+            -logic_name        => 'DumpPhenotypesJson',
+            -module            =>
                 'Bio::EnsEMBL::Production::Pipeline::Search::DumpPhenotypesJson',
-            -parameters    => {},
+            -parameters        => {},
             -analysis_capacity => 10,
-            -rc_name       => '1g',
+            -rc_name           => '1g',
             #-flow_into     => {
             #    2 => 'ReformatPhenotypesSolr'
             #}
@@ -369,12 +370,12 @@ sub pipeline_analyses {
                 }
         },
         {
-            -logic_name    => 'DumpProbeJson',
+            -logic_name        => 'DumpProbeJson',
             -analysis_capacity => 10,
-            -module        =>
+            -module            =>
                 'Bio::EnsEMBL::Production::Pipeline::Search::DumpProbesJson',
-            -rc_name       => '32g',
-            -flow_into     => {
+            -rc_name           => $self->o('resource_class'),
+            -flow_into         => {
                 2 => [
                     '?accu_name=probes_dump_file&accu_address=[]',
                     '?accu_name=probesets_dump_file&accu_address=[]',
@@ -391,17 +392,17 @@ sub pipeline_analyses {
                 {
                     #2 => ['ReformatProbesSolr','ReformatProbesAdvancedSearch'],
                     #3 => ['ReformatProbeSetsSolr','ReformatProbesetsAdvancedSearch'],
-                    2 => ['ReformatProbesAdvancedSearch'],
-                    3 => ['ReformatProbesetsAdvancedSearch'],
+                    2 => [ 'ReformatProbesAdvancedSearch' ],
+                    3 => [ 'ReformatProbesetsAdvancedSearch' ],
                 }
         },
         {
-            -logic_name => 'ReformatGenomeAdvancedSearch',
-            -module     =>
+            -logic_name        => 'ReformatGenomeAdvancedSearch',
+            -module            =>
                 'Bio::EnsEMBL::Production::Pipeline::Search::ReformatGenomeAdvancedSearch',
-            -rc_name    => '1g',
+            -rc_name           => '1g',
             -analysis_capacity => 10,
-            -flow_into  => {}
+            -flow_into         => {}
         },
         {
             -logic_name => 'ReformatVariantsAdvancedSearch',
@@ -439,12 +440,12 @@ sub pipeline_analyses {
             -flow_into  => {}
         },
         {
-            -logic_name => 'ReformatGenomeEBeye',
-            -module     =>
+            -logic_name        => 'ReformatGenomeEBeye',
+            -module            =>
                 'Bio::EnsEMBL::Production::Pipeline::Search::ReformatGenomeEBeye',
-            -rc_name    => '4g',
+            -rc_name           => '4g',
             -analysis_capacity => 10,
-            -flow_into  => 'ValidateXMLFileEBeye'
+            -flow_into         => 'ValidateXMLFileEBeye'
         },
         {
             -logic_name => 'ReformatVariantsSolr',
@@ -506,12 +507,12 @@ sub beekeeper_extra_cmdline_options {
 sub resource_classes {
     my $self = shift;
     return {
-        '32g' => { LSF => '-q production-rh74 -M 32000 -R "rusage[mem=32000]"' },
+        '32g'  => { LSF => '-q production-rh74 -M 32000 -R "rusage[mem=32000]"' },
         '100g' => { LSF => '-q production-rh74 -M 100000 -R "rusage[mem=100000]"' },
-        '16g' => { LSF => '-q production-rh74 -M 16000 -R "rusage[mem=16000]"' },
-        '8g'  => { LSF => '-q production-rh74 -M 16000 -R "rusage[mem=8000]"' },
-        '4g'  => { LSF => '-q production-rh74 -M 4000 -R "rusage[mem=4000]"' },
-        '1g'  => { LSF => '-q production-rh74 -M 1000 -R "rusage[mem=1000]"' } };
+        '16g'  => { LSF => '-q production-rh74 -M 16000 -R "rusage[mem=16000]"' },
+        '8g'   => { LSF => '-q production-rh74 -M 16000 -R "rusage[mem=8000]"' },
+        '4g'   => { LSF => '-q production-rh74 -M 4000 -R "rusage[mem=4000]"' },
+        '1g'   => { LSF => '-q production-rh74 -M 1000 -R "rusage[mem=1000]"' } };
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Search/DumpGenesJson.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Search/DumpGenesJson.pm
@@ -38,133 +38,135 @@ use Bio::EnsEMBL::Production::Search::IdFetcher;
 use Log::Log4perl qw/:easy/;
 
 sub dump {
-  my ($self, $species, $type) = @_;
-  $self->{logger} = get_logger();
-  if ($species !~ /Ancestral sequences/) {
+    my ($self, $species, $type) = @_;
+    $self->{logger} = get_logger();
+    if ($species !~ /Ancestral sequences/) {
 
-    my $compara = $self->param('compara');
-    if (!defined $compara) {
-      $compara = $self->division();
-      if (!defined $compara || $compara eq '' || lc($compara) eq 'vertebrates') {
-        $compara = 'multi';
-      }
-    }
-    if (defined $compara) {
-      $self->{logger}->info("Using compara $compara");
-      $self->{logger}->info("Also using pan taxonomic compara") if $self->param('use_pan_compara');
-    }
+        my $compara = $self->param('compara');
+        if (!defined $compara) {
+            $compara = $self->division();
+            if (!defined $compara || $compara eq '' || lc($compara) eq 'vertebrates') {
+                $compara = 'multi';
+            }
+        }
+        if (defined $compara) {
+            $self->{logger}->info("Using compara $compara");
+            $self->{logger}->info("Also using pan taxonomic compara") if $self->param('use_pan_compara');
+        }
 
-    $type ||= 'core';
-    my $dba = Bio::EnsEMBL::Registry->get_DBAdaptor($species, $type);
+        $type ||= 'core';
+        my $dba = Bio::EnsEMBL::Registry->get_DBAdaptor($species, $type);
 
-    my $output = {
-        species     => $species,
-        type        => $type,
-        genome_file => $self->param('genome_file')
-    };
-    $self->hive_dbc()->disconnect_if_idle() if defined $self->hive_dbc();
-    $self->{logger}->info("Dumping data for $species $type");
-    $self->{logger}->info("Dumping genes");
-    $output->{genes_file} = $self->dump_genes($dba, $compara, $type, $self->param('use_pan_compara'));
-    $self->{logger}->info("Dumping sequences");
-    $output->{sequences_file} = $self->dump_sequences($dba, $type);
-    $self->{logger}->info("Dumping LRGs");
-    $output->{lrgs_file} = $self->dump_lrgs($dba, $type);
-    $self->{logger}->info("Dumping markers");
-    $output->{markers_file} = $self->dump_markers($dba, $type);
-    $self->{logger}->info("Dumping IDs");
-    $output->{ids_file} = $self->dump_ids($dba, $type);
+        my $output = {
+            species     => $species,
+            type        => $type,
+            genome_file => $self->param('genome_file')
+        };
+        $self->hive_dbc()->disconnect_if_idle() if defined $self->hive_dbc();
+        $self->{logger}->info("Dumping data for $species $type");
+        $self->{logger}->info("Dumping genes");
+        $output->{genes_file} = $self->dump_genes($dba, $compara, $type, $self->param('use_pan_compara'));
+        $self->{logger}->info("Dumping sequences");
+        $output->{sequences_file} = $self->dump_sequences($dba, $type);
+        $self->{logger}->info("Dumping LRGs");
+        $output->{lrgs_file} = $self->dump_lrgs($dba, $type);
+        $self->{logger}->info("Dumping markers");
+        $output->{markers_file} = $self->dump_markers($dba, $type);
+        $self->{logger}->info("Dumping IDs");
+        $output->{ids_file} = $self->dump_ids($dba, $type);
 
-    $self->{logger}->info("Completed dumping $species $type");
-    $dba->dbc()->disconnect_if_idle(1);
-    $self->dataflow_output_id($output, 1);
-  } ## end if ( $species !~ /Ancestral sequences/)
-  return;
+        $self->{logger}->info("Completed dumping $species $type");
+        $dba->dbc()->disconnect_if_idle(1);
+        $self->dataflow_output_id($output, 1);
+    } ## end if ( $species !~ /Ancestral sequences/)
+    return;
 } ## end sub dump
 
 sub dump_genes {
-  my ($self, $dba, $compara, $type, $use_pan_compara) = @_;
-  $self->{logger} = get_logger();
-  my $funcgen_dba;
-  my $compara_dba;
-  my $pan_compara_dba;
+    my ($self, $dba, $compara, $type, $use_pan_compara) = @_;
+    $self->{logger} = get_logger();
+    my $funcgen_dba;
+    my $compara_dba;
+    my $pan_compara_dba;
 
-  if ($type eq 'core') {
-    $funcgen_dba = Bio::EnsEMBL::Registry->get_DBAdaptor($dba->species(), 'funcgen');
-    $compara_dba = Bio::EnsEMBL::Registry->get_DBAdaptor($compara, 'compara') if defined $compara;
-    $pan_compara_dba = Bio::EnsEMBL::Registry->get_DBAdaptor('pan_homology', 'compara') if $use_pan_compara;
-  }
+    if ($type eq 'core') {
+        $funcgen_dba = Bio::EnsEMBL::Registry->get_DBAdaptor($dba->species(), 'funcgen');
+        my $compara_dba = eval {
+          Bio::EnsEMBL::Registry->get_DBAdaptor($compara, 'compara') if defined $compara;
+        };
+        $pan_compara_dba = Bio::EnsEMBL::Registry->get_DBAdaptor('pan_homology', 'compara') if $use_pan_compara;
+    }
 
-  my $genes = Bio::EnsEMBL::Production::Search::GeneFetcher->new()->fetch_genes_for_dba($dba, $compara_dba, $funcgen_dba, $pan_compara_dba);
-  if (defined $genes && scalar(@$genes) > 0) {
-    $self->{logger}->info("Writing " . scalar(@$genes) . " genes to JSON");
-    my $f = $self->write_json($dba->species, 'genes', $genes, $type);
-    $self->{logger}->info("Wrote " . scalar(@$genes) . " genes to $f");
-    return $f;
-  }
-  else {
-    return undef;
-  }
+    my $genes = Bio::EnsEMBL::Production::Search::GeneFetcher->new()->fetch_genes_for_dba($dba, $compara_dba, $funcgen_dba, $pan_compara_dba);
+    if (defined $genes && scalar(@$genes) > 0) {
+        $self->{logger}->info("Writing " . scalar(@$genes) . " genes to JSON");
+        my $f = $self->write_json($dba->species, 'genes', $genes, $type);
+        $self->{logger}->info("Wrote " . scalar(@$genes) . " genes to $f");
+        return $f;
+    }
+    else {
+        return undef;
+    }
 }
 
 sub dump_sequences {
-  my ($self, $dba, $type) = @_;
-  $self->{logger} = get_logger();
-  my $sequences = Bio::EnsEMBL::Production::Search::SequenceFetcher->new()->fetch_sequences_for_dba($dba);
-  if (scalar(@$sequences) > 0) {
-    $self->{logger}->info("Writing " . scalar(@$sequences) . " sequences to JSON");
-    my $f = $self->write_json($dba->species, 'sequences', $sequences, $type);
-    $self->{logger}->info("Wrote " . scalar(@$sequences) . " sequences to $f");
-    return $f;
-  }
-  else {
-    return undef;
-  }
+    my ($self, $dba, $type) = @_;
+    $self->{logger} = get_logger();
+    my $sequences = Bio::EnsEMBL::Production::Search::SequenceFetcher->new()->fetch_sequences_for_dba($dba);
+    if (scalar(@$sequences) > 0) {
+        $self->{logger}->info("Writing " . scalar(@$sequences) . " sequences to JSON");
+        my $f = $self->write_json($dba->species, 'sequences', $sequences, $type);
+        $self->{logger}->info("Wrote " . scalar(@$sequences) . " sequences to $f");
+        return $f;
+    }
+    else {
+        return undef;
+    }
 }
 
 sub dump_markers {
-  my ($self, $dba, $type) = @_;
-  $self->{logger} = get_logger();
-  my $markers = Bio::EnsEMBL::Production::Search::MarkerFetcher->new()->fetch_markers_for_dba($dba);
-  if (scalar(@$markers) > 0) {
-    $self->{logger}->info("Writing " . scalar(@$markers) . " markers to JSON");
-    my $f = $self->write_json($dba->species, 'markers', $markers, $type);
-    $self->{logger}->info("Wrote " . scalar(@$markers) . " markers to $f");
-    return $f;
-  }
-  else {
-    return undef;
-  }
+    my ($self, $dba, $type) = @_;
+    $self->{logger} = get_logger();
+    my $markers = Bio::EnsEMBL::Production::Search::MarkerFetcher->new()->fetch_markers_for_dba($dba);
+    if (scalar(@$markers) > 0) {
+        $self->{logger}->info("Writing " . scalar(@$markers) . " markers to JSON");
+        my $f = $self->write_json($dba->species, 'markers', $markers, $type);
+        $self->{logger}->info("Wrote " . scalar(@$markers) . " markers to $f");
+        return $f;
+    }
+    else {
+        return undef;
+    }
 }
 
 sub dump_lrgs {
-  my ($self, $dba, $type) = @_;
-  $self->{logger} = get_logger();
-  my $lrgs = Bio::EnsEMBL::Production::Search::LRGFetcher->new()->fetch_lrgs_for_dba($dba);
-  if (scalar(@$lrgs) > 0) {
-    $self->{logger}->info("Writing " . scalar(@$lrgs) . " LRGs to JSON");
-    my $f = $self->write_json($dba->species, 'lrgs', $lrgs, $type);
-    $self->{logger}->info("Wrote " . scalar(@$lrgs) . " LRGs to $f");
-    return $f;
-  }
-  else {
-    return undef;
-  }
+    my ($self, $dba, $type) = @_;
+    $self->{logger} = get_logger();
+    my $lrgs = Bio::EnsEMBL::Production::Search::LRGFetcher->new()->fetch_lrgs_for_dba($dba);
+    if (scalar(@$lrgs) > 0) {
+        $self->{logger}->info("Writing " . scalar(@$lrgs) . " LRGs to JSON");
+        my $f = $self->write_json($dba->species, 'lrgs', $lrgs, $type);
+        $self->{logger}->info("Wrote " . scalar(@$lrgs) . " LRGs to $f");
+        return $f;
+    }
+    else {
+        return undef;
+    }
 }
 
 sub dump_ids {
-  my ($self, $dba, $type) = @_;
-  $self->{logger} = get_logger();
-  my $ids = Bio::EnsEMBL::Production::Search::IdFetcher->new()->fetch_ids_for_dba($dba);
-  if (scalar(@$ids) > 0) {
-    $self->{logger}->info("Writing " . scalar(@$ids) . " IDs to JSON");
-    my $f = $self->write_json($dba->species, 'ids', $ids, $type);
-    $self->{logger}->info("Wrote " . scalar(@$ids) . " IDs to $f");
-    return $f;
-  }
-  else {
-    return undef;
-  }
+    my ($self, $dba, $type) = @_;
+    $self->{logger} = get_logger();
+    my $ids = Bio::EnsEMBL::Production::Search::IdFetcher->new()->fetch_ids_for_dba($dba);
+    if (scalar(@$ids) > 0) {
+        $self->{logger}->info("Writing " . scalar(@$ids) . " IDs to JSON");
+        my $f = $self->write_json($dba->species, 'ids', $ids, $type);
+        $self->{logger}->info("Wrote " . scalar(@$ids) . " IDs to $f");
+        return $f;
+    }
+    else {
+        return undef;
+    }
 }
 
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Search/DumpGenomeJson.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Search/DumpGenomeJson.pm
@@ -40,66 +40,70 @@ use Bio::EnsEMBL::Production::Pipeline::Common::SpeciesFactory qw(has_variation)
 use Log::Log4perl qw/:easy/;
 
 sub dump {
-	my ( $self, $species ) = @_;
-	if ( $species !~ /Ancestral sequences/ ) {
-		my $compara = $self->param('compara');
-		if ( !defined $compara ) {
-			$compara = $self->division();
-			if ( !defined $compara || $compara eq '' ) {
-				$compara = 'multi';
-			}
-		}
-		if ( defined $compara ) {
-			$self->{logger}->info("Using compara $compara");
-		}
-		# dump the genome file
-		$self->{logger}->info( "Dumping genome for " . $species );
-		my $genome_file = $self->dump_genome( $species, $compara );
-		$self->{logger}->info( "Completed dumping " . $species );
+    my ($self, $species) = @_;
+    if ($species !~ /Ancestral sequences/) {
+        my $compara = $self->param('compara');
+        if (!defined $compara) {
+            $compara = $self->division();
+            if (!defined $compara || $compara eq '') {
+                $compara = 'multi';
+            }
+        }
+        if (defined $compara) {
+            $self->{logger}->info("Using compara $compara");
+        }
+        # dump the genome file
+        $self->{logger}->info("Dumping genome for " . $species);
+        my $genome_file = $self->dump_genome($species, $compara);
+        $self->{logger}->info("Completed dumping " . $species);
 
-		# figure out output
-		$self->dataflow_output_id( {  species     => $species,
-									  type        => 'core',
-									  genome_file => $genome_file },
-								   2 );
+        # figure out output
+        $self->dataflow_output_id({
+            species     => $species,
+            type        => 'core',
+            genome_file => $genome_file },
+            2);
 
-		$self->dataflow_output_id( {  species     => $species,
-									  type        => 'otherfeatures',
-									  genome_file => $genome_file },
-								   7 )
-		  if (Bio::EnsEMBL::Registry->get_DBAdaptor( $species, 'otherfeatures' )
-		  );
+        $self->dataflow_output_id({
+            species     => $species,
+            type        => 'otherfeatures',
+            genome_file => $genome_file },
+            7)
+            if (Bio::EnsEMBL::Registry->get_DBAdaptor($species, 'otherfeatures')
+            );
 
-		$self->dataflow_output_id( {  species     => $species,
-									  type        => 'variation',
-									  genome_file => $genome_file },
-								   4 )
-		  if ( $self->has_variation($species) );
+        $self->dataflow_output_id({
+            species     => $species,
+            type        => 'variation',
+            genome_file => $genome_file },
+            4)
+            if ($self->has_variation($species));
 
-		$self->dataflow_output_id( {  species     => $species,
-									  type        => 'funcgen',
-									  genome_file => $genome_file },
-								   6 )
-		  if ( Bio::EnsEMBL::Registry->get_DBAdaptor( $species, 'funcgen' ) )
-		  ;
+        $self->dataflow_output_id({
+            species     => $species,
+            type        => 'funcgen',
+            genome_file => $genome_file },
+            6)
+            if (Bio::EnsEMBL::Registry->get_DBAdaptor($species, 'funcgen'))
+        ;
 
-	} ## end if ( $species !~ /Ancestral sequences/)
-	return;
+    } ## end if ( $species !~ /Ancestral sequences/)
+    return;
 } ## end sub dump
 
 sub dump_genome {
-	my ( $self, $species, $compara ) = @_;
-	my $genome;
-	if ( $compara && $compara ne 'multi' ) {
-		$genome =
-		  Bio::EnsEMBL::Production::Search::GenomeFetcher->new( -EG => 1 )
-		  ->fetch_genome($species);
-	}
-	else {
-		$genome = Bio::EnsEMBL::Production::Search::GenomeFetcher->new()
-		  ->fetch_genome($species);
-	}
-	return $self->write_json( $species, 'genome', $genome );
+    my ($self, $species, $compara) = @_;
+    my $genome;
+    if ($compara && $compara ne 'multi') {
+        $genome =
+            Bio::EnsEMBL::Production::Search::GenomeFetcher->new(-EG => 1)
+                ->fetch_genome($species);
+    }
+    else {
+        $genome = Bio::EnsEMBL::Production::Search::GenomeFetcher->new()
+            ->fetch_genome($species);
+    }
+    return $self->write_json($species, 'genome', $genome);
 }
 
 1;


### PR DESCRIPTION
… for now)

**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Description

Failures in search dumps for covid-19 viruses division because of missing comparative dataset.

## Use case

Search dumps for viruses (covid-19)

## Benefits

Well... it works now
In order to speed up the run, the `rc_name` used in resources class attribution is now override-able in pipeline configuration

## Possible Drawbacks

Nonw

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
