### PR TITLE
Bareword "PR" not allowed while "strict subs" in use at

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/OLSLoad_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/OLSLoad_conf.pm
@@ -174,7 +174,7 @@ sub pipeline_analyses {
             },
             -flow_into  => {
                 '2->A' => WHEN(
-                    '#ontology_name# eq PR' => { 'ontology_term_load_light' => INPUT_PLUS },
+                    '#ontology_name# eq "PR"' => { 'ontology_term_load_light' => INPUT_PLUS },
                     ELSE { 'ontology_term_load' => INPUT_PLUS },
                 ),
                 'A->1' => [ 'ontology_report' ]


### PR DESCRIPTION
Fix for : failed: ParamError: Cannot evaluate the expression: 'expr(#ontology_name# eq PR)expr' ==> '$self->_param_possibly_overridden('ontology_name', $overriding_hash) eq PR' Bareword "PR" not allowed while "strict subs" in use at (eval 78) line 1.