### PR TITLE
ENSCORESW-3196: separate checksum entries by source to avoid cross so…

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/RNAcentralMapping.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/RNAcentralMapping.pm
@@ -44,7 +44,9 @@ sub run {
  
   my $target = $mapper->target;
   my $object_type = $mapper->object_type;
-  my $source_id = $mapper->source_id;
+  my ($user, $pass, $host, $port, $source_db) = $self->parse_url($db_url);
+  my $dbi = $self->get_dbi($host, $port, $user, $pass, $source_db);
+  my $source_id = $self->get_source_id_from_name($dbi, 'RNACentral');
 
   my $method = XrefMapper::Methods::MySQLChecksum->new( -MAPPER => $mapper);
   my $results = $method->run($target, $source_id, $object_type, $db_url);

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/UniParcMapping.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/UniParcMapping.pm
@@ -46,7 +46,9 @@ sub run {
 
   my $target = $mapper->target;
   my $object_type = $mapper->object_type;
-  my $source_id = $mapper->source_id;
+  my ($user, $pass, $host, $port, $source_db) = $self->parse_url($db_url);
+  my $dbi = $self->get_dbi($host, $port, $user, $pass, $source_db);
+  my $source_id = $self->get_source_id_from_name($dbi, 'UniParc');
 
   my $method = XrefMapper::Methods::MySQLChecksum->new( -MAPPER => $mapper);
   my $results = $method->run($target, $source_id, $object_type, $db_url);


### PR DESCRIPTION
…urce mappings

**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

_Using one or more sentences, describe in detail the proposed changes._
We have checksum entries for RNAcentral (transcript sequences) and UniParc (protein sequences)
Currently, we do not distinguish between the two sources and attempt to map checksums from both sources to all sequences available.
Recently, due to clash in checksums, we have started mapping some UniParc checksums to transcript sequences.
To avoid this, we want to store the checksums with the source they come from and use that information in the later mapping stage, to only attempt to map RNAcentral to transcript sequences, and UniParc to protein sequences

## Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._
UPI0001765128 is a UniParc entry with checksum CFECF93F30021B262B430492E53B847C
The transcript sequence for ENST00000616594.2 has the same checksum and maps to UPI0001765128
With this change, UPI0001765128 is only compared to protein sequences and will not map to ENST00000616594.2

## Benefits

_If applicable, describe the advantages the changes will have._
No cross-source checksum mapping happening

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._
The individual checksum mapping stages might be slower, as the SQL query restricts on individual source_id

## Testing

- [ ] Have you added/modified unit tests to test the changes?
NA
- [ ] If so, do the tests pass?
NA
- [ ] Have you run the entire test suite and no regression was detected?
NA
There is no test case for this pipeline
The whole xref pipeline was run before and after the change.
In particular, the DataChecks run at the end were reporting the mismapped UPI0001765128 xref before the change, but not after
- [ ] TravisCI passed on your branch
NA

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.

To fully work, this will also require the following change in the Ensembl repository: https://github.com/Ensembl/ensembl/pull/496