### PR TITLE
Add dcstat script for parsing DC JSON results

### DIFF
--- a/scripts/py/dcparse.py
+++ b/scripts/py/dcparse.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+
+# Requirements:
+#   Python 3.7+
+# Usage example:
+#   python dcparse.py /path/to/dc_dir -o failed_dc.json
+# Print help:
+#   python dcparse.py -h
+
+
+import argparse
+import json
+import os
+import re
+from typing import Any, List, Dict, IO, Pattern
+
+
+test_re = re.compile(r'^ {8}(not ok .+)$')
+species_re = re.compile(r'^ {4}not ok \d+ - (.+)$')
+dc_re = re.compile(r'^not ok \d+ - (\w+)$')
+test_line_re = re.compile(r'^ {8}#(.+)$')
+empty_re = re.compile(r'^$')
+
+
+def skip_to(regex: Pattern, dc_file: IO, skip_empty: bool = True) -> str:
+    for line in dc_file:
+        if skip_empty and empty_re.match(line):
+            continue
+        match = regex.match(line)
+        if match:
+            return match.group(1)
+
+
+def skip_multiple_lines(regex: Pattern, dc_file: IO, skip_empty: bool = True) -> List[str]:
+    test_lines = []
+    for line in dc_file:
+        if skip_empty and empty_re.match(line):
+            continue
+        match = regex.match(line)
+        if match:
+            test_lines.append(match.group(1))
+        else:
+            return test_lines
+
+
+def load_failed(dc_file: IO, data: Dict[str, Any]) -> None:
+    for line in dc_file:
+        match = test_re.match(line)
+        if match:
+            test = match.group(1)
+            test_lines = skip_multiple_lines(test_line_re, dc_file)
+            species = skip_to(species_re, dc_file)
+            dc = skip_to(dc_re, dc_file)
+            data.setdefault(dc, {}).setdefault(species, {}).setdefault('tests', {}).setdefault(test, []).extend(test_lines)
+
+
+def parse_dc(dc_dir: str, out_file: str) -> None:
+    data: Dict[str, Any] = {}
+    for filename in os.listdir(dc_dir):
+        if filename.endswith('.txt'):
+            filepath = os.path.join(dc_dir, filename)
+            with open(filepath, 'r') as dc_f:
+                load_failed(dc_f, data)
+    with open(out_file, 'w') as out_f:
+        json.dump(data, out_f, indent=2)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='DataChecks to JSON parser')
+    parser.add_argument('dc_dir', type=str,
+                        help='Path DataCheck files directory. All .txt files will be loaded.')
+    parser.add_argument('-o', '--output-file', type=str,
+                        help='Path to output JSON file. (Defaults to <dc_dir>/failed_dcs.json)')
+    args = parser.parse_args()
+
+    if args.output_file:
+        out_file = args.output_file
+    else:
+        out_file = os.path.join(args.dc_dir, 'failed_dcs.json')
+
+    parse_dc(args.dc_dir, out_file)
+
+
+if __name__ == '__main__':
+    main()
+

--- a/scripts/py/dcstat.py
+++ b/scripts/py/dcstat.py
@@ -1,5 +1,18 @@
 #!/usr/bin/env python
 
+# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+# Copyright [2016-2020] EMBL-European Bioinformatics Institute
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 # Requirements:
 #   Python 3.7+
 # Usage example:
@@ -10,9 +23,16 @@
 
 import argparse
 from functools import partial
+import logging
 import json
 import re
 from typing import NamedTuple, List, Pattern, Callable
+
+
+logging.basicConfig(format='%(levelname)s: %(message)s')
+
+
+logger = logging.getLogger(__name__)
 
 
 class FailedTests(NamedTuple):
@@ -41,7 +61,13 @@ def collect_failures(dc_label: str, dc_data: dict, filter_species: set = None) -
                 continue
         failures = []
         for test_label, test_lines in dc_tests_elems['tests'].items():
-            if not valid_test_func(test_lines):  # type: ignore
+            try:
+                valid = valid_test_func(test_lines)  # type: ignore
+            except ValueError as e:
+                # print(f'Test: {test_label}\n{test_lines}')
+                logger.warning('Could not parse %s failures for "%s"', dc_label, test_label)
+                valid = False
+            if not valid:  # type: ignore
                 failures.append(FailedTests(test_label, test_lines))
         if failures:
             failures_list.append(Failure(db_params, failures))
@@ -70,7 +96,10 @@ def compare_xref(parsed_results: List[dict]) -> bool:
 
 def compare_two(regex: Pattern, compare_func: Callable, dc_result: List[str]) -> bool:
     error_log = ' '.join(dc_result)
-    first, second = regex.match(error_log).groups() # type: ignore
+    try:
+        first, second = regex.match(error_log).groups() # type: ignore
+    except AttributeError:
+        raise ValueError('Test lines do not match regex')
     return compare_func(first, second)
 
 
@@ -89,11 +118,22 @@ def compare_xref_exists(current: str, previous: str) -> bool:
 
 
 
-got_expected_re = re.compile(r"^.+?\s+got: \'(?P<got>\d+)\'\s+expected: \'(?P<expected>\d+)\'.+$")
+got_expected_re = re.compile(r"^.+?\s+got: \'(?P<got>\d+)\'\s+expected: \'(?P<expected>\d+)\'.*$")
 
-def compare_got_expected(got: str, expected: str) -> bool:
+got_expected_obj_re = re.compile(r"^.+?\s+\$got->.+? = (?P<got>.*?)\s+\$expected->.+? = (?P<expected>.*?).*$")
+
+
+def compare_got_expected_int(got: str, expected: str) -> bool:
     # Obviously we can do fancier things here
     return int(got) == int(expected)
+
+def compare_got_expected_str(got: str, expected: str) -> bool:
+    # Obviously we can do fancier things here
+    return got == expected
+
+
+got_expected_int = partial(compare_two, got_expected_re, compare_got_expected_int)
+got_expected_obj = partial(compare_two, got_expected_obj_re, compare_got_expected_str)
 
 
 # TODO: Specify more analysis here
@@ -102,14 +142,28 @@ ANALYSIS_MAP = {
     'CompareProjectedGOXrefs': valid_compare_xref,
     'CompareXref': valid_compare_xref,
     'CompareProjectedGeneNames': partial(compare_two, gene_names_re, compare_projected_gene_names),
-    'DuplicateTranscriptNames': partial(compare_two, got_expected_re, compare_got_expected),
-    'DuplicateXref': partial(compare_two, got_expected_re, compare_got_expected),
-    'HGNCMultipleGenes': partial(compare_two, got_expected_re, compare_got_expected),
-    'XrefTypes': partial(compare_two, got_expected_re, compare_got_expected),
-    'ForeignKeys': partial(compare_two, got_expected_re, compare_got_expected),
-    'StableIdDisplayXref': partial(compare_two, got_expected_re, compare_got_expected),
-    'XrefPrefixes': partial(compare_two, got_expected_re, compare_got_expected),
+    'DuplicateTranscriptNames': got_expected_int,
+    'DuplicateXref': got_expected_int,
+    'HGNCMultipleGenes': got_expected_int,
+    'XrefTypes': got_expected_int,
+    'ForeignKeys': got_expected_int,
+    'StableIdDisplayXref': got_expected_int,
+    'XrefPrefixes': got_expected_int,
     'DisplayXrefExists': partial(compare_two, xref_exists_re, compare_xref_exists),
+    'CanonicalTranscripts': got_expected_int,
+    'GeneBiotypes': got_expected_int,
+    'ProteinTranslation': got_expected_int,
+    'VersionedGenes': got_expected_int,
+    'FeatureBounds': got_expected_int,
+    'TranscriptBounds': got_expected_int,
+    'AnalysisFormat': got_expected_int,
+    'SeqRegionTopLevel': got_expected_int,
+    'ValidTranslations': got_expected_int,
+    'ControlledAnalysis': got_expected_obj,
+    'SchemaPatchesApplied': got_expected_obj,
+    'CompareMetaKeys': got_expected_obj,
+    'MetaKeyConditional': got_expected_obj,
+    'CompareSchema': got_expected_obj,
 }
 
 
@@ -136,7 +190,7 @@ def dc_failures(data: dict, dc_label: str, verbosity: int = 1, filter_species: s
                     lines.append(f'\t{failed_test.title}')
                     if verbosity >= 3:
                         for result in failed_test.content:
-                            lines.append(f'\t\t{result}')
+                            lines.append(f'\t\t{result}\n')
     else:
         lines.append('Unknown DC')
     return lines
@@ -152,17 +206,22 @@ def main():
             help='Verbosity level: 1) shows only DB names. 2) shows also failed tests names. 3) shows also errors log')
     parser.add_argument('-s', '--filter-species', type=str, nargs='+',
                         help='Filter results by species.')
+    parser.add_argument('-Q', '--quiet', action='store_true',
+                        help='Silence warnings and infos.')
     args = parser.parse_args()
 
     with open(args.dc_file, 'r') as f:
         dcs = json.load(f)
+
+    if args.quiet:
+        logger.setLevel(logging.ERROR)
 
     filter_species = None
     if args.filter_species:
         filter_species = set(args.filter_species)
 
     stats = dc_stats(dcs, filter_species)
-    print(f'{"DATACHECK":<30}{"REPORTED":<20}{"SUSPICIOUS":<10}')
+    print(f'\n{"DATACHECK":<30}{"REPORTED":<20}{"SUSPICIOUS":<10}')
 
     dc_filter_labels = None
     if args.dc:

--- a/scripts/py/dcstat.py
+++ b/scripts/py/dcstat.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python
+
+# Requirements:
+#   Python 3.7+
+# Usage example:
+#   python dcstat.py /path/to/failed_dcs.json -v 2 -d CompareXref CompareGOXref -s ovis_aries bos_taurus
+# Print help:
+#   python dcstat.py -h
+
+
+import argparse
+from functools import partial
+import json
+import re
+from typing import NamedTuple, List, Pattern, Callable
+
+
+class FailedTests(NamedTuple):
+    title: str
+    content: List[str]
+
+
+class DBParams(NamedTuple):
+    species: str
+    db_type: str
+    db_name: str
+
+
+class Failure(NamedTuple):
+    db_params: DBParams
+    tests: List[FailedTests]
+
+
+def collect_failures(dc_label: str, dc_data: dict) -> List[Failure]:
+    valid_test_func = ANALYSIS_MAP[dc_label]
+    failures_list: List[Failure] = []
+    for db_labels, dc_tests_elems in dc_data.items():
+        db_params = DBParams(*db_labels.split(', '))
+        failures = []
+        for test_label, test_lines in dc_tests_elems['tests'].items():
+            if not valid_test_func(test_lines):  # type: ignore
+                failures.append(FailedTests(test_label, test_lines))
+        if failures:
+            failures_list.append(Failure(db_params, failures))
+    return failures_list
+
+
+xref_re = re.compile(r'^(?P<current_count>\d+) \< (?P<previous_count>\d+) \* (?P<treshold>\d+)\%$')
+
+def valid_compare_xref(dc_result: List[str]) -> bool:
+    parsed_results = []
+    for line in dc_result:
+        match = xref_re.match(line)
+        if match:
+            parsed_results.append(match.groupdict())
+    return compare_xref(parsed_results)
+
+
+def compare_xref(parsed_results: List[dict]) -> bool:
+    # If at least one is 0 the DC is SUSPICIOUS!
+    # Obviously we can do fancier things here
+    for result in parsed_results:
+        if result['current_count'] == '0':
+            return False
+    return True
+
+
+def compare_two(regex: Pattern, compare_func: Callable, dc_result: List[str]) -> bool:
+    error_log = ' '.join(dc_result)
+    first, second = regex.match(error_log).groups() # type: ignore
+    return compare_func(first, second)
+
+
+gene_names_re = re.compile(r"^.+?\s+\'(?P<current>\d+\.\d)\'\s+<=\s+\'(?P<previous>\d+)\'.+$")
+
+def compare_projected_gene_names(current: str, previous: str) -> bool:
+    # Obviously we can do fancier things here
+    return float(current) <= float(previous)
+
+
+xref_exists_re = re.compile(r"^.+?\s+\'(?P<current>\d+)\'\s+>\s+\'(?P<previous>\d+)\'.+$")
+
+def compare_xref_exists(current: str, previous: str) -> bool:
+    # Obviously we can do fancier things here
+    return int(current) > int(previous)
+
+
+
+got_expected_re = re.compile(r"^.+?\s+got: \'(?P<got>\d+)\'\s+expected: \'(?P<expected>\d+)\'.+$")
+
+def compare_got_expected(got: str, expected: str) -> bool:
+    # Obviously we can do fancier things here
+    return int(got) == int(expected)
+
+
+# TODO: Specify more analysis here
+ANALYSIS_MAP = {
+    'CompareGOXref': valid_compare_xref,
+    'CompareProjectedGOXrefs': valid_compare_xref,
+    'CompareXref': valid_compare_xref,
+    'CompareProjectedGeneNames': partial(compare_two, gene_names_re, compare_projected_gene_names),
+    'DuplicateTranscriptNames': partial(compare_two, got_expected_re, compare_got_expected),
+    'DuplicateXref': partial(compare_two, got_expected_re, compare_got_expected),
+    'HGNCMultipleGenes': partial(compare_two, got_expected_re, compare_got_expected),
+    'XrefTypes': partial(compare_two, got_expected_re, compare_got_expected),
+    'ForeignKeys': partial(compare_two, got_expected_re, compare_got_expected),
+    'StableIdDisplayXref': partial(compare_two, got_expected_re, compare_got_expected),
+    'XrefPrefixes': partial(compare_two, got_expected_re, compare_got_expected),
+    'DisplayXrefExists': partial(compare_two, xref_exists_re, compare_xref_exists),
+}
+
+
+def dc_stats(data: dict) -> list:
+    lines = []
+    for dc_label, dc_data in data.items():
+        if dc_label in ANALYSIS_MAP:
+            collected_failures = collect_failures(dc_label, dc_data)
+            lines.append(f'{dc_label:<30}{len(dc_data):<20}\t{len(collected_failures):<10}')
+        else:
+            lines.append(f'{dc_label:<30}{len(dc_data):<20}{"DUNNO":<10}')
+    return lines
+
+
+def dc_failures(data: dict, dc_label: str, verbosity: int = 1, filter_species: set = None) -> list:
+    lines = []
+    if dc_label in ANALYSIS_MAP:
+        collected_failures = collect_failures(dc_label, data[dc_label])
+        for failure in collected_failures:
+            if filter_species:
+                if failure.db_params.species not in filter_species:
+                    continue
+            if verbosity >= 1:
+                lines.append(f'{failure.db_params.db_name:<50}')
+            if verbosity >= 2:
+                for failed_test in failure.tests:
+                    lines.append(f'\t{failed_test.title}')
+                    if verbosity >= 3:
+                        for result in failed_test.content:
+                            lines.append(f'\t\t{result}')
+    else:
+        lines.append('Unknown DC')
+    return lines
+
+
+def main():
+    parser = argparse.ArgumentParser(description='DataCheck Statistics & Report')
+    parser.add_argument('dc_file', type=str,
+                        help='Path to JSON DataCheck file to analize.')
+    parser.add_argument('-d', '--dc', type=str, nargs='+',
+                        help='List of DC names to show.')
+    parser.add_argument('-v', '--verbosity', type=int, default=1,
+            help='Verbosity level: 1) shows only DB names. 2) shows also failed tests names. 3) shows also errors log')
+    parser.add_argument('-s', '--filter-species', type=str, nargs='+',
+                        help='Filter results by species.')
+    args = parser.parse_args()
+
+    with open(args.dc_file, 'r') as f:
+        dcs = json.load(f)
+
+    stats = dc_stats(dcs)
+    print(f'{"DATACHECK":<30}{"REPORTED":<20}{"SUSPICIOUS":<10}')
+    for line in stats:
+        if args.dc:
+            dc_filter_labels = set(args.dc)
+            if not line.split()[0] in dc_filter_labels:
+                continue
+        print(line)
+
+    if args.dc:
+        for dc_label in args.dc:
+            filter_species = None
+            if args.filter_species:
+                filter_species = set(args.filter_species)
+            failures = dc_failures(dcs, dc_label, args.verbosity, filter_species)
+            print('\n\n')
+            print(f'{dc_label}:\n')
+            for line in failures:
+                print(line)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

Python 3.7+

## Description

Console Python script for parsing and reporting data from a Datacheck JSON report.

## Use case

In many cases DCs generate lots of failures, some of them might not be relevant. This scripts help filtering out the not relevant ones and potentially add more complex criteria.