### PR TITLE
Use datacheck groups relevant to the pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GPAD_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GPAD_conf.pm
@@ -272,7 +272,7 @@ sub pipeline_analyses {
       -analysis_capacity => 10,
       -batch_size        => 10,
       -parameters        => {
-                              datacheck_groups => ['xref'],
+                              datacheck_groups => ['xref_go_projection'],
                               datacheck_types  => ['advisory'],
                               registry_file    => $self->o('registry'),
                               config_file      => $self->o('config_file'),

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GeneNameDescProjection_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GeneNameDescProjection_conf.pm
@@ -352,7 +352,7 @@ sub pipeline_analyses {
       -batch_size        => 10,
       -analysis_capacity => 10,
       -parameters        => {
-                              datacheck_groups => ['xref'],
+                              datacheck_groups => ['xref_name_projection'],
                               datacheck_types  => ['advisory'],
                               registry_file    => $self->o('registry'),
                               config_file      => $self->o('config_file'),


### PR DESCRIPTION
## Description
Multiple xref-related pipelines were using the same 'xref' datacheck group - some of these are specific to the work of a particular pipeline, so running them in another pipeline is redundant and potentially confusing.

## Benefits
Pipelines only run relevant datachecks.

## Possible Drawbacks
None I can think of.

## Testing
None done, but this is a very simple update.