### PR TITLE
ENSCORESW-3263: run mapping sequentially for same species

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/Xref_update_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/Xref_update_conf.pm
@@ -146,7 +146,7 @@ sub pipeline_analyses {
                              xref_pass     => $self->o('xref_pass'),
                             },
              -flow_into  => { '2->A' => 'parse_source',
-                              'A->2' => 'schedule_tertiary_source',
+                              'A->1' => 'schedule_tertiary_source',
                              },
              -rc_name    => 'small',
             },
@@ -215,7 +215,7 @@ sub pipeline_analyses {
                              'release'     => $self->o('release'),
                              'source_url'  => $self->o('source_url')},
              -rc_name    => 'small',
-             -flow_into  => { '2->A' => ['direct_xrefs', 'process_alignment', 'rnacentral_mapping', 'uniparc_mapping', 'coordinate_mapping'],
+             -flow_into  => { '2->A' => ['direct_xrefs', 'rnacentral_mapping'],
                               'A->1' => 'mapping'
                             },
             },
@@ -224,6 +224,7 @@ sub pipeline_analyses {
              -rc_name    => 'normal',
              -parameters => {'base_path'   => $self->o('base_path'),
                              'release'     => $self->o('release')},
+             -flow_into  => { 1 => 'process_alignment' },
              -analysis_capacity => 30
             },
             {-logic_name => 'process_alignment',
@@ -239,6 +240,7 @@ sub pipeline_analyses {
              -parameters => {'base_path'   => $self->o('base_path'),
                              'release'     => $self->o('release')},
              -hive_capacity => 300,
+             -flow_into  => { 1 => 'uniparc_mapping' },
              -analysis_capacity => 30
             },
             {-logic_name => 'uniparc_mapping',
@@ -247,6 +249,7 @@ sub pipeline_analyses {
              -parameters => {'base_path'   => $self->o('base_path'),
                              'release'     => $self->o('release')},
              -hive_capacity => 300,
+             -flow_into  => { 1 => 'coordinate_mapping' },
              -analysis_capacity => 30
             },
             {-logic_name => 'coordinate_mapping',


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

_Using one or more sentences, describe in detail the proposed changes._
The xref pipeline runs multiple mapping stages in parallel for the same species
This can cause contention on the database to which these steps are writing on, both slowing down the process and potentially causing corruption to the data as it is partially written.
Running these steps sequentially reduces these risks, although running 300 species at the same time is still proving problematic

## Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._
The xref pipeline aims to update xrefs for multiple species at the same time, taking advantage of the same input files.
As the number of species run simultaneously increases, the number of failed jobs and partially stored data increases.
This change in dataflow aims to reduce that problem

## Benefits

_If applicable, describe the advantages the changes will have._
Smoother workflow, less job contention, less strain on the same xref database

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._
Not yet reliable for full scale vertebrate running, more optimisation is required

## Testing

- [ ] Have you added/modified unit tests to test the changes?
No test cases available, the whole xref pipeline has been run on various subsets of vertebrate species
- [ ] If so, do the tests pass?
The pipeline runs fine for dozens of species. When run on 292 vertebrate species, most results are fine but there are still issues with job contention
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
