### PR TITLE
When running the MySQL dumps for Rapid Release, we need a list of dat…

### DIFF
--- a/scripts/py/meta_hive_species.py
+++ b/scripts/py/meta_hive_species.py
@@ -101,9 +101,8 @@ if __name__ == '__main__':
         out_file_path = join(home_dir, args.output_file)
         with open(out_file_path, 'w') as f:
             for spec in species:
-                f.write('-species {} '.format(spec)) if args.output == 'species' else f.write('{},'.format(spec))
+                f.write('-species {} '.format(spec)) if args.output == 'species' else f.write('-database {} '.format(spec)) if args.output == 'dbname' else f.write('{},'.format(spec))
         logger.info("File generated in %s", out_file_path)
     else:
         for spec in species:
-            print('-species {} '.format(spec), end="", flush=True) if args.output == 'species' else print(
-                '{},'.format(spec), end="", flush=True)
+            print('-species {} '.format(spec), end='', flush=True) if args.output == 'species' else print('-database {} '.format(spec), end='', flush=True) if args.output == 'dbname' else print('{},'.format(spec), end='', flush=True)


### PR DESCRIPTION
…abases. Added option to print -database and updated the SOP

**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Updated the script to print -database when the -o is dbname. This is to allow us to run the MySQL dumps.
## Use case

For Rapid Release when we run the MySQL dumps

## Benefits

We can now easily run the MySQL dumps for RR

## Possible Drawbacks

None

## Testing

- [N ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
