### PR TITLE
Check if version of InterProScan service matches that of the command line program.

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProteinFeatures_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProteinFeatures_conf.pm
@@ -47,9 +47,10 @@ sub default_options {
     max_dirs_per_directory  => $self->o('max_files_per_directory'),
 
     # InterPro settings
-    interproscan_version => '5.45-80.0',
-    interproscan_exe     => 'interproscan.sh',
-   	run_interproscan     => 1,
+    interproscan_version    => '5.45-80.0',
+    interproscan_exe        => 'interproscan.sh',
+    ignore_service_mismatch => 0,
+   	run_interproscan        => 1,
 
     # A file with md5 sums of translations that are in the lookup service
     md5_checksum_file => '/nfs/nobackup/interpro/ensembl_precalc/precalc_md5s',
@@ -301,8 +302,9 @@ sub pipeline_analyses {
       -max_retry_count   => 0,
       -input_ids         => [ {} ],
       -parameters        => {
-                              interproscan_version => $self->o('interproscan_version'),
-                              interproscan_exe     => $self->o('interproscan_exe'),
+                              interproscan_version    => $self->o('interproscan_version'),
+                              interproscan_exe        => $self->o('interproscan_exe'),
+                              ignore_service_mismatch => $self->o('ignore_service_mismatch'),
                             },
       -rc_name           => 'normal',
       -flow_into         => ['LoadChecksums'],

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProteinFeatures_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProteinFeatures_conf.pm
@@ -49,7 +49,6 @@ sub default_options {
     # InterPro settings
     interproscan_version    => '5.45-80.0',
     interproscan_exe        => 'interproscan.sh',
-    ignore_service_mismatch => 0,
    	run_interproscan        => 1,
 
     # A file with md5 sums of translations that are in the lookup service
@@ -302,9 +301,9 @@ sub pipeline_analyses {
       -max_retry_count   => 0,
       -input_ids         => [ {} ],
       -parameters        => {
-                              interproscan_version    => $self->o('interproscan_version'),
-                              interproscan_exe        => $self->o('interproscan_exe'),
-                              ignore_service_mismatch => $self->o('ignore_service_mismatch'),
+                              interproscan_version  => $self->o('interproscan_version'),
+                              interproscan_exe      => $self->o('interproscan_exe'),
+                              skip_checksum_loading => $self->o('skip_checksum_loading'),
                             },
       -rc_name           => 'normal',
       -flow_into         => ['LoadChecksums'],

--- a/modules/Bio/EnsEMBL/Production/Pipeline/ProteinFeatures/InterProScanVersionCheck.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/ProteinFeatures/InterProScanVersionCheck.pm
@@ -23,17 +23,40 @@ use strict;
 use warnings;
 use base ('Bio::EnsEMBL::Production::Pipeline::Common::Base');
 
+use File::Fetch;
+use Path::Tiny;
+
 sub run {
   my ($self) = @_;
-  my $interproscan_version = $self->param_required('interproscan_version');
-  my $interproscan_exe     = $self->param_required('interproscan_exe');
-  
+  my $interproscan_version    = $self->param_required('interproscan_version');
+  my $interproscan_exe        = $self->param_required('interproscan_exe');
+  my $ignore_service_mismatch = $self->param_required('ignore_service_mismatch');
+  my $service_version_file    = 'http://www.ebi.ac.uk/interpro/match-lookup/version';
+
   my $interpro_cmd = "$interproscan_exe --version";
   my $version_info = `$interpro_cmd` or $self->throw("Failed to run ".$interpro_cmd);
-  
+
   if ($version_info =~ /InterProScan version (\S+)/) {
-    if ($1 ne $interproscan_version) {
-      $self->throw("InterProScan version mismatch\nConf file: $interproscan_version\n$interproscan_exe: $1");
+    my $cmd_version = $1;
+    if ($cmd_version ne $interproscan_version) {
+      $self->throw("InterProScan version mismatch\nConf file: $interproscan_version\n$interproscan_exe: $cmd_version");
+    } else {
+      my $temp_dir = Path::Tiny->tempdir();
+      my $ff = File::Fetch->new(uri => $service_version_file);
+      my $file = $ff->fetch(to => $temp_dir->stringify);
+      my $data = path($file)->slurp;
+      if ($data =~ /SERVER:(\S+)/) {
+        my $service_version = $1;
+        if ($service_version ne $cmd_version) {
+          if ($ignore_service_mismatch) {
+            $self->dataflow_output_id({'skip_checksum_loading' => 1}, 1);
+          } else {
+            $self->throw("InterProScan version mismatch\n$interproscan_exe: $cmd_version\n$service_version_file: $service_version");
+          }
+        }
+      } else {
+        $self->throw("Could not find version in service file:\n$service_version_file\n$data");
+      }
     }
   } else {
     $self->throw("Could not find version in output from $interpro_cmd:\n$version_info");


### PR DESCRIPTION
## Description
Check if version of InterProScan service matches that of the command line program.

## Use case
If the command line version is different to that of the lookup service, then the service cannot be used, and the program will do all computation locally. This is extremely time-consuming, so we generally don't want to do that - these changes make the pipeline fail if there is a mismatch, by default.

Occasionally, you may want to force the local computation to happen anyway, which can be done by setting `-skip_checksum_loading`. If that is true, then the service version check is not done.

## Benefits
Do not silently fall back to local computation, and then wonder why the lookups are taking so long.

## Possible Drawbacks
Not aware of any.

## Testing
Module tested in isolation; sample pipeline initialised and first job run. Works as expected.
