### PR TITLE
Add HH version of eg-publicsql to grant script

### DIFF
--- a/scripts/sync/publish_db.sh
+++ b/scripts/sync/publish_db.sh
@@ -23,6 +23,8 @@ sql='grant select, show view on `'$db'`.* to `anonymous`@`%`';
 echo "database: " $db
 echo "sql: " $sql
 admin-mysql-eg-publicsql -e "$sql"
+admin-mysql-eg-publicsql-hh -e "$sql"
 sql2='grant select, show view on `'$db'`.* to `ensro`@`%.ebi.ac.uk`';
 echo "sql: " $sql2
 admin-mysql-eg-publicsql -e "$sql2"
+admin-mysql-eg-publicsql-hh -e "$sql2"


### PR DESCRIPTION
## Description
Permission-granting script was not updating the new '-hh' server; added the appropriate shortcut, and updated the script to apply SQL there too.

## Testing
Script works as intended for release 101.