### PR TITLE
ENSCORESW-3534: enable disconnect_if_idle for alignment jobs

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/Alignment.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/Alignment.pm
@@ -65,9 +65,10 @@ sub run {
 
   $self->dbc()->disconnect_if_idle() if defined $self->dbc();
   my ($user, $pass, $host, $port, $dbname) = $self->parse_url($xref_url);
-  my $dbi = $self->get_dbi($host, $port, $user, $pass, $dbname);
-  my $job_sth = $dbi->prepare("insert into mapping_jobs (map_file, status, out_file, err_file, array_number, job_id) values (?,?,?,?,?,?)");
-  my $mapping_sth = $dbi->prepare("insert into mapping (job_id, method, percent_query_cutoff, percent_target_cutoff) values (?,?,?,?)");
+  my $dbc = $self->get_dbc($host, $port, $user, $pass, $dbname);
+  $dbc->disconnect_if_idle();
+  my $job_sth = $dbc->prepare("insert into mapping_jobs (map_file, status, out_file, err_file, array_number, job_id) values (?,?,?,?,?,?)");
+  my $mapping_sth = $dbc->prepare("insert into mapping (job_id, method, percent_query_cutoff, percent_target_cutoff) values (?,?,?,?)");
 
   my $out_file = "xref_".$seq_type.".".$max_chunks."-".$chunk.".out";
   my $job_id = $source_id . $job_index . $chunk;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/Base.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/Base.pm
@@ -33,6 +33,7 @@ use XrefParser::BaseParser;
 use IO::File;
 use JSON;
 use Bio::EnsEMBL::Hive::Utils::URL;
+use Bio::EnsEMBL::DBSQL::DBConnection;
 use Text::Glob qw( match_glob );
 use Bio::EnsEMBL::Utils::IO qw/slurp/;
 use Bio::EnsEMBL::Utils::URI qw(parse_uri);
@@ -202,6 +203,17 @@ sub get_dbi {
   }
   my $dbi = DBI->connect( $dbconn, $user, $pass, { 'RaiseError' => 1 } ) or croak( "Can't connect to database: " . $DBI::errstr );
   return $dbi;
+}
+
+sub get_dbc {
+  my ($self, $host, $port, $user, $pass, $dbname) = @_;
+  my $dbconn = Bio::EnsEMBL::DBSQL::DBConnection->new(
+        -HOST   => $host,
+        -DBNAME => $dbname,
+        -USER   => $user,
+        -PASS   => $pass,
+        -PORT   => $port);
+  return $dbconn;
 }
 
 sub get_path {


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

disconnect_if_idle is implemented on the xref database during the alignment stage

## Use case

The align jobs are mostly IO and memory bound, as the command line is run on the farm and the result stored on file
The xref database is used at the start of the job to get the parameters of the exonerate command and alignments can take several minutes to run, during which the connection remains open although idle.
There are several thousand alignment jobs being run for every species, leading to potentially hundreds of idle connections.
Enabling disconnect_if_idle will mean those connections are not maintained, reducing the load on the server

## Benefits

Less connections are maintained during the alignment stage, meaning there is less contention on the server and more jobs can run in parallel without impacting on each other

## Possible Drawbacks

If the alignment job is quick, the connection needs to be re-establish frequently

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch
There are no unit tests for the Xref code.
The pipeline has been run with 20 species in parallel, before and after the proposed code changes.
After the proposed changes, I noticed less idle connections on the server at the alignment stage

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
