### PR TITLE
Compara families pipeline wasn't populating some fields in the compara db

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/LoadFamily/AddFamilyMembers.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/LoadFamily/AddFamilyMembers.pm
@@ -107,8 +107,9 @@ sub run {
     # create and store gene member
     my $gene_member =
       Bio::EnsEMBL::Compara::GeneMember->new_from_Gene(
-        -GENE      => $gene,
-        -GENOME_DB => $genome_db
+        -GENE          => $gene,
+        -GENOME_DB     => $genome_db,
+        -BIOTYPE_GROUP => $gene->get_Biotype->biotype_group();
       );
     # If there are duplicate stable IDs, trap fatal error from compara
     # method, so we can skip it and carry on with others.


### PR DESCRIPTION
## Description
The compara families pipeline wasn't populating some fields in the compara db - I don't think this causes anything to break, at the minute, but there might be future problems, because expected data is missing. And the datachecks fail, creating unnecessary noise.

## Benefits
Compara data is more complete, datachecks pass.

## Possible Drawbacks
None.
