### PR TITLE
Non-core synchronisation datacheck pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Common/DbFactory.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Common/DbFactory.pm
@@ -164,7 +164,9 @@ sub run {
     }
     elsif ( scalar(@division) ) {
       foreach my $division (@division) {
-        $self->process_division( $all_dbas, $division, \%dbs );
+        if ($group ne 'compara') {
+          $self->process_division( $all_dbas, $division, \%dbs );
+        }
         $self->process_division_compara( $all_compara_dbas, $division, \%compara_dbs );
       }
     }
@@ -225,10 +227,13 @@ sub write_output {
     $self->dataflow_output_id( $dataflow_params, $db_flow );
   }
 
-  if ($group eq 'core') {
+  if ($group eq 'core' || $group eq 'compara') {
     foreach my $division ( keys %$compara_dbs ) {
+      my $dbname = $$compara_dbs{$division}->dbc->dbname;
+      push @dbnames, $dbname;
+
       my $dataflow_params = {
-        dbname  => $$compara_dbs{$division}->dbc->dbname,
+        dbname  => $dbname,
         species => $division,
       };
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DataChecksNonCore_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DataChecksNonCore_conf.pm
@@ -1,0 +1,91 @@
+=head1 LICENSE
+Copyright [2018-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+Bio::EnsEMBL::Production::Pipeline::PipeConfig::DataChecksNonCore_conf
+
+=head1 DESCRIPTION
+A pipeline for executing datachecks across non-core databases,
+to test whether they are synchronised with associated core databases.
+
+=cut
+
+package Bio::EnsEMBL::Production::Pipeline::PipeConfig::DataChecksNonCore_conf;
+
+use strict;
+use warnings;
+
+use base ('Bio::EnsEMBL::DataCheck::Pipeline::DbDataChecks_conf');
+
+use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
+use Bio::EnsEMBL::Hive::Version 2.5;
+
+sub default_options {
+  my ($self) = @_;
+  return {
+    %{$self->SUPER::default_options},
+
+    pipeline_name => 'noncore_datachecks',
+
+    db_types => ['cdna', 'otherfeatures', 'rnaseq', 'compara', 'funcgen', 'variation'],
+
+    datacheck_groups => ['core_sync'],
+    datacheck_types  => ['critical'],
+
+    registry_file => $self->o('registry'),
+
+    email => $ENV{'USER'}.'@ebi.ac.uk',
+  };
+}
+
+sub pipeline_analyses {
+  my $self = shift @_;
+
+  my @analyses = @{$self->SUPER::pipeline_analyses};
+
+  foreach my $analysis (@analyses) {
+    if ($$analysis{'-logic_name'} eq 'DataCheckSubmission') {
+      $$analysis{'-parameters'}{'tag'} = 'Core synchronisation for #expr(join(", ", @{#division#}))expr# #db_type# dbs';
+    }
+    if ($$analysis{'-logic_name'} eq 'DbFactory') {
+      if ($self->o('parallelize_datachecks')) {
+        $$analysis{'-flow_into'}{'5->A'} = ['DataCheckFactory'];
+      } else {
+        $$analysis{'-flow_into'}{'5->A'} = ['RunDataChecks'];
+      }
+    }
+  }
+
+  unshift @analyses,
+    {
+      -logic_name        => 'NonCoreDbTypeFactory',
+      -module            => 'Bio::EnsEMBL::Hive::RunnableDB::JobFactory',
+      -max_retry_count   => 1,
+      -analysis_capacity => 1,
+      -input_ids         => [ {} ],
+      -parameters        => {
+                              inputlist    => $self->o('db_types'),
+                              column_names => ['db_type']
+                            },
+      -flow_into         => {
+                              '2' => ['DataCheckSubmission'],
+                            }
+    }
+  ;
+
+  return \@analyses;
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DataChecksNonCore_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DataChecksNonCore_conf.pm
@@ -1,4 +1,5 @@
 =head1 LICENSE
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
 Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DataChecksNonCore_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DataChecksNonCore_conf.pm
@@ -1,5 +1,5 @@
 =head1 LICENSE
-Copyright [2018-2020] EMBL-European Bioinformatics Institute
+Copyright [2016-2020] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description
When a non-core database (core-like, compara, funcgen, variation) is handed over, we run datachecks to check if it is correctly in-sync with the associated core database. If a new core database is handed over, the non-core databases will often need to be updated - but we only run the non-core datachecks when a new non-core database is handed over. If nothing is handed over, we have no mechanism to warn us of inconsistencies. So we need something that triggers those datachecks.

## Use case
This PR introduces a new pipeline that runs the subset of non-core datachecks that relate to synchronisation with the core db. It is intended to be run by Production when the core handover is complete. The ensuing datacheck reports will undoubtedly have failures, because new core databases will have introduced inconsistencies - the point is that Production can communicate to the non-core teams the set of databases that are expected to be handed over, in order for things to get back in sync. The datacheck reports can provide information to data teams about exactly what changes will be needed. Hopefully this will not be news to the non-core teams, if the intentions are complete and have been understood  by all parties. But it's nice to have a safety net...

The pipeline should be run by Production a second time, following completion of the non-core handover. This time, no failures are expected - if they occur, this will be communicated to the relevant teams, and the severity can be assessed to decide if a known bug is warranted.

In this process, the Production team are receiving the results of the pipeline, and reacting accordingly - in time, it would make sense to get the pipeline to email the teams directly. But in the first instance I think it's useful for Production to act as intermediaries in order to explain the reports and the expected actions.

## Benefits
Data is synchronised across different types of database, in order for the API and website to provide expected behaviour. Inconsistencies can produce hidden bugs, where data is not displayed when it should be, for example, rather than generating any error messages - so this pipeline uncovers problems which may otherwise be hard to spot.

## Possible Drawbacks
One more pipeline to run/maintain, but I think it's usefulness is sufficient compensation.

## Testing
Pipelines initialised and run to successful completion for release 102 dbs.
