### PR TITLE
Add duplicate report to Stable ID pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/StableIDs_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/StableIDs_conf.pm
@@ -68,6 +68,7 @@ sub resource_classes {
 
   return {
     %{$self->SUPER::resource_classes},
+    '8GB'  => {'LSF' => '-q production-rh74 -M 8000 -R "rusage[mem=8000,scratch=1000]"'},
     '32GB' => {'LSF' => '-q production-rh74 -M 32000 -R "rusage[mem=32000,scratch=1000]"'},
   }
 }
@@ -157,7 +158,7 @@ sub pipeline_analyses {
         pipeline_name => $self->o('pipeline_name'),
         output_dir    => $self->o('output_dir'),
       },
-      -rc_name    => '32GB',
+      -rc_name    => '8GB',
     }
   ];
 }

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/StableIDs_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/StableIDs_conf.pm
@@ -36,7 +36,7 @@ package Bio::EnsEMBL::Production::Pipeline::PipeConfig::StableIDs_conf;
 
 use strict;
 use warnings;
-use base ('Bio::EnsEMBL::Production::Pipeline::PipeConfig::Base_conf');
+use base ('Bio::EnsEMBL::Hive::PipeConfig::EnsemblGeneric_conf');
 
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
 use Bio::EnsEMBL::Hive::Version 2.5;
@@ -50,6 +50,7 @@ sub default_options {
     db_name  => 'ensembl_stable_ids',
     db_url   => $self->o('srv_url') . $self->o('db_name'),
     release  => $self->o('ensembl_release'),
+    email    => $ENV{'USER'}.'@ebi.ac.uk'
   }
 }
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/StableIDs_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/StableIDs_conf.pm
@@ -21,137 +21,123 @@ limitations under the License.
 
 =head1 DESCRIPTION
 
-Pipeline to generate ensembl_stable_ids database for both vertebrates and non-vertebrates.
-This is mainly used for the REST server but can also be used in the main API call, to figure out what database to refer to when fetching a stable ID. It is useful for web for non-species specific pages, like www.ensembl.org/id/ENSG00000139618 
-The pipeline run the following script. ensembl/misc-scripts/stable_id_lookup/populate_stable_id_lookup.pl 
-The hive pipeline is doing what used to be done in the script with the "create" and "create_index" subroutines
-
-=head1 AUTHOR
-
- maurel@ebi.ac.uk
+Pipeline to generate ensembl_stable_ids database for both vertebrates
+and non-vertebrates.
+This is mainly used for the REST server but can also be used in API
+calls, to figure out what database to use when fetching a stable ID.
+It is useful for web for non-species specific pages, like
+www.ensembl.org/id/ENSG00000139618
+The pipeline runs a script:
+  ensembl/misc-scripts/stable_id_lookup/populate_stable_id_lookup.pl
 
 =cut
+
 package Bio::EnsEMBL::Production::Pipeline::PipeConfig::StableIDs_conf;
 
 use strict;
 use warnings;
+use base ('Bio::EnsEMBL::Production::Pipeline::PipeConfig::Base_conf');
 
-#use base ('Bio::EnsEMBL::Production::Pipeline::PipeConfig::Base_conf');
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
-# All Hive databases configuration files should inherit from HiveGeneric, directly or indirectly
-use base ('Bio::EnsEMBL::Hive::PipeConfig::EnsemblGeneric_conf');
-
 use Bio::EnsEMBL::Hive::Version 2.5;
 
 sub default_options {
-    my ($self) = @_;
+  my ($self) = @_;
 
-    return {
-        %{$self->SUPER::default_options},
-        run_from => [], # 'st1', 'st2', 'st4'
-        db_name  => 'ensembl_stable_ids',
-        db_url   => $self->o('srv_url') . $self->o('db_name')
-    }
+  return {
+    %{$self->SUPER::default_options},
+    run_from => [], # 'st1', 'st3', 'st4'
+    db_name  => 'ensembl_stable_ids',
+    db_url   => $self->o('srv_url') . $self->o('db_name'),
+    release  => $self->o('ensembl_release'),
+  }
 }
 
 sub resource_classes {
-    my $self = shift;
-    return {
-        'default' => { 'LSF' => '-q production-rh74 -n 4 -M 4000   -R "rusage[mem=4000]"' },
-        '32GB'    => { 'LSF' => '-q production-rh74 -n 4 -M 32000  -R "rusage[mem=32000]"' },
-        '16GB'    => { 'LSF' => '-q production-rh74 -n 4 -M 16000  -R "rusage[mem=16000]"' },
-        '64GB'    => { 'LSF' => '-q production-rh74 -n 4 -M 64000  -R "rusage[mem=64000]"' },
-    }
-}
+  my ($self) = @_;
 
+  return {
+    %{$self->SUPER::resource_classes},
+    '32GB' => {'LSF' => '-q production-rh74 -M 32000 -R "rusage[mem=32000,scratch=1000]"'},
+  }
+}
 
 sub pipeline_analyses {
-    my ($self) = @_;
+  my ($self) = @_;
 
-    return [
-        {
-            -logic_name => 'cleanup_db',
-            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SqlCmd',
-            -input_ids  => [ {} ],
-            -parameters => {
-                db_conn => $self->o('srv_url'),
-                sql     => [ 'DROP DATABASE IF EXISTS ' . $self->o('db_name') . ';' ],
-            },
-            -rc_name    => 'default',
-            -flow_into  => [ 'create_db' ]
-        },
-        {
-            -logic_name => 'create_db',
-            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SqlCmd',
-            -parameters => {
-                db_conn => $self->o('srv_url'),
-                sql     => [
-                    'CREATE DATABASE ' . $self->o('db_name') . ';' ],
-            },
-            -rc_name    => 'default',
-            -flow_into  => [ 'setup_db' ]
-        },
-        {
-            -logic_name => 'setup_db',
-            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::DbCmd',
-            -parameters => {
-                db_conn    => $self->o('db_url'),
-                input_file => $self->o('base_dir') . '/ensembl/misc-scripts/stable_id_lookup/sql/tables.sql',
-            },
-            -rc_name    => 'default',
-            -flow_into  => [ 'populate_meta' ]
-        },
-        {
-            -logic_name => 'populate_meta',
-            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SqlCmd',
-            -parameters => {
-                db_conn => $self->o('db_url'),
-                sql     => [
-                    "INSERT INTO meta(species_id,meta_key,meta_value) VALUES (NULL,'schema_version','" . $self->o('release') . "')" ],
-            },
-            -rc_name    => 'default',
-            -flow_into  => [ 'stable_id_script_factory' ],
-
-        },
-        {
-            -logic_name  => "stable_id_script_factory",
-            -module      => 'Bio::EnsEMBL::Hive::RunnableDB::JobFactory',
-            -meadow_type => 'LSF',
-            -parameters  => {
-                inputlist    => $self->o('run_from'),
-                column_names => [ 'species_server' ]
-            },
-            -flow_into   => {
-                '2->A' => [ 'stable_id_script' ],
-                'A->1' => [ 'index' ],
-            },
-        },
-        {
-            -logic_name  => "stable_id_script",
-            -module      => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
-            -meadow_type => 'LSF',
-            -parameters  => {
-                'cmd'      =>
-                    'perl #base_dir#/ensembl/misc-scripts/stable_id_lookup/populate_stable_id_lookup.pl $(#db_srv# details script_l) $(#species_server# details script) -dbname #dbname# -version #release#',
-                'db_srv'   => $self->o('db_srv'),
-                'dbname'   => $self->o('db_name'),
-                'release'  => $self->o('release'),
-                'base_dir' => $self->o('base_dir')
-            },
-            -rc_name     => '32GB',
-        },
-        {
-            -logic_name => 'index',
-            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::DbCmd',
-            -parameters => {
-                db_conn    => $self->o('db_url'),
-                input_file => $self->o('base_dir') . '/ensembl/misc-scripts/stable_id_lookup/sql/indices.sql',
-            },
-            -rc_name    => 'default',
-        }
-    ];
+  return [
+    {
+      -logic_name => 'cleanup_db',
+      -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SqlCmd',
+      -input_ids  => [ {} ],
+      -parameters => {
+        db_conn => $self->o('srv_url'),
+        sql     => [ 'DROP DATABASE IF EXISTS ' . $self->o('db_name') . ';' ],
+      },
+      -flow_into  => [ 'create_db' ]
+    },
+    {
+      -logic_name => 'create_db',
+      -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SqlCmd',
+      -parameters => {
+        db_conn => $self->o('srv_url'),
+        sql     => [ 'CREATE DATABASE ' . $self->o('db_name') . ';' ],
+      },
+      -flow_into  => [ 'setup_db' ]
+    },
+    {
+      -logic_name => 'setup_db',
+      -module     => 'Bio::EnsEMBL::Hive::RunnableDB::DbCmd',
+      -parameters => {
+        db_conn    => $self->o('db_url'),
+        input_file => $self->o('base_dir') . '/ensembl/misc-scripts/stable_id_lookup/sql/tables.sql',
+      },
+      -flow_into  => [ 'populate_meta' ]
+    },
+    {
+      -logic_name => 'populate_meta',
+      -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SqlCmd',
+      -parameters => {
+        db_conn => $self->o('db_url'),
+        sql     => [ "INSERT INTO meta(species_id,meta_key,meta_value) VALUES (NULL,'schema_version','" . $self->o('release') . "')" ],
+      },
+      -flow_into  => [ 'stable_id_script_factory' ],
+    },
+    {
+      -logic_name  => "stable_id_script_factory",
+      -module      => 'Bio::EnsEMBL::Hive::RunnableDB::JobFactory',
+      -meadow_type => 'LSF',
+      -parameters  => {
+        inputlist    => $self->o('run_from'),
+        column_names => [ 'species_server' ]
+      },
+      -flow_into   => {
+        '2->A' => [ 'stable_id_script' ],
+        'A->1' => [ 'index' ],
+      },
+    },
+    {
+      -logic_name  => "stable_id_script",
+      -module      => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+      -meadow_type => 'LSF',
+      -parameters  => {
+        'cmd'      => 'perl #base_dir#/ensembl/misc-scripts/stable_id_lookup/populate_stable_id_lookup.pl $(#db_srv# details script_l) $(#species_server# details script) -dbname #dbname# -version #release#',
+        'db_srv'   => $self->o('db_srv'),
+        'dbname'   => $self->o('db_name'),
+        'release'  => $self->o('release'),
+        'base_dir' => $self->o('base_dir')
+      },
+      -rc_name     => '32GB',
+    },
+    {
+      -logic_name => 'index',
+      -module     => 'Bio::EnsEMBL::Hive::RunnableDB::DbCmd',
+      -parameters => {
+        db_conn    => $self->o('db_url'),
+        input_file => $self->o('base_dir') . '/ensembl/misc-scripts/stable_id_lookup/sql/indices.sql',
+      },
+    }
+  ];
 }
-
-
 
 1;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/StableID/EmailReport.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/StableID/EmailReport.pm
@@ -1,0 +1,86 @@
+=head1 LICENSE
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2020] EMBL-European Bioinformatics Institute
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+Bio::EnsEMBL::Production::Pipeline::StableID::EmailReport
+
+=head1 DESCRIPTION
+Send an email with details of any non-unique stable IDs.
+
+=cut
+
+package Bio::EnsEMBL::Production::Pipeline::StableID::EmailReport;
+
+use strict;
+use warnings;
+use feature 'say';
+
+use base ('Bio::EnsEMBL::Hive::RunnableDB::NotifyByEmail');
+
+use File::Spec::Functions qw(catdir);
+use Path::Tiny;
+
+sub fetch_input {
+  my ($self) = @_;
+
+  my $pipeline_name = $self->param('pipeline_name');
+  my $output_dir    = $self->param('output_dir');
+  my $output_file   = catdir($output_dir, "$pipeline_name.txt");
+
+  my $duplicates = $self->find_duplicates($output_file);
+
+  my $subject = "Stable ID pipeline completed ($pipeline_name)";
+  $self->param('subject', $subject);
+
+  my $text =
+    "The $pipeline_name pipeline has completed successfully.\n\n".
+    "There are $duplicates duplicated stable IDs. ".
+    "Details: $output_file";
+
+  $self->param('text', $text);
+}
+
+sub find_duplicates {
+  my ($self, $output_file) = @_;
+
+  my $duplicates = 0;
+
+  my $dbh = $self->data_dbc->db_handle;
+  my $sql = qq/
+    SELECT
+      stable_id, db_type, object_type,
+      COUNT(species_id) AS species_count,
+      GROUP_CONCAT(name) AS species_name_list
+    FROM
+      stable_id_lookup INNER JOIN
+      species USING (species_id)
+    GROUP BY
+      stable_id, db_type, object_type
+    HAVING
+      species_count > 1
+  /;
+  my $sth = $dbh->prepare($sql) or die $dbh->errstr();
+  $sth->execute();
+
+  my $out = path($output_file);
+  $out->remove if -e $output_file;
+
+  while (my @row = $sth->fetchrow_array) {
+    $out->append_raw(join("\t",@row)."\n");
+    $duplicates++;
+  }
+
+  return $duplicates;
+}
+
+1;


### PR DESCRIPTION
## Description
We are not supposed to have duplicate stable IDs either within or across species. We can make sure of the former with the GeneStableID datacheck, but the latter is not enforcable, because we are not in control of the stable IDs that are used in the gene sets that we import, rather than annotate in-house.

## Use case
We want to have a report of duplicate stable IDs, so that we can a) check for egregious errors, and b) understand the scale and nature of duplication, and even if it can't easily be tackled we can provide this information to those using the Ensembl data, so that they can account for it if necessary.

There was a nascent datacheck for this, but it was only comprehensive if you provided the right parameters; it was easy to get a passing result by accidentally omitting a database server. It also used colossal amounts of memory, and it didn't really fit into the processes we have for running datachecks.

Since we create, every release, a database with all stable IDs in an indexed table, it makes sense to use that to get a comprehensive report on the duplicates. This PR adds such a step to the stable ID pipeline (as well as doing a bit of tidying/housekeeping of the pipeline structure).

## Benefits
We will know which stable IDs are duplicated in which species.

## Possible Drawbacks
Pipeline will take longer to run, because the table which we are querying has 800 million rows.

## Testing
Pipeline run successfully with small dataset. Results pending for complete table.