### PR TITLE
ENSCORESW-3554: run RefSeq dependent ZFIN parsing last

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_sources.json
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_sources.json
@@ -199,7 +199,7 @@
       "name" : "ZFIN_ID",
       "parser" : "ZFINParser",
       "file" : "http://zfin.org/data_transfer/Downloads/refseq.txt",
-      "priority" : 2
+      "priority" : 3
     },
     {
       "name" : "ZFIN_ID",


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Run RefSeq dependent ZFIN parsing last to avoid any race conditions.

## Use case

We have several ZFIN related files to parse. Some of these required other sources (RefSeq, UniProt) to already be in the database to find related links.
Running this source as a priority 3 source means all necessary data has already been processed

## Benefits

No race conditions between ZFIN sources and all the required RefSeq data has already been processed.
This results in more links and more reproducible results.

## Possible Drawbacks

NA

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch
There are no test cases for the xref pipeline.
Running the xref pipeline without the change results in DataCheck failures and varying gene symbol assignment.
Running the xref pipeline with the proposed change finishes successfully.
Multiple runs produce the same gene symbol assignment.

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
