### PR TITLE
ENSCORESW-3534: disconnect from database while parsing big files

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/ParseSource.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/ParseSource.pm
@@ -47,6 +47,7 @@ sub run {
             port    => $port,
             user    => $user,
             pass    => $pass });
+  $xref_dbc->disconnect_when_inactive(1);
 
   my $dbi = $self->get_dbi($host, $port, $user, $pass, $dbname);
 


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

_Using one or more sentences, describe in detail the proposed changes._
Implement disconnect_if_idle on ParseSource jobs

## Use case

During the ParseSource analysis, jobs connect to the database at the start of the job then typically process a large file, which can take several minutes. The job is IO bound and does not require the connection to the database any more.
As there can be several thousand parsing jobs when running the pipeline for multiple species, this can create a large number of unused connection to the database, slowing the pipeline down unnecessarily.

## Benefits

Disconnecting from the xref database during the job will reduce contention on the server

## Possible Drawbacks

For short jobs, the disconnection can be more costly.

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch
The xref pipeline has been run successfully on multiple species with the implemented change. A decrease in concurrent database connections has been observed.

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
