### PR TITLE
Fix copy script to produce non-truncated GVF and VCF files

### DIFF
--- a/scripts/copy_ftp_release.pl
+++ b/scripts/copy_ftp_release.pl
@@ -24,7 +24,6 @@ use Getopt::Long;
 use Pod::Usage;
 use Log::Log4perl qw/:easy/;
 
-
 my $opts = {};
 my @flags = qw(
     src_dir=s tgt_dir=s old_rel=s new_rel=s old_ens=s new_ens=s verbose
@@ -77,19 +76,12 @@ sub process_file {
     return if -d $file || -l $file;
     return if $file =~ m/mysql/ || $file =~ /CHECKSUMS/;
     $log->info("Processing $file");
-    if($file=~m/\.vcf\.gz/ || $file =~ m/\.gvf\.gz/) {	
-	my $newfile = rename_file($file);
-	$log->debug("VCF: $file -> $newfile");
-	# read and replace header
-	open my $in, "<:gzip", $file or die $!;
-	open my $out, ">:gzip", $newfile or die $!;
-	while(<$in>) {
-	    s/version=${old_ens_rel}/version=${new_ens_rel}/;
-	    s/e${old_ens_rel}/e${new_ens_rel}/;
-	    print $out $_;
-	}
-	close $in;
-	close $out;
+    if($file=~m/\.vcf\.gz$/ || $file =~ m/\.gvf\.gz$/) {
+      my $newfile = rename_file($file);
+
+      $log->debug("Doing: gunzip < $file | sed -e 's/version=${old_ens_rel}/version=${new_ens_rel}/g' | gzip -c > $newfile");
+      `gunzip < $file | sed -e 's/version=${old_ens_rel}/version=${new_ens_rel}/g' | gzip -c > $newfile`;
+
     } elsif($file=~m/Compara\..*_trees\.([0-9]+)\.tar\.gz/) {
 	my $newfile = rename_file(substr($file,0,$-[1]).$new_rel.substr($file,$+[1]));	
 	my $newtar = basename($newfile);


### PR DESCRIPTION
## Description
A user reported that a protist VCF file was truncated. On further inspection, all GVF and VCF files for fungi, metazoa and protist species had the same problem. The cause was a bug in the file we use to copy files, when there have been no new/updated variation databases in a release.

The code tried to update a release version directly in the compressed file, and that bit works, but I think the implementation of this functionality in Perl is a bit flaky. At some point during processing the file handling fails without raising an error, so you have a partial file and no indication that anything has gone wrong.

To resolve this, I removed the bit of code which was parsing the gzip file line by line in Perl, and did a gunzip-sed-gzip command instead. Both take about the same amount of time, but the latter has the distinction of working...

## Benefits
Valid files on the ftp site.

## Possible Drawbacks
None.

## Testing
Updated script was successfully used to correct all the affected GVF/VCF files for releases 47 and 48.
