### PR TITLE
Removed `/nfs/nobackup/` usage

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DBCopyPatch_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DBCopyPatch_conf.pm
@@ -37,7 +37,7 @@ sub default_options {
     'registry'      => '',
     'pipeline_name' => $self->o( 'ENV', 'USER' ) . '_DBCopyPatch_' .
       $self->o('ensembl_release'),
-    'output_dir' => '/nfs/nobackup/ensemblgenomes/' .
+    'output_dir' => '/nfs/production/ensembl/production/' .
       $self->o( 'ENV', 'USER' ) . '/workspace/' .
       $self->o('pipeline_name'),
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DBCopyPatch_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DBCopyPatch_conf.pm
@@ -37,7 +37,7 @@ sub default_options {
     'registry'      => '',
     'pipeline_name' => $self->o( 'ENV', 'USER' ) . '_DBCopyPatch_' .
       $self->o('ensembl_release'),
-    'output_dir' => '/nfs/nobackup/ensemblgenomes/' .
+    'output_dir' => '/hps/nobackup2/production/ensembl/' .
       $self->o( 'ENV', 'USER' ) . '/workspace/' .
       $self->o('pipeline_name'),
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DBCopyPatch_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DBCopyPatch_conf.pm
@@ -37,7 +37,7 @@ sub default_options {
     'registry'      => '',
     'pipeline_name' => $self->o( 'ENV', 'USER' ) . '_DBCopyPatch_' .
       $self->o('ensembl_release'),
-    'output_dir' => '/hps/nobackup2/production/ensembl/' .
+    'output_dir' => '/nfs/nobackup/ensemblgenomes/' .
       $self->o( 'ENV', 'USER' ) . '/workspace/' .
       $self->o('pipeline_name'),
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_conf.pm
@@ -48,7 +48,7 @@ sub default_options {
        'release'       => $self->o('release'),
        'pipeline_name' => "ftp_pipeline",
 	     'email'         => $self->o('ENV', 'USER').'@ebi.ac.uk',
-       'ftp_dir'       => '/nfs/nobackup/ensemblgenomes/'.$self->o('ENV', 'USER').'/workspace/'.$self->o('pipeline_name').'/ftp_site/release-'.$self->o('release'),
+       'ftp_dir'       => '/nfs/production/ensembl/production/'.$self->o('ENV', 'USER').'/workspace/'.$self->o('pipeline_name').'/ftp_site/release-'.$self->o('release'),
        'dumps'     	   => [],
 
 	   ## 'job_factory' parameters

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_conf.pm
@@ -48,7 +48,7 @@ sub default_options {
        'release'       => $self->o('release'),
        'pipeline_name' => "ftp_pipeline",
 	     'email'         => $self->o('ENV', 'USER').'@ebi.ac.uk',
-       'ftp_dir'       => '/hps/nobackup2/production/ensembl/'.$self->o('ENV', 'USER').'/workspace/'.$self->o('pipeline_name').'/ftp_site/release-'.$self->o('release'),
+       'ftp_dir'       => '/nfs/nobackup/ensemblgenomes/'.$self->o('ENV', 'USER').'/workspace/'.$self->o('pipeline_name').'/ftp_site/release-'.$self->o('release'),
        'dumps'     	   => [],
 
 	   ## 'job_factory' parameters

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_conf.pm
@@ -48,7 +48,7 @@ sub default_options {
        'release'       => $self->o('release'),
        'pipeline_name' => "ftp_pipeline",
 	     'email'         => $self->o('ENV', 'USER').'@ebi.ac.uk',
-       'ftp_dir'       => '/nfs/nobackup/ensemblgenomes/'.$self->o('ENV', 'USER').'/workspace/'.$self->o('pipeline_name').'/ftp_site/release-'.$self->o('release'),
+       'ftp_dir'       => '/hps/nobackup2/production/ensembl/'.$self->o('ENV', 'USER').'/workspace/'.$self->o('pipeline_name').'/ftp_site/release-'.$self->o('release'),
        'dumps'     	   => [],
 
 	   ## 'job_factory' parameters

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpVariation_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpVariation_conf.pm
@@ -51,8 +51,8 @@ sub default_options {
        'eg_version'    => $self->o('release'),
        'pipeline_name' => $self->o('hive_dbname'),       
 	   'email'         => $self->o('ENV', 'USER').'@ebi.ac.uk',
-       'ftp_dir'       => '/hps/nobackup2/production/ensembl/'.$self->o('ENV', 'USER').'/workspace/'.$self->o('pipeline_name').'/ftp_site/release-'.$self->o('release'),
-       'temp_dir'      => '/hps/nobackup2/production/ensembl/'.$self->o('ENV', 'USER').'/workspace/'.$self->o('pipeline_name').'/temp_dir/release-'.$self->o('release'),
+       'ftp_dir'       => '/nfs/nobackup/ensemblgenomes/'.$self->o('ENV', 'USER').'/workspace/'.$self->o('pipeline_name').'/ftp_site/release-'.$self->o('release'),
+       'temp_dir'      => '/nfs/nobackup/ensemblgenomes/'.$self->o('ENV', 'USER').'/workspace/'.$self->o('pipeline_name').'/temp_dir/release-'.$self->o('release'),
        'dumps'     	   => [],
 
 	   ## 'job_factory' parameters

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpVariation_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpVariation_conf.pm
@@ -51,8 +51,8 @@ sub default_options {
        'eg_version'    => $self->o('release'),
        'pipeline_name' => $self->o('hive_dbname'),       
 	   'email'         => $self->o('ENV', 'USER').'@ebi.ac.uk',
-       'ftp_dir'       => '/nfs/nobackup/ensemblgenomes/'.$self->o('ENV', 'USER').'/workspace/'.$self->o('pipeline_name').'/ftp_site/release-'.$self->o('release'),
-       'temp_dir'      => '/nfs/nobackup/ensemblgenomes/'.$self->o('ENV', 'USER').'/workspace/'.$self->o('pipeline_name').'/temp_dir/release-'.$self->o('release'),
+       'ftp_dir'       => '/nfs/production/ensembl/production/'.$self->o('ENV', 'USER').'/workspace/'.$self->o('pipeline_name').'/ftp_site/release-'.$self->o('release'),
+       'temp_dir'      => '/nfs/production/ensembl/production/'.$self->o('ENV', 'USER').'/workspace/'.$self->o('pipeline_name').'/temp_dir/release-'.$self->o('release'),
        'dumps'     	   => [],
 
 	   ## 'job_factory' parameters

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpVariation_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpVariation_conf.pm
@@ -51,8 +51,8 @@ sub default_options {
        'eg_version'    => $self->o('release'),
        'pipeline_name' => $self->o('hive_dbname'),       
 	   'email'         => $self->o('ENV', 'USER').'@ebi.ac.uk',
-       'ftp_dir'       => '/nfs/nobackup/ensemblgenomes/'.$self->o('ENV', 'USER').'/workspace/'.$self->o('pipeline_name').'/ftp_site/release-'.$self->o('release'),
-       'temp_dir'      => '/nfs/nobackup/ensemblgenomes/'.$self->o('ENV', 'USER').'/workspace/'.$self->o('pipeline_name').'/temp_dir/release-'.$self->o('release'),
+       'ftp_dir'       => '/hps/nobackup2/production/ensembl/'.$self->o('ENV', 'USER').'/workspace/'.$self->o('pipeline_name').'/ftp_site/release-'.$self->o('release'),
+       'temp_dir'      => '/hps/nobackup2/production/ensembl/'.$self->o('ENV', 'USER').'/workspace/'.$self->o('pipeline_name').'/temp_dir/release-'.$self->o('release'),
        'dumps'     	   => [],
 
 	   ## 'job_factory' parameters

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GPAD_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GPAD_conf.pm
@@ -50,7 +50,7 @@ sub default_options {
     meta_filters => {},
 
     ## General parameters
-    output_dir => '/nfs/nobackup/ensembl/'.$self->o('user').'/workspace/'.$self->o('pipeline_name'),
+    output_dir => '/nfs/production/ensembl/nobackup/production/'.$self->o('user').'/workspace/'.$self->o('pipeline_name'),
 
     ## Location of GPAD files
     gpad_directory => '',

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GPAD_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GPAD_conf.pm
@@ -50,7 +50,7 @@ sub default_options {
     meta_filters => {},
 
     ## General parameters
-    output_dir => '/hps/nobackup2/production/ensembl/'.$self->o('user').'/workspace/'.$self->o('pipeline_name'),
+    output_dir => '/nfs/nobackup/ensembl/'.$self->o('user').'/workspace/'.$self->o('pipeline_name'),
 
     ## Location of GPAD files
     gpad_directory => '',

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GPAD_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GPAD_conf.pm
@@ -50,7 +50,7 @@ sub default_options {
     meta_filters => {},
 
     ## General parameters
-    output_dir => '/nfs/nobackup/ensembl/'.$self->o('user').'/workspace/'.$self->o('pipeline_name'),
+    output_dir => '/hps/nobackup2/production/ensembl/'.$self->o('user').'/workspace/'.$self->o('pipeline_name'),
 
     ## Location of GPAD files
     gpad_directory => '',

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/OLSLoad_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/OLSLoad_conf.pm
@@ -44,7 +44,7 @@ sub default_options {
     return {
         %{$self->SUPER::default_options},
         ## General parameters
-        'output_dir'       => '/nfs/nobackup/ensembl/' . $self->o('ENV', 'USER') . '/ols_loader/' . $self->o('pipeline_name'),
+        'output_dir'       => '/nfs/production/ensembl/production/' . $self->o('ENV', 'USER') . '/ols_loader/' . $self->o('pipeline_name'),
         'base_dir'         => $self->o('ENV', 'BASE_DIR'),
         'srv_cmd'          => undef,
         'wipe_all'         => 0,

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/OLSLoad_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/OLSLoad_conf.pm
@@ -44,7 +44,7 @@ sub default_options {
     return {
         %{$self->SUPER::default_options},
         ## General parameters
-        'output_dir'       => '/nfs/nobackup/ensembl/' . $self->o('ENV', 'USER') . '/ols_loader/' . $self->o('pipeline_name'),
+        'output_dir'       => '/hps/nobackup2/production/ensembl/' . $self->o('ENV', 'USER') . '/ols_loader/' . $self->o('pipeline_name'),
         'base_dir'         => $self->o('ENV', 'BASE_DIR'),
         'srv_cmd'          => undef,
         'wipe_all'         => 0,

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/OLSLoad_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/OLSLoad_conf.pm
@@ -44,7 +44,7 @@ sub default_options {
     return {
         %{$self->SUPER::default_options},
         ## General parameters
-        'output_dir'       => '/hps/nobackup2/production/ensembl/' . $self->o('ENV', 'USER') . '/ols_loader/' . $self->o('pipeline_name'),
+        'output_dir'       => '/nfs/nobackup/ensembl/' . $self->o('ENV', 'USER') . '/ols_loader/' . $self->o('pipeline_name'),
         'base_dir'         => $self->o('ENV', 'BASE_DIR'),
         'srv_cmd'          => undef,
         'wipe_all'         => 0,

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ReadQueues_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ReadQueues_conf.pm
@@ -47,7 +47,7 @@ sub default_options {
     'release'       => $self->o('release'),
     'pipeline_name' => $self->o('hive_dbname'),       
     'email'         => $self->o('ENV', 'USER').'@ebi.ac.uk',
-    'output_dir'    => '/nfs/nobackup/ensemblgenomes/'.$self->o('ENV', 'USER').'/workspace/'.$self->o('pipeline_name'),     
+    'output_dir'    => '/hps/nobackup2/production/ensembl/'.$self->o('ENV', 'USER').'/workspace/'.$self->o('pipeline_name'),
 
     ## Messaging Queue Server
     'queue_host'  => 'ebi-007.ebi.ac.uk',

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ReadQueues_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ReadQueues_conf.pm
@@ -47,7 +47,7 @@ sub default_options {
     'release'       => $self->o('release'),
     'pipeline_name' => $self->o('hive_dbname'),       
     'email'         => $self->o('ENV', 'USER').'@ebi.ac.uk',
-    'output_dir'    => '/nfs/nobackup/ensemblgenomes/'.$self->o('ENV', 'USER').'/workspace/'.$self->o('pipeline_name'),     
+    'output_dir'    => '/nfs/production/ensembl/production/'.$self->o('ENV', 'USER').'/workspace/'.$self->o('pipeline_name'),
 
     ## Messaging Queue Server
     'queue_host'  => 'ebi-007.ebi.ac.uk',

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ReadQueues_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ReadQueues_conf.pm
@@ -47,7 +47,7 @@ sub default_options {
     'release'       => $self->o('release'),
     'pipeline_name' => $self->o('hive_dbname'),       
     'email'         => $self->o('ENV', 'USER').'@ebi.ac.uk',
-    'output_dir'    => '/hps/nobackup2/production/ensembl/'.$self->o('ENV', 'USER').'/workspace/'.$self->o('pipeline_name'),
+    'output_dir'    => '/nfs/nobackup/ensemblgenomes/'.$self->o('ENV', 'USER').'/workspace/'.$self->o('pipeline_name'),     
 
     ## Messaging Queue Server
     'queue_host'  => 'ebi-007.ebi.ac.uk',

--- a/modules/Bio/EnsEMBL/Production/Utils/CopyDatabase.pm
+++ b/modules/Bio/EnsEMBL/Production/Utils/CopyDatabase.pm
@@ -48,7 +48,7 @@ sub copy_database {
 
   $logger->info("Pre-Copy Checks");
   # Path for MySQL dump
-  my $dump_path='/nfs/nobackup/ensembl/ensprod/copy_service/';
+  my $dump_path='/hps/nobackup2/production/ensembl/ensprod/copy_service/';
   # Get list of tables that we want to copy or skip
   my %only_tables;
   my %skip_tables;
@@ -662,7 +662,7 @@ sub copy_mysql_files {
   return;
 } 
 
-# Dump the database in /nfs/nobackup/ensembl/ensprod/copy_service
+# Dump the database in /hps/nobackup2/production/ensembl/ensprod/copy_service
 # Create database on target server
 # Load the database to the target server
 sub copy_mysql_dump {

--- a/modules/Bio/EnsEMBL/Production/Utils/CopyDatabase.pm
+++ b/modules/Bio/EnsEMBL/Production/Utils/CopyDatabase.pm
@@ -48,7 +48,7 @@ sub copy_database {
 
   $logger->info("Pre-Copy Checks");
   # Path for MySQL dump
-  my $dump_path='/hps/nobackup2/production/ensembl/ensprod/copy_service/';
+  my $dump_path='/nfs/nobackup/ensembl/ensprod/copy_service/';
   # Get list of tables that we want to copy or skip
   my %only_tables;
   my %skip_tables;
@@ -662,7 +662,7 @@ sub copy_mysql_files {
   return;
 } 
 
-# Dump the database in /hps/nobackup2/production/ensembl/ensprod/copy_service
+# Dump the database in /nfs/nobackup/ensembl/ensprod/copy_service
 # Create database on target server
 # Load the database to the target server
 sub copy_mysql_dump {

--- a/modules/Bio/EnsEMBL/Production/Utils/CopyDatabase.pm
+++ b/modules/Bio/EnsEMBL/Production/Utils/CopyDatabase.pm
@@ -48,7 +48,7 @@ sub copy_database {
 
   $logger->info("Pre-Copy Checks");
   # Path for MySQL dump
-  my $dump_path='/nfs/nobackup/ensembl/ensprod/copy_service/';
+  my $dump_path='/nfs/production/ensembl/production/copy_service/';
   # Get list of tables that we want to copy or skip
   my %only_tables;
   my %skip_tables;
@@ -662,7 +662,7 @@ sub copy_mysql_files {
   return;
 } 
 
-# Dump the database in /nfs/nobackup/ensembl/ensprod/copy_service
+# Dump the database in /nfs/production/ensembl/production/ensprod/copy_service
 # Create database on target server
 # Load the database to the target server
 sub copy_mysql_dump {

--- a/scripts/copy_and_patch_db.sh
+++ b/scripts/copy_and_patch_db.sh
@@ -19,7 +19,7 @@ src=$1
 tgt=$2
 db=$3
 if [ -z "$TMP_DIR" ]; then
-    TMP_DIR=/nfs/nobackup/ensemblgenomes/$USER/dbcopy
+    TMP_DIR=/nfs/production/ensembl/production/$USER/dbcopy
     mkdir -p $TMP_DIR
 fi
 


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Description

/nfs/nobackup will be retired ruding this release. moved everything to /hps/nobackup2/production/ensembl/

## Use case

/nfs/nobackup/ temp dir usage.

## Benefits

No missing mount point when running pipeline. 

## Possible Drawbacks

Unexisting expected directory. 

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
