### PR TITLE
Don't remove "\r" characters from mysql dumps

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Utils/MySQLDumping.sh
+++ b/modules/Bio/EnsEMBL/Production/Utils/MySQLDumping.sh
@@ -69,6 +69,6 @@ tables=$(mysql -NBA --host=$host --user=$user --password=$password --port=$port 
 for t in $tables
 do
     echo "DUMPING TABLE: $database.$t"
-    mysql --host=$host --max_allowed_packet=1024M --user=$user --password=$password --port=$port -e "SELECT * FROM ${database}.${t}" --quick --silent --skip-column-names | sed -r -e 's/\r//g' -e 's/(^|\t)NULL($|\t)/\1\\N\2/g' -e 's/(^|\t)NULL($|\t)/\1\\N\2/g' |  gzip -1nc > ${output_dir}/$database/$t.txt.gz
+    mysql --host=$host --max_allowed_packet=1024M --user=$user --password=$password --port=$port -e "SELECT * FROM ${database}.${t}" --quick --silent --skip-column-names | sed -r -e 's/(^|\t)NULL($|\t)/\1\\N\2/g' -e 's/(^|\t)NULL($|\t)/\1\\N\2/g' |  gzip -1nc > ${output_dir}/$database/$t.txt.gz
 done
 


### PR DESCRIPTION
## Description
Having "\r" characters in fields is problematic for mysql dumps; without having server access to do the dumping, escaping the characters is surprisingly difficult. However, stripping out "\r" with a sed command causes significant problems, because for fields with compressed/binary data, this often corrupts the data.
The lesser evil is to have "\r" characters in our dump files - this impacts fewer tables, and is immediately obvious, because loading the data fails. The corrupted binary fields weren't spotted for several releases, and was time-consuming to fix.
But, hopefully that shouldn't be an issue in future, because this PR is in conjunction with a new datacheck, that disallows "\r" in any database field ("\t" and "\n" are OK in the mysql dumps, although since they are potentially problematic for web display etc, they are the subject of a new advisory datacheck).