### PR TITLE
Base decision-making in Core Stats pipeline on datachecks

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/CoreStatistics_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/CoreStatistics_conf.pm
@@ -59,8 +59,6 @@ sub default_options {
     bin_count => '150',
     max_run   => '100',
 
-    skip_metadata_check => 0,
-
     pepstats_binary => 'pepstats',
     pepstats_tmpdir => '/scratch',
 
@@ -116,11 +114,12 @@ sub pipeline_analyses {
                          },
       -max_retry_count => 1,
       -flow_into       => {
-                            '3->A' => ['CheckAssemblyGeneset_ChromosomeRelatedTasks'],
+                            '3->A' => ['CheckStatistics_Chromosome'],
                             'A->1' => ['SpeciesFactory_All'],
                           },
       -rc_name         => 'normal',
     },
+
     {
       -logic_name      => 'SpeciesFactory_All',
       -module          => 'Bio::EnsEMBL::Production::Pipeline::Common::SpeciesFactory',
@@ -133,52 +132,61 @@ sub pipeline_analyses {
                          },
       -max_retry_count => 1,
       -flow_into       => {
-                            '2' => ['CheckAssemblyGeneset_GeneRelatedTasks'],
+                            '2' => ['CheckStatistics_All'],
                           },
       -rc_name         => 'normal',
     },
+
     {
-      -logic_name      => 'CheckAssemblyGeneset_GeneRelatedTasks',
-      -module          => 'Bio::EnsEMBL::Production::Pipeline::Common::CheckAssemblyGeneset',
-      -parameters  => {
-          skip_metadata_check => $self->o('skip_metadata_check'),
-          release => $self->o('release')
-       },
+      -logic_name      => 'CheckStatistics_Chromosome',
+      -module          => 'Bio::EnsEMBL::DataCheck::Pipeline::RunDataChecks',
+      -parameters      => {
+                            datacheck_groups => ['core_statistics'],
+                            history_file     => $self->o('history_file'),
+                            failures_fatal   => 0,
+                          },
       -max_retry_count => 1,
-      -hive_capacity   => 10,
-      -priority        => 5,
+      -hive_capacity   => 50,
+      -batch_size      => 10,
+      -flow_into       => WHEN(
+                            '#datachecks_failed#' =>
+                            [
+                              'CodingDensity',
+                              'PseudogeneDensity',
+                              'ShortNonCodingDensity',
+                              'LongNonCodingDensity',
+                              'PercentGC',
+                              'PercentRepeat',
+                            ]
+                          ),
+      -rc_name         => 'normal',
+    },
+
+    {
+      -logic_name      => 'CheckStatistics_All',
+      -module          => 'Bio::EnsEMBL::DataCheck::Pipeline::RunDataChecks',
+      -parameters      => {
+                            datacheck_groups => ['core_statistics'],
+                            history_file     => $self->o('history_file'),
+                            failures_fatal   => 0,
+                          },
+      -max_retry_count => 1,
+      -hive_capacity   => 50,
+      -batch_size      => 10,
       -rc_name         => 'normal',
       -flow_into       => {
-                            '1->A' => WHEN( '#new_assembly# >= 1 or #new_genebuild# >=1' => [
-                                        'ConstitutiveExons',
-                                        'GeneCount',
-                                        'GeneGC',
-                                        'PepStats',
-                                      ]),
-                            'A->1' => WHEN('#new_assembly# >= 1 or #new_genebuild# >=1' => ['GenomeStats']),
+                            '1->A' => WHEN(
+                              '#datachecks_failed#' => [
+                                'ConstitutiveExons',
+                                'GeneCount',
+                                'GeneGC',
+                                'PepStats',
+                              ]
+                            ),
+                            'A->1' => WHEN(
+                              '#datachecks_failed#' => ['GenomeStats']
+                            ),
                           },
-    },
-    {
-      -logic_name      => 'CheckAssemblyGeneset_ChromosomeRelatedTasks',
-      -module          => 'Bio::EnsEMBL::Production::Pipeline::Common::CheckAssemblyGeneset',
-      -parameters  => {
-          skip_metadata_check => $self->o('skip_metadata_check'),
-          release => $self->o('release')
-      },
-      -max_retry_count => 1,
-      -hive_capacity   => 10,
-      -priority        => 5,
-      -rc_name         => 'normal',
-      -flow_into       => [ WHEN(
-                        '#new_assembly# >= 1 or #new_genebuild# >=1' =>[
-                            'CodingDensity',
-                            'PseudogeneDensity',
-                            'ShortNonCodingDensity',
-                            'LongNonCodingDensity',
-                            'PercentGC',
-                            'PercentRepeat',
-                          ])
-      ],
     },
 
     {

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Production/EmailSummaryCore.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Production/EmailSummaryCore.pm
@@ -22,180 +22,58 @@ package Bio::EnsEMBL::Production::Pipeline::Production::EmailSummaryCore;
 use strict;
 use warnings;
 use base qw/Bio::EnsEMBL::Hive::RunnableDB::NotifyByEmail Bio::EnsEMBL::Production::Pipeline::Common::Base/;
-use Bio::EnsEMBL::Hive::Utils qw/destringify/;
 
 sub fetch_input {
   my ($self) = @_;
-  
+
   $self->assert_executable('sendmail');
-  
-  my $pep_stats = $self->jobs('PepStats');
-  my $gene_gc = $self->jobs('GeneGC');
-  my $percent_gc = $self->jobs('PercentGC');
-  my $percent_repeat = $self->jobs('PercentRepeat');
-  my $coding_density = $self->jobs('CodingDensity');
-  my $pseudogene_density = $self->jobs('PseudogeneDensity');
-  my $short_non_coding_density = $self->jobs('ShortNonCodingDensity');
-  my $long_non_coding_density = $self->jobs('LongNonCodingDensity');
-  my $gene_count = $self->jobs('GeneCount');
-  my $ct_exons = $self->jobs('ConstitutiveExons');
 
-    
-  my @args = (
-    $pep_stats->{successful_jobs},
-    $pep_stats->{failed_jobs},
-    $gene_gc->{successful_jobs},
-    $gene_gc->{failed_jobs},
-    $percent_gc->{successful_jobs},
-    $percent_gc->{failed_jobs},
-    $percent_repeat->{successful_jobs},
-    $percent_repeat->{failed_jobs},
-    $coding_density->{successful_jobs},
-    $coding_density->{failed_jobs},
-    $pseudogene_density->{successful_jobs},
-    $pseudogene_density->{failed_jobs},
-    $short_non_coding_density->{successful_jobs},
-    $short_non_coding_density->{failed_jobs},
-    $long_non_coding_density->{successful_jobs},
-    $long_non_coding_density->{failed_jobs},
-    $gene_count->{successful_jobs},
-    $gene_count->{failed_jobs},
-    $ct_exons->{successful_jobs},
-    $ct_exons->{failed_jobs},
-    $self->failed(),
-    $self->summary($pep_stats),
-    $self->summary($gene_gc),
-    $self->summary($percent_gc),
-    $self->summary($percent_repeat),
-    $self->summary($coding_density),
-    $self->summary($pseudogene_density),
-    $self->summary($short_non_coding_density),
-    $self->summary($long_non_coding_density),
-    $self->summary($gene_count),
-    $self->summary($ct_exons),
-  );
-  
-  my $msg = sprintf(<<'MSG', @args);
-Your Production Pipeline has finished. We have:
+  my $percent_gc = $self->job_count('PercentGC');
+  my $percent_repeat = $self->job_count('PercentRepeat');
+  my $coding_density = $self->job_count('CodingDensity');
+  my $pseudogene_density = $self->job_count('PseudogeneDensity');
+  my $short_non_coding_density = $self->job_count('ShortNonCodingDensity');
+  my $long_non_coding_density = $self->job_count('LongNonCodingDensity');
+  my $gene_gc = $self->job_count('GeneGC');
+  my $gene_count = $self->job_count('GeneCount');
+  my $ct_exons = $self->job_count('ConstitutiveExons');
+  my $pep_stats = $self->job_count('PepStats');
+  my $genome_stats = $self->job_count('GenomeStats');
 
-  * %d species with pep stats (%d failed)
-  * %d species with gene gc (%d failed)
-  * %d species with percent gc (%d failed)
-  * %d species with percent repeat (%d failed)
-  * %d species with coding density (%d failed)
-  * %d species with pseudogene density (%d failed)
-  * %d species with short non coding density (%d failed)
-  * %d species with long non coding density (%d failed)
-  * %d species with gene count (%d failed)
-  * %d species with constitutive exons (%d failed)
+  my $msg = qq/
+The Core Statistics pipeline has finished.
 
-%s
-
-===============================================================================
-
-Full breakdown follows ...
-
-%s
-
-%s
-
-%s
-
-%s
-
-%s
-
-%s
-
-%s
-
-%s
-
-%s
-
-%s
-
-MSG
-  $self->param('text', $msg);
-  return;
+Job counts:
+  * PercentGC: $percent_gc species
+  * PercentRepeat: $percent_repeat species
+  * CodingDensity: $coding_density species
+  * PseudogeneDensity: $pseudogene_density species
+  * ShortNonCodingDensity: $short_non_coding_density species
+  * LongNonCodingDensity: $long_non_coding_density species
+  * GeneGC: $gene_gc species
+  * GeneCount: $gene_count species
+  * ConstitutiveExons: $ct_exons species
+  * PepStats:$pep_stats species
+  * GenomeStats: $genome_stats species
+/;
+  $self->param('text', $msg)
 }
 
-sub jobs {
+sub job_count {
   my ($self, $logic_name) = @_;
+  my $job_count = 0;
+
   my $aa = $self->db->get_AnalysisAdaptor();
   my $aja = $self->db->get_AnalysisJobAdaptor();
   my $analysis = $aa->fetch_by_logic_name($logic_name);
-  my @jobs;
-  if (!$analysis) {
-    return {
-      name => $logic_name,
-      successful_jobs => 0,
-      failed_jobs => 0,
-      jobs => \@jobs,
-    };
+  
+  if ($analysis) {
+    my $id = $analysis->dbID();
+    my @jobs = @{$aja->fetch_all_by_analysis_id($id)};
+    $job_count = scalar(@jobs);
   }
-  my $id = $analysis->dbID();
-  @jobs = @{$aja->fetch_all_by_analysis_id($id)};
-  $_->{input} = destringify($_->input_id()) for @jobs;
-  @jobs = sort { $a->{input}->{species} cmp $b->{input}->{species} } @jobs;
-  my %passed_species = map { $_->{input}->{species}, 1 } grep { $_->status() eq 'DONE' } @jobs;
-  my %failed_species = map { $_->{input}->{species}, 1 } grep { $_->status() eq 'FAILED' } @jobs;
-  return {
-    analysis => $analysis,
-    name => $logic_name,
-    jobs => \@jobs,
-    successful_jobs => scalar(keys %passed_species),
-    failed_jobs => scalar(keys %failed_species),
-  };
-}
 
-
-sub failed {
-  my ($self) = @_;
-  my $failed = $self->db()->get_AnalysisJobAdaptor()->fetch_all_by_analysis_id_status(undef, 'FAILED');
-  if(! @{$failed}) {
-    return 'No jobs failed. Congratulations!';
-  }
-  my $output = <<'MSG';
-The following jobs have failed during this run. Please check your hive's error msg table for the following jobs:
-
-MSG
-  foreach my $job (@{$failed}) {
-    my $analysis = $self->db()->get_AnalysisAdaptor()->fetch_by_dbID($job->analysis_id());
-    my $line = sprintf(q{  * job_id=%d %s(%5d) input_id='%s'}, $job->dbID(), $analysis->logic_name(), $analysis->dbID(), $job->input_id());
-    $output .= $line;
-    $output .= "\n";
-  }
-  return $output;
-}
-
-my $sorter = sub {
-  my $status_to_int = sub {
-    my ($v) = @_;
-    return ($v->status() eq 'FAILED') ? 0 : 1;
-  };
-  my $status_sort = $status_to_int->($a) <=> $status_to_int->($b);
-  return $status_sort if $status_sort != 0;
-  return $a->{input}->{species} cmp $b->{input}->{species};
-};
-
-sub summary {
-  my ($self, $data) = @_;
-  my $name = $data->{name};
-  my $underline = '~'x(length($name));
-  my $output = "$name\n$underline\n\n";
-  my @jobs = @{$data->{jobs}};
-  if(@jobs) {
-    foreach my $job (sort $sorter @{$data->{jobs}}) {
-      my $species = $job->{input}->{species};
-      $output .= sprintf("  * %s - job_id=%d %s\n", $species, $job->dbID(), $job->status());
-    }
-  }
-  else {
-    $output .= "No jobs run for this analysis\n";
-  }
-  $output .= "\n";
-  return $output;
+  return $job_count;
 }
 
 1;


### PR DESCRIPTION
## Description
The core stats pipeline was using the geneset and assembly information in the metadata db to decide when it needed to be run. This does not take into account some scenarios which affect the statistics: for example, if the members of a biotype group change, or if 'karyotype_rank' attribs are added. The easiest way to tackle this is to run the appropriate group of datachecks, and run the pipeline for any species which fails. This is a bit redundant, because we don't necessarily need to re-do density calculations if only a biotype has changed (for example), but the pipeline is not _that_ expensive to run, so we tolerate this for the sake of a simpler pipeline to maintain.

## Use case
We ended up with species with out-of-date statistics because we didn't have sufficient triggers in place to re-calculate them in all scenarios. Although we had a group of datachecks for this, there was no mechanism to run them across all divisions every release.

## Benefits
Statistics are correct.

## Possible Drawbacks
It takes a bit longer to run the datacheck group, compared to the assembly/geneset lookup in the metadata db. But it doesn't take ages, the datacheck queries are fairly simple.

## Testing
No unit tests, but pipeline initialised and successfully run to completion for one division.
