### PR TITLE
For release 102 only, we need to replace \r characters in three tables.

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Utils/MySQLDumping.sh
+++ b/modules/Bio/EnsEMBL/Production/Utils/MySQLDumping.sh
@@ -68,7 +68,11 @@ tables=$(mysql -NBA --host=$host --user=$user --password=$password --port=$port 
 
 for t in $tables
 do
-    echo "DUMPING TABLE: $database.$t"
-    mysql --host=$host --max_allowed_packet=1024M --user=$user --password=$password --port=$port -e "SELECT * FROM ${database}.${t}" --quick --silent --skip-column-names | sed -r -e 's/(^|\t)NULL($|\t)/\1\\N\2/g' -e 's/(^|\t)NULL($|\t)/\1\\N\2/g' |  gzip -1nc > ${output_dir}/$database/$t.txt.gz
+    if [[ $t == 'analysis_description' || $t == 'attrib_type' || $t == 'external_db' ]]; then
+      echo "DUMPING TABLE with /r sub: $database.$t"
+      mysql --host=$host --max_allowed_packet=1024M --user=$user --password=$password --port=$port -e "SELECT * FROM ${database}.${t}" --quick --silent --skip-column-names | sed -r -e 's/\r//g' -e 's/(^|\t)NULL($|\t)/\1\\N\2/g' -e 's/(^|\t)NULL($|\t)/\1\\N\2/g' |  gzip -1nc > ${output_dir}/$database/$t.txt.gz
+    else
+      echo "DUMPING TABLE: $database.$t"
+      mysql --host=$host --max_allowed_packet=1024M --user=$user --password=$password --port=$port -e "SELECT * FROM ${database}.${t}" --quick --silent --skip-column-names | sed -r -e 's/(^|\t)NULL($|\t)/\1\\N\2/g' -e 's/(^|\t)NULL($|\t)/\1\\N\2/g' |  gzip -1nc > ${output_dir}/$database/$t.txt.gz
+    fi
 done
-


### PR DESCRIPTION
This is resolved for future releases, by fixing the source tables in the production database.
