### PR TITLE
Run populate_assembly_converter_dir.sh for verts/nonverts independently 103

### DIFF
--- a/scripts/assembly_converter/populate_assembly_converter_dir.sh
+++ b/scripts/assembly_converter/populate_assembly_converter_dir.sh
@@ -18,9 +18,12 @@ base_src=/hps/nobackup2/production/ensembl/ensprod/release_dumps
 base_dest=/hps/nobackup2/production/ensembl/ensprod/release_dumps/assembly_converter
 vert_ftp=/nfs/ensemblftp/PUBLIC/pub
 non_vert_ftp=/nfs/ensemblgenomes/ftp/pub
-test=false
+testing=false
+do_verts=false
+do_nonverts=false
 
-while getopts ":s:d:t" opt; do
+
+while getopts "n:v:s:d:TVN" opt; do
   case $opt in
     s) base_src="$OPTARG"
     ;;
@@ -30,212 +33,215 @@ while getopts ":s:d:t" opt; do
     ;;
     n) non_vert_ftp="$OPTARG"
     ;;
-    t) test=true
+    T) testing=true
     ;;
-    \?) echo "Invalid option -$OPTARG" >&2
+    V) do_verts=true
+    ;;
+    N) do_nonverts=true
+    ;;
+    \?) echo "Invalid option -$OPTARG" 1>&2
     ;;
   esac
 done
 
-echo ""
-echo "PROCESSING VERTEBRATES"
-echo "----------------------"
-# FIRST process vertebrates and copy into wwww
-for dir in `ls ${base_src}/release-${ENS_VERSION}/vertebrates/assembly_chain`
-do
-    echo "mkdir -p ${base_dest}/www/${dir} if not exists"
-    if test ${test} !=  "true"
-    then
-        mkdir -p ${base_dest}/www/${dir}
-    fi
 
-    echo "---------------------------"
-    echo "Copying... ${dir} chain files"
-    echo "---------------------------"
-
-    for file in `ls ${base_src}/release-${ENS_VERSION}/vertebrates/assembly_chain/${dir}`
-    do
-        if test ${file} !=  "CHECKSUMS"
-        then
-            echo "cp ${base_src}/release-${ENS_VERSION}/vertebrates/assembly_chain/${dir}/${file} ${base_dest}/www/${dir}/"
-            if test ${test} !=  "true"
-            then
-                cp ${base_src}/release-${ENS_VERSION}/vertebrates/assembly_chain/${dir}/${file} ${base_dest}/www/${dir}/
-            fi
-        fi
-    done
-
-    echo "------------------------"
-    echo "Copying, unzipping and renaming indexed current ${dir} dna.toplevel.fa"
-    echo "------------------------"
-
-    for file in `ls ${base_src}/release-${ENS_VERSION}/vertebrates/fasta/${dir}/dna_index/`
-    do
-        if test ${file} !=  "CHECKSUMS"
-        then
-            if test ${test} !=  "true"
-            then
-                if [[ "${file}" = *".fa.gz.fai" ]]
-                then
-                    echo "cp ${base_src}/release-${ENS_VERSION}/vertebrates/fasta/${dir}/dna_index/${file} ${base_dest}/www/${dir}/"
-                    cp ${base_src}/release-${ENS_VERSION}/vertebrates/fasta/${dir}/dna_index/${file} ${base_dest}/www/${dir}/
-                    mv -f "${base_dest}/www/${dir}/${file}" "${base_dest}/www/${dir}/${file/.fa.gz.fai/.fa.fai}"
-                elif [[ "${file}" = *".fa.gz" ]]
-                then
-                   echo "cp ${base_src}/release-${ENS_VERSION}/vertebrates/fasta/${dir}/dna_index/${file} ${base_dest}/www/${dir}/"
-                   cp ${base_src}/release-${ENS_VERSION}/vertebrates/fasta/${dir}/dna_index/${file} ${base_dest}/www/${dir}/
-                   echo "Unzipping files ${file}"
-                   gunzip -f ${base_dest}/www/${dir}/${file}
-                fi
-            fi
-        fi
-    done
-
-    echo "------------------------"
-    echo "Copying, unzipping and indexing previous assembly ${dir} dna.toplevel.fa"
-    echo "------------------------"
-
-    for assembly in `ls ${base_src}/release-${ENS_VERSION}/vertebrates/assembly_chain/${dir} | xargs -n 1 basename | sed s/_to.*// | uniq`
-    do
-        if test ${assembly} !=  "CHECKSUMS"
-        then
-            if test ${test} !=  "true"
-            then
-                if [[ "${assembly}" = 'GRCh37' && "${dir}" = 'homo_sapiens' ]]
-                then
-                    file_path=`find ${vert_ftp}/grch37/release-*/fasta/${dir}/dna/ -type f -name "${dir^}.${assembly}.*.dna.toplevel.fa.gz" -o -name "${dir^}.${assembly}.dna.toplevel.fa.gz" | sort -r | head -n1`
-                elif [[ "${assembly}" = 'NCBI35' && "${dir}" = 'homo_sapiens' ]]
-                then
-                    file_path=`find ${vert_ftp}/release-*/homo_sapiens*/data/fasta/dna/ -type f -name "${dir^}.*.${assembly}.*.dna.contig.fa.gz" | sort -r | head -n1`
-                elif [[ "${assembly}" = 'NCBI34' && "${dir}" = 'homo_sapiens' ]]
-                then
-                    file_path=`find ${vert_ftp}/release-*/human*/data/fasta/dna/ -type f -name "${dir^}.${assembly}.*.dna.contig.fa.gz" | sort -r | head -n1`
-                elif [[ "${assembly}" = 'NCBIM36' && "${dir}" = 'mus_musculus' ]]
-                then
-                    file_path=`find ${vert_ftp}/release-*/mus_musculus*/data/fasta/dna/ -type f -name "${dir^}.${assembly}.*.dna.seqlevel.fa.gz" | sort -r | head -n1`
-                else
-                    file_path=`find ${vert_ftp}/release-*/fasta/${dir}/dna/ -type f -name "${dir^}.${assembly}.*.dna.toplevel.fa.gz" -o -name "${dir^}.${assembly}.dna.toplevel.fa.gz" | sort -r | head -n1`
-                fi
-                if [[ -n "$file_path" ]]
-                then
-                    file=`echo ${file_path} | xargs -n 1 basename | sed s/.gz//`
-                else
-                    echo "WARNING: Cannot find file for assembly '$assembly'"
-                    continue
-                fi
-                if [ ! -f "${base_dest}/www/${dir}/$file" ]
-                then
-                    echo "cp $file_path ${base_dest}/www/${dir}"
-                    cp $file_path ${base_dest}/www/${dir}
-                    echo "Unzipping file ${file}.gz"
-                    gunzip -f ${base_dest}/www/${dir}/${file}.gz
-                    echo "indexing ${file}"
-                    samtools faidx ${base_dest}/www/${dir}/${file}
-                fi
-            fi
-        fi
-    done
-done
-
-echo ""
-echo "PROCESSING NV DIVISIONS"
-echo "--------------------"
-# Then process NV
-for division in plants fungi metazoa protists
-do
+if [ "$do_verts" = true ]; then
     echo ""
-    echo "------------------"
-    echo "Division $division"
-    echo "------------------"
-    for dir in `ls ${base_src}/release-${EG_VERSION}/${division}/assembly_chain`
+    echo "PROCESSING VERTEBRATES"
+    echo "----------------------"
+    # FIRST process vertebrates and copy into wwww
+    for dir in `ls ${base_src}/release-${ENS_VERSION}/vertebrates/assembly_chain`
     do
-        if [[ "${dir}" != *"collection" ]]
-        then
-            if test ${test} !=  "true"
-            # Create dirs
-            then
-                mkdir -p ${base_dest}/${division}/${dir}
-            else
-                echo "mkdir -p ${base_dest}/${division}/${dir}"
-            fi
-
-            echo "--------------------------------------"
-            echo "Copying... $division  ${dir} chain files"
-            echo "--------------------------------------"
-
-            for file in `ls ${base_src}/release-${EG_VERSION}/${division}/assembly_chain/${dir}`
-            do
-                if test ${file} !=  "CHECKSUMS"
-                then
-                    echo "cp ${base_src}/release-${EG_VERSION}/${division}/assembly_chain/${dir}/${file} ${base_dest}/${division}/${dir}/"
-                    if test ${test} !=  "true"
-                    then
-                        cp ${base_src}/release-${EG_VERSION}/${division}/assembly_chain/${dir}/${file} ${base_dest}/${division}/${dir}/
-                    fi
-
-                fi
-            done
-            echo "----------------------------------"
-            echo "Copying, unzipping and renaming indexed $division ${dir} dna.toplevel.fa"
-            echo "----------------------------------"
-
-            for file in `ls ${base_src}/release-${EG_VERSION}/${division}/fasta/${dir}/dna_index/`
-            do
-                if test ${file} !=  "CHECKSUMS"
-                then
-                    if test ${test} !=  "true"
-                    then
-                        if [[ "${file}" = *".fa.gz.fai" ]]
-                        then
-                            echo "cp ${base_src}/release-${EG_VERSION}/${division}/fasta/${dir}/dna_index/${file} ${base_dest}/${division}/${dir}/"
-                            cp ${base_src}/release-${EG_VERSION}/${division}/fasta/${dir}/dna_index/${file} ${base_dest}/${division}/${dir}/
-                            mv -f "${base_dest}/${division}/${dir}/${file}" "${base_dest}/${division}/${dir}/${file/.fa.gz.fai/.fa.fai}"
-                        elif [[ "${file}" = *".fa.gz" ]]
-                        then
-                            echo "cp ${base_src}/release-${EG_VERSION}/${division}/fasta/${dir}/dna_index/${file} ${base_dest}/${division}/${dir}/"
-                            cp ${base_src}/release-${EG_VERSION}/${division}/fasta/${dir}/dna_index/${file} ${base_dest}/${division}/${dir}/
-                            echo "Unzipping files ${file}"
-                            gunzip -f ${base_dest}/${division}/${dir}/${file}
-                        fi
-                    fi
-                fi
-            done
-
-            echo "------------------------"
-            echo "Copying, unzipping and indexing previous assembly ${dir} dna.toplevel.fa"
-            echo "------------------------"
-
-            for assembly in `ls ${base_src}/release-${EG_VERSION}/${division}/assembly_chain/${dir}| xargs -n 1 basename | sed s/_to.*// | uniq`
-            do
-                if test ${assembly} !=  "CHECKSUMS"
-                then
-                    if test ${test} !=  "true"
-                    then
-                        file_path=`find ${non_vert_ftp}/release-*/${division}/fasta/${dir}/dna/ -type f -name "${dir^}.${assembly}.*.dna.toplevel.fa.gz" -o -name "${dir^}.${assembly}.dna.toplevel.fa.gz" | sort -r | head -n1`
-                        if [[ -n "$file_path" ]]
-                        then
-                            file=`echo ${file_path} | xargs -n 1 basename | sed s/.gz//`
-                        else
-                            echo "WARNING: Cannot find file for assembly '$assembly'"
-                            continue
-                        fi
-                        if [ ! -f "${base_dest}/${division}/${dir}/$file" ]
-                        then
-                            echo "cp $file_path ${base_dest}/${division}/${dir}"
-                            cp $file_path ${base_dest}/${division}/${dir}
-                            echo "Unzipping file ${file}.gz"
-                            gunzip -f ${base_dest}/${division}/${dir}/${file}.gz
-                            echo "indexing ${file}"
-                            samtools faidx ${base_dest}/${division}/${dir}/${file}
-                        fi
-                    fi
-                fi
-            done
-        else
-            echo "Skipping collection ${dir}"
+        echo "mkdir -p ${base_dest}/www/${dir} if not exists"
+        if [ "$testing" = false ]; then
+            mkdir -p ${base_dest}/www/${dir}
         fi
+
+        echo "---------------------------"
+        echo "Copying... ${dir} chain files"
+        echo "---------------------------"
+
+        for file in `ls ${base_src}/release-${ENS_VERSION}/vertebrates/assembly_chain/${dir}`
+        do
+            if test ${file} !=  "CHECKSUMS"
+            then
+                echo "cp ${base_src}/release-${ENS_VERSION}/vertebrates/assembly_chain/${dir}/${file} ${base_dest}/www/${dir}/"
+                if [ "$testing" = false ]; then
+                    cp ${base_src}/release-${ENS_VERSION}/vertebrates/assembly_chain/${dir}/${file} ${base_dest}/www/${dir}/
+                fi
+            fi
+        done
+
+        echo "------------------------"
+        echo "Copying, unzipping and renaming indexed current ${dir} dna.toplevel.fa"
+        echo "------------------------"
+
+        for file in `ls ${base_src}/release-${ENS_VERSION}/vertebrates/fasta/${dir}/dna_index/`
+        do
+            if test ${file} !=  "CHECKSUMS"
+            then
+                if [ "$testing" = false ]; then
+                    if [[ "${file}" = *".fa.gz.fai" ]]
+                    then
+                        echo "cp ${base_src}/release-${ENS_VERSION}/vertebrates/fasta/${dir}/dna_index/${file} ${base_dest}/www/${dir}/"
+                        cp ${base_src}/release-${ENS_VERSION}/vertebrates/fasta/${dir}/dna_index/${file} ${base_dest}/www/${dir}/
+                        mv -f "${base_dest}/www/${dir}/${file}" "${base_dest}/www/${dir}/${file/.fa.gz.fai/.fa.fai}"
+                    elif [[ "${file}" = *".fa.gz" ]]
+                    then
+                       echo "cp ${base_src}/release-${ENS_VERSION}/vertebrates/fasta/${dir}/dna_index/${file} ${base_dest}/www/${dir}/"
+                       cp ${base_src}/release-${ENS_VERSION}/vertebrates/fasta/${dir}/dna_index/${file} ${base_dest}/www/${dir}/
+                       echo "Unzipping files ${file}"
+                       gunzip -f ${base_dest}/www/${dir}/${file}
+                    fi
+                fi
+            fi
+        done
+
+        echo "------------------------"
+        echo "Copying, unzipping and indexing previous assembly ${dir} dna.toplevel.fa"
+        echo "------------------------"
+
+        for assembly in `ls ${base_src}/release-${ENS_VERSION}/vertebrates/assembly_chain/${dir} | xargs -n 1 basename | sed s/_to.*// | uniq`
+        do
+            if test ${assembly} !=  "CHECKSUMS"
+            then
+                if [ "$testing" = false ]; then
+                    if [[ "${assembly}" = 'GRCh37' && "${dir}" = 'homo_sapiens' ]]
+                    then
+                        file_path=`find ${vert_ftp}/grch37/release-*/fasta/${dir}/dna/ -type f -name "${dir^}.${assembly}.*.dna.toplevel.fa.gz" -o -name "${dir^}.${assembly}.dna.toplevel.fa.gz" | sort -r | head -n1`
+                    elif [[ "${assembly}" = 'NCBI35' && "${dir}" = 'homo_sapiens' ]]
+                    then
+                        file_path=`find ${vert_ftp}/release-*/homo_sapiens*/data/fasta/dna/ -type f -name "${dir^}.*.${assembly}.*.dna.contig.fa.gz" | sort -r | head -n1`
+                    elif [[ "${assembly}" = 'NCBI34' && "${dir}" = 'homo_sapiens' ]]
+                    then
+                        file_path=`find ${vert_ftp}/release-*/human*/data/fasta/dna/ -type f -name "${dir^}.${assembly}.*.dna.contig.fa.gz" | sort -r | head -n1`
+                    elif [[ "${assembly}" = 'NCBIM36' && "${dir}" = 'mus_musculus' ]]
+                    then
+                        file_path=`find ${vert_ftp}/release-*/mus_musculus*/data/fasta/dna/ -type f -name "${dir^}.${assembly}.*.dna.seqlevel.fa.gz" | sort -r | head -n1`
+                    else
+                        file_path=`find ${vert_ftp}/release-*/fasta/${dir}/dna/ -type f -name "${dir^}.${assembly}.*.dna.toplevel.fa.gz" -o -name "${dir^}.${assembly}.dna.toplevel.fa.gz" | sort -r | head -n1`
+                    fi
+                    if [[ -n "$file_path" ]]
+                    then
+                        file=`echo ${file_path} | xargs -n 1 basename | sed s/.gz//`
+                    else
+                        echo "WARNING: Cannot find file for assembly '$assembly'"
+                        continue
+                    fi
+                    if [ ! -f "${base_dest}/www/${dir}/$file" ]
+                    then
+                        echo "cp $file_path ${base_dest}/www/${dir}"
+                        cp $file_path ${base_dest}/www/${dir}
+                        echo "Unzipping file ${file}.gz"
+                        gunzip -f ${base_dest}/www/${dir}/${file}.gz
+                        echo "indexing ${file}"
+                        samtools faidx ${base_dest}/www/${dir}/${file}
+                    fi
+                fi
+            fi
+        done
     done
-done
+fi
+
+
+if [ "$do_nonverts" = true ]; then
+    echo ""
+    echo "PROCESSING NV DIVISIONS"
+    echo "--------------------"
+    # Then process NV
+    for division in plants fungi metazoa protists
+    do
+        echo ""
+        echo "------------------"
+        echo "Division $division"
+        echo "------------------"
+        for dir in `ls ${base_src}/release-${EG_VERSION}/${division}/assembly_chain`
+        do
+            if [[ "${dir}" != *"collection" ]]
+            then
+                if [ "$testing" = false ]; then
+                    # Create dirs
+                    mkdir -p ${base_dest}/${division}/${dir}
+                else
+                    echo "mkdir -p ${base_dest}/${division}/${dir}"
+                fi
+
+                echo "--------------------------------------"
+                echo "Copying... $division  ${dir} chain files"
+                echo "--------------------------------------"
+
+                for file in `ls ${base_src}/release-${EG_VERSION}/${division}/assembly_chain/${dir}`
+                do
+                    if test ${file} !=  "CHECKSUMS"
+                    then
+                        echo "cp ${base_src}/release-${EG_VERSION}/${division}/assembly_chain/${dir}/${file} ${base_dest}/${division}/${dir}/"
+                        if [ "$testing" = false ]; then
+                            cp ${base_src}/release-${EG_VERSION}/${division}/assembly_chain/${dir}/${file} ${base_dest}/${division}/${dir}/
+                        fi
+
+                    fi
+                done
+                echo "----------------------------------"
+                echo "Copying, unzipping and renaming indexed $division ${dir} dna.toplevel.fa"
+                echo "----------------------------------"
+
+                for file in `ls ${base_src}/release-${EG_VERSION}/${division}/fasta/${dir}/dna_index/`
+                do
+                    if test ${file} !=  "CHECKSUMS"
+                    then
+                        if [ "$testing" = false ]; then
+                            if [[ "${file}" = *".fa.gz.fai" ]]
+                            then
+                                echo "cp ${base_src}/release-${EG_VERSION}/${division}/fasta/${dir}/dna_index/${file} ${base_dest}/${division}/${dir}/"
+                                cp ${base_src}/release-${EG_VERSION}/${division}/fasta/${dir}/dna_index/${file} ${base_dest}/${division}/${dir}/
+                                mv -f "${base_dest}/${division}/${dir}/${file}" "${base_dest}/${division}/${dir}/${file/.fa.gz.fai/.fa.fai}"
+                            elif [[ "${file}" = *".fa.gz" ]]
+                            then
+                                echo "cp ${base_src}/release-${EG_VERSION}/${division}/fasta/${dir}/dna_index/${file} ${base_dest}/${division}/${dir}/"
+                                cp ${base_src}/release-${EG_VERSION}/${division}/fasta/${dir}/dna_index/${file} ${base_dest}/${division}/${dir}/
+                                echo "Unzipping files ${file}"
+                                gunzip -f ${base_dest}/${division}/${dir}/${file}
+                            fi
+                        fi
+                    fi
+                done
+
+                echo "------------------------"
+                echo "Copying, unzipping and indexing previous assembly ${dir} dna.toplevel.fa"
+                echo "------------------------"
+
+                for assembly in `ls ${base_src}/release-${EG_VERSION}/${division}/assembly_chain/${dir}| xargs -n 1 basename | sed s/_to.*// | uniq`
+                do
+                    if test ${assembly} !=  "CHECKSUMS"
+                    then
+                        if [ "$testing" = false ]; then
+                            file_path=`find ${non_vert_ftp}/release-*/${division}/fasta/${dir}/dna/ -type f -name "${dir^}.${assembly}.*.dna.toplevel.fa.gz" -o -name "${dir^}.${assembly}.dna.toplevel.fa.gz" | sort -r | head -n1`
+                            if [[ -n "$file_path" ]]
+                            then
+                                file=`echo ${file_path} | xargs -n 1 basename | sed s/.gz//`
+                            else
+                                echo "WARNING: Cannot find file for assembly '$assembly'"
+                                continue
+                            fi
+                            if [ ! -f "${base_dest}/${division}/${dir}/$file" ]
+                            then
+                                echo "cp $file_path ${base_dest}/${division}/${dir}"
+                                cp $file_path ${base_dest}/${division}/${dir}
+                                echo "Unzipping file ${file}.gz"
+                                gunzip -f ${base_dest}/${division}/${dir}/${file}.gz
+                                echo "indexing ${file}"
+                                samtools faidx ${base_dest}/${division}/${dir}/${file}
+                            fi
+                        fi
+                    fi
+                done
+            else
+                echo "Skipping collection ${dir}"
+            fi
+        done
+    done
+fi
+
 
 echo "All Done!!..."
 

--- a/scripts/assembly_converter/populate_assembly_converter_dir.sh
+++ b/scripts/assembly_converter/populate_assembly_converter_dir.sh
@@ -125,7 +125,7 @@ if [ "$do_verts" = true ]; then
                     then
                         file=`echo ${file_path} | xargs -n 1 basename | sed s/.gz//`
                     else
-                        echo "WARNING: Cannot find file for assembly '$assembly'"
+                        echo "INFO: Cannot find file for assembly '$assembly'"
                         continue
                     fi
                     if [ ! -f "${base_dest}/www/${dir}/$file" ]
@@ -220,7 +220,7 @@ if [ "$do_nonverts" = true ]; then
                             then
                                 file=`echo ${file_path} | xargs -n 1 basename | sed s/.gz//`
                             else
-                                echo "WARNING: Cannot find file for assembly '$assembly'"
+                                echo "INFO: Cannot find file for assembly '$assembly'"
                                 continue
                             fi
                             if [ ! -f "${base_dest}/${division}/${dir}/$file" ]
@@ -242,8 +242,11 @@ if [ "$do_nonverts" = true ]; then
     done
 fi
 
-
-echo "All Done!!..."
+if [[ "$do_verts" = true || "$do_nonverts" = true ]]; then
+    echo "All Done!!..."
+else
+    echo "Nothing done. Either '-V' and/or '-N' must be used."
+fi
 
 
 


### PR DESCRIPTION
## Description

Add the option to run `populate_assembly_converter_dir.sh` script for either _vertebrates_ or _non-vertebrates_

## Use case

As assembly files are generated separately for _vertebrates_ and _non-vertebrates_, this option will make possible to run `populate_assembly_converter_dir.sh` on only _vertebrates_ or _non-vertebrates_ in case files generation isn't completed for one of the two.

## Benefits

Gives more flexibility (and possibly speeds up) the overall release process as _assembly converter_ step doesn't have to wait for all the tools files to be generated.

## Possible Drawbacks

Either _vertebrates_ (`-V`) or _non-vertebrates_ (`-N`) options must be provided when running the script.

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [x] TravisCI passed on your branch
