### PR TITLE
ENSCORESW-3565: run HGNC parsing after RefSeq parsing

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_sources.json
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_sources.json
@@ -251,6 +251,6 @@
       "parser" : "HGNCParser",
       "file" : "https://www.genenames.org/cgi-bin/download?col=gd_hgnc_id&col=gd_app_sym&col=gd_app_name&col=gd_prev_sym&col=gd_aliases&col=gd_pub_eg_id&col=gd_pub_ensembl_id&col=gd_pub_refseq_ids&col=gd_ccds_ids&col=gd_lsdb_links&status=Approved&status_opt=2&where=&order_by=gd_app_sym_sort&format=text&limit=&hgnc_dbtag=on&submit=submit",
       "db" : "ccds",
-      "priority" : 2
+      "priority" : 3
     }
 ]


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Run HGNC parsing later in the pipeline

## Use case

HGNC parsing uses already loaded RefSeq xrefs to create mappings on the fly.
Recent changes to source parsing order mean that RefSeq and HGNC are now parsed at the same time.
The proposed change ensures all RefSeq_mRNA data has already been parsed when HGNC data is processed

## Benefits

All required dependencies for HGNC data are already loaded

## Possible Drawbacks

If other sources rely on having HGNC data loaded, that data will not be available.
It is not the case at the moment but something to watch out for if we add a new source.

## Testing

- [NA ] Have you added/modified unit tests to test the changes?
- [NA ] If so, do the tests pass?
- [NA ] Have you run the entire test suite and no regression was detected?
- [NA ] TravisCI passed on your branch
There are no test cases for the xref pipeline.
The whole pipeline has been re-run with the proposed configuration change and the expected xrefs have been loaded.

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
