### PR TITLE
Reduce Sample Data time/memory usage

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/SampleData_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/SampleData_conf.pm
@@ -158,22 +158,20 @@ sub pipeline_analyses {
                               maximum_gene_length => $self->o('maximum_gene_length'),
                            },
       -hive_capacity   => 50,
-      -batch_size      => 10,
       -flow_into        => {
                              '1' => ['RunDataChecks'],
-                             '-1' => ['GenerateSampleData_25GB'],
+                             '-1' => ['GenerateSampleData_mem'],
                            },
       -rc_name          => 'mem',
     },
     {
-      -logic_name       => 'GenerateSampleData_25GB',
+      -logic_name       => 'GenerateSampleData_mem',
       -module           => 'Bio::EnsEMBL::Production::Pipeline::SampleData::GenerateSampleData',
       -max_retry_count  => 1,
       -parameters      =>  {
                               maximum_gene_length => $self->o('maximum_gene_length'),
                            },
       -hive_capacity   => 50,
-      -batch_size      => 10,
       -flow_into        => {
                              '1' => ['RunDataChecks'],
                            },
@@ -218,7 +216,7 @@ sub resource_classes {
   
   return {
     %{$self->SUPER::resource_classes},
-    'mem_high'    => {'LSF' => '-q production-rh74 -M 25000 -R "rusage[mem=25000]"'},
+    'mem_high'    => {'LSF' => '-q production-rh74 -M 8000 -R "rusage[mem=8000]"'},
   }
 }
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/SampleData/GenerateSampleData.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/SampleData/GenerateSampleData.pm
@@ -62,11 +62,11 @@ sub run {
     my $gene_tree_adaptor = $compara_dba->get_GeneTreeAdaptor;
     my $good_gene_trees_sql = "SELECT root_id, tree_type, member_type, clusterset_id, gene_align_id, method_link_species_set_id, species_tree_root_id, stable_id, version, ref_root_id, NULL, NULL, NULL ".
                 "FROM gene_tree_root_attr a JOIN gene_tree_root r USING(root_id) ".
-                "WHERE a.taxonomic_coverage > 0.95 AND a.aln_percent_identity > 75 AND r.member_type = 'protein' and r.clusterset_id = 'default' and r.tree_type = 'tree';";
+                "WHERE a.taxonomic_coverage > 0.95 AND a.aln_percent_identity > 75 AND r.member_type = 'protein' and r.clusterset_id = 'default' and r.tree_type = 'tree' limit 500;";
     my $gene_tree_sth = $compara_dba->dbc->prepare($good_gene_trees_sql);
     $gene_tree_sth->execute;
     my $good_gene_trees = $gene_tree_adaptor->_objs_from_sth($gene_tree_sth);
-    $self->warning("Found " . scalar @$good_gene_trees . " 'good' gene trees\n") if $self->debug();
+    $self->warning("Found " . scalar @$good_gene_trees . " 'good' gene trees\n");
     # next, pick out genes from any tree that includes human (i.e. has a human ortholog) for vert only
     my $human_genome_db = $genome_db_adaptor->fetch_by_name_assembly('homo_sapiens') if $self->division() eq 'vertebrates';
     my @candidate_genes;
@@ -89,7 +89,7 @@ sub run {
     # Disconnect from the Compara db
     $compara_dba->dbc()->disconnect_if_idle();
     # now find a candidate with xrefs and good support
-    $self->warning("Found: " . scalar @candidate_genes . " genes for ".$species."\n") if $self->debug();
+    $self->warning("Found: " . scalar @candidate_genes . " genes for ".$species."\n");
     my %sample_transcripts;
     my $sample_transcript;
     TRANSCRIPT:foreach my $seq_member ( @candidate_genes ) {


### PR DESCRIPTION
## Description
The analysis that derives a 'good' example gene/transcript/location was taking hours and large (sometimes >16GB) amounts of memory. This is excessive - it's not important to get the absolute best example gene, we just need something that is in a decent-looking gene tree, and is preferably in RefSeq/UniProt. Rather than spend time optimising, we can just reduce the number of trees we look at in the first place - currently ~6000 trees are examined. Reducing that by an order of magnitude, by limiting the set of results to 500, cuts down both time and memory usage.

## Benefits
Pipeline runs faster, uses less memory.

## Possible Drawbacks
We do not guarantee that we choose the best possible gene, optimised for all our criteria.

## Testing
Run for a test species - new code took 37 mins and 2GB, rather than 2 hr 29 mins and 9GB. Different examples were chosen, but both were fine as sample entry points into the data.