### PR TITLE
Features/replace precalc md5

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProteinFeatures_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProteinFeatures_conf.pm
@@ -52,7 +52,7 @@ sub default_options {
    	run_interproscan        => 1,
 
     # A file with md5 sums of translations that are in the lookup service
-    md5_checksum_file => '/nfs/nobackup/interpro/ensembl_precalc/precalc_md5s',
+    md5_checksum_file => '/nfs/panda/ensembl/production/ensprod/precalc_md5s',
 
     # Allow the checksum loading to be skipped (not recommended)
     skip_checksum_loading => 0,

--- a/scripts/intepro/precalc_md5.sh
+++ b/scripts/intepro/precalc_md5.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+# Copyright [2016-2020] EMBL-European Bioinformatics Institute
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+SET NEWPAGE   NONE;
+SET PAGESIZE     0;
+SET LINESIZE  200;
+SET HEADING    OFF;
+SET FEEDBACK   OFF;
+SET TRIMSPOOL   ON;
+SET TRIMOUT     ON;
+SET WRAP       OFF;
+SET TAB        OFF;
+SET TERMOUT    OFF;
+SET ECHO       OFF;
+SET VERIFY     OFF;
+SET TIMING     OFF;
+SPOOL ipr_precalc_md5s
+select /*+ parallel */ md5 from uniparc.protein where upi < (select  /*+ parallel */ max(upi) from iprscan.mv_iprscan);
+SPOOL OFF


### PR DESCRIPTION
## Description

Avoid using /nfs/nobackup file system. 
Implement script to run precalc-md5 on our own, instead of a randomly generated one by Interpro team.

## Use case

Inteproscan

## Benefits

Can run our own script for precalc. Might speed up a little the Protein Features pipelines. 

## Possible Drawbacks

None

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
