### PR TITLE
Fix GFF3 tidying/validation in ftp dumping pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_vertebrates_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_vertebrates_conf.pm
@@ -43,16 +43,8 @@ sub default_options {
        # inherit other stuff from the base class
        %{ $self->SUPER::default_options() },
 
-#'exe_dir'       => '/nfs/panda/ensemblgenomes/production/compara/binaries/',
-       'gt_exe'       => '/nfs/software/ensembl/RHEL7/linuxbrew/Cellar/genometools/1.5.8/bin/gt',
-        # create BLAST databases, version 2.2.27+
-#'ncbiblast_exe' => $self->o('exe_dir').'ncbi-blast/makeblastdb',
        'ncbiblast_exe' => 'makeblastdb',
-        # convert DNA from fasta to 2bit format
-#'blat_exe' => $self->o('exe_dir').'faToTwoBit',
        'blat_exe' => 'faToTwoBit',
-       # Previous release FASTA DNA files location
-       'prev_rel_dir' => '/nfs/ensemblftp/PUBLIC/pub/',
 	};
 }
 


### PR DESCRIPTION
## Description
Pipeline config for vertbrate GFF3 tidying/validation was hard-coded to an out-dated version of 'gt' - and was consequently producing GFF3 with invalid phases. Remove this to use the latest version installed in the Ensembl software environment. (Also removed some old commented-out code, and the 'prev_rel_dir' parameter which was the same as in the parent config.)

## Benefits
Valid GFF3!

## Possible Drawbacks
Pipeline won't work if you have not configured the Ensembl software environment - but we have that as our standard practice.

## Testing
Not explicitly tested, but the non-vert config has been using the default 'gt' for many releases, and that works fine.