### PR TITLE
Add explicit disconnects in variant json dumps

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Search/VariationFetcher.pm
+++ b/modules/Bio/EnsEMBL/Production/Search/VariationFetcher.pm
@@ -77,6 +77,9 @@ sub fetch_variations_callback {
   $dba->dbc()->db_handle()->{mysql_use_result} = 1; # streaming
   my $h = $dba->dbc()->sql_helper();
 
+  $dba->dbc()->disconnect_if_idle();
+  $onto_dba->dbc()->disconnect_if_idle();
+
   # global data
   my $gwas = $self->_fetch_all_gwas($h);
   my $sources = $self->_fetch_all_sources($h);


### PR DESCRIPTION
## Description
Add explicit disconnects, so that long-running queries don't cause 'mysql has gone away' errors.

## Use case
This is a problem for release/102 dumping, so PR is against that branch - will replicate on release/103.

## Benefits
Dumps complete without timing out.

## Possible Drawbacks
None.

## Testing
Modified code run for sample long-running jobs - completed successfully.