### PR TITLE
RR ftp pipeline updates

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Assembly_Chain.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Assembly_Chain.pm
@@ -61,7 +61,7 @@ sub run {
   my ($self) = @_;
 
   my $file_type    = $self->param_required('file_type');
-  my $tools_dir    = $self->param_required('tools_dir');
+  my $web_dir      = $self->param_required('web_dir');
   my $species_name = $self->param_required('species_name');
   my $chain_dir    = $self->param_required('chain_dir');
 
@@ -71,9 +71,6 @@ sub run {
  
   if (scalar(@{$liftovers})) {
     path($chain_dir)->mkpath();
-
-    my $tools_chain_dir = catdir($tools_dir, $species_name);
-    path($tools_chain_dir)->mkpath();
 
     $self->param('ucsc_name_cache', {});
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Base.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Base.pm
@@ -30,11 +30,12 @@ sub param_defaults {
   return {
     %{$self->SUPER::param_defaults},
     db_type             => 'core',
-    species_dirname     => 'Species',
-    timestamped_dirname => 'Timestamped',
-    tools_dirname       => 'Tools',
+    species_dirname     => 'species',
+    timestamped_dirname => 'timestamped',
+    web_dirname         => 'web',
     genome_dirname      => 'genome',
     geneset_dirname     => 'geneset',
+    rnaseq_dirname      => 'rnaseq',
   };
 }
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Base.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Base.pm
@@ -40,9 +40,9 @@ sub param_defaults {
 }
 
 sub dba {
-  my ($self) = @_;
-  my $species = $self->param_required('species');
-  my $db_type = $self->param_required('db_type');
+  my ($self, $species, $db_type) = @_;
+  $species = $self->param_required('species') unless defined $species;
+  $db_type = $self->param_required('db_type') unless defined $db_type;
 
   my $dba = Bio::EnsEMBL::Registry->get_DBAdaptor($species, $db_type);
   unless (defined $dba) {
@@ -82,22 +82,15 @@ sub species_name {
   $self->throw("Missing dba parameter: species_name method") unless defined $dba;
 
   my $mca = $dba->get_adaptor("MetaContainer");
-  my $species_name = $mca->single_value_by_key('species.strain_group');
-  if (! defined $species_name or $species_name eq '') {
-    $species_name = $mca->single_value_by_key('species.db_name');
-    if (! defined $species_name or $species_name eq '') {
-      $species_name = $mca->single_value_by_key('species.display_name');
-      if (defined $species_name and $species_name ne '') {
-        $species_name =~ s/^([\w ]+) [\-\(].+/$1/;
-        $species_name =~ s/ /_/g;
-      } else {
-        $species_name = $mca->single_value_by_key('species.production_name');
-      }
-    }
+  my $species_name = $mca->single_value_by_key('species.display_name');
+  if (defined $species_name and $species_name ne '') {
+    $species_name =~ s/^([\w ]+) [\-\(].+/$1/;
+    $species_name =~ s/ /_/g;
+  } else {
+    $self->throw("No species.display_name");
   }
-  $species_name =~ s/_?gca_?.+$//;
 
-  return ucfirst($species_name);
+  return $species_name;
 }
 
 sub repeat_mask_date {

--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Base_Filetype.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Base_Filetype.pm
@@ -112,6 +112,7 @@ sub filenames {
     $dir = $self->param('output_dir');
   }
   path($dir)->mkpath();
+  path($dir)->chmod("g+w");
 
   my %filenames;
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/DirectoryPaths.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/DirectoryPaths.pm
@@ -41,19 +41,6 @@ sub run {
   my ($output_dir, $timestamped_dir, $web_dir, $ftp_dir) =
     $self->directories($data_category);
 
-  if (! -e $output_dir) {
-    path($output_dir)->mkpath();
-    path($output_dir)->chmod("g+w");
-  }
-  if (! -e $timestamped_dir) {
-    path($timestamped_dir)->mkpath();
-    path($timestamped_dir)->chmod("g+w");
-  }
-  if (! -e $web_dir) {
-    path($web_dir)->mkpath();
-    path($web_dir)->chmod("g+w");
-  }
-
   $self->param('output_dir', $output_dir);
   $self->param('timestamped_dir', $timestamped_dir);
   $self->param('web_dir', $web_dir);

--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/DirectoryPaths.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/DirectoryPaths.pm
@@ -29,7 +29,12 @@ use Path::Tiny;
 sub run {
   my ($self) = @_;
 
-  my $data_category = $self->param_required('data_category');
+  my $analysis_types = $self->param_required('analysis_types');
+  my $data_category  = $self->param_required('data_category');
+
+  if (scalar(@$analysis_types) == 0) {
+    $self->complete_early("No $data_category analyses specified");
+  }
 
   my $dba = $self->dba;
   $self->param('species_name', $self->species_name($dba));
@@ -65,7 +70,7 @@ sub write_output {
     $output{'geneset'} = $self->param_required('geneset');
   }
 
-  $self->dataflow_output_id(\%output, 1);
+  $self->dataflow_output_id(\%output, 3);
 }
 
 sub directories {

--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_FASTA.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_FASTA.pm
@@ -180,7 +180,7 @@ sub header {
 sub blast_index {
   my ($self, $filename, $dbtype) = @_;
 
-  my $tools_dir = $self->param_required('tools_dir');
+  my $web_dir = $self->param_required('web_dir');
   my $blast_dirname = $self->param_required('blast_dirname');
   my $file_type = $self->param_required('file_type');
 
@@ -190,7 +190,7 @@ sub blast_index {
   $basename =~ s/\-[^-]+(\-[^-]+\.$file_type)$/$1/;
 
   my $blast_filename = catdir(
-    $tools_dir,
+    $web_dir,
     $blast_dirname,
     'genes',
     $basename

--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_FASTA.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_FASTA.pm
@@ -37,7 +37,7 @@ sub param_defaults {
     data_types      => ['cdna', 'cds', 'pep'],
     file_type       => 'fa',
     chunk_size      => 10000,
-    line_width      => 80,
+    line_width      => 60,
     blast_index     => 0,
     blastdb_exe     => 'makeblastdb',
     blast_dirname   => 'ncbi_blast',

--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Genome_FASTA.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Genome_FASTA.pm
@@ -216,11 +216,11 @@ sub hardmask {
 sub blast_index {
   my ($self, $filename, $dbtype) = @_;
 
-  my $tools_dir = $self->param_required('tools_dir');
+  my $web_dir = $self->param_required('web_dir');
   my $blast_dirname = $self->param_required('blast_dirname');
 
   my $blast_filename = catdir(
-    $tools_dir,
+    $web_dir,
     $blast_dirname,
     'genomes',
     path($filename)->basename

--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Metadata_JSON.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Metadata_JSON.pm
@@ -1,0 +1,120 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::Production::Pipeline::FileDump::Metadata_JSON;
+
+use strict;
+use warnings;
+use feature 'say';
+use base qw(Bio::EnsEMBL::Production::Pipeline::FileDump::Base_Filetype);
+
+use JSON;
+use Path::Tiny;
+
+sub param_defaults {
+  my ($self) = @_;
+
+  return {
+    %{$self->SUPER::param_defaults},
+    data_type => 'species_metadata',
+    file_type => 'json',
+  };
+}
+
+sub fetch_input {
+  my ($self) = @_;
+
+  my $dump_dir  = $self->param_required('dump_dir');
+  my $data_type = $self->param_required('data_type');
+  my $file_type = $self->param_required('file_type');
+
+  my $filename = $self->generate_custom_filename(
+    $dump_dir, $data_type, $file_type
+  );
+
+  $self->param('filename', $filename);
+}
+
+sub run {
+  my ($self) = @_;
+
+  my $mdba = $self->dba('multi', 'metadata');
+  my $dria = $mdba->get_adaptor('DataReleaseInfo');
+  my $gia = $mdba->get_adaptor('GenomeInfo');
+  my $helper = $mdba->dbc->sql_helper;
+
+  my $dri = $dria->fetch_current_ensembl_release;
+  $gia->data_release($dri);
+
+  my $sql = qq/
+    SELECT MIN(release_date) FROM
+      genome INNER JOIN
+      organism USING (organism_id) INNER JOIN
+      data_release USING (data_release_id)
+    WHERE organism_id = ?
+  /;
+
+  my @metadata;
+
+  my $genomes = $gia->fetch_all;
+  foreach my $genome (@$genomes) {
+    my $production_name = $genome->name;
+    my $dba = $self->dba($production_name, 'core');
+
+    my $species_name = $self->species_name($dba);
+    $species_name =~ s/_/ /g;
+
+    my $strain = $genome->organism->strain;
+    $strain = undef if defined $strain && $strain eq 'reference';
+
+    my $mca = $dba->get_adaptor('MetaContainer');
+    my $common_name = $mca->single_value_by_key('species.common_name');
+    $common_name = ucfirst($common_name) if defined $common_name;
+
+    my $geneset = $self->geneset($dba);
+
+    my $release_date = $helper->execute_single_result(
+      -SQL => $sql,
+      -PARAMS => [$genome->organism->dbID]
+    );
+
+    $dba->dbc->disconnect_if_idle();
+
+    push @metadata, {
+      species => $species_name,
+      strain => $strain,
+      common_name => $common_name,
+      ensembl_production_name  => $production_name,
+      taxonomy_id => $genome->organism->taxonomy_id,
+      assembly_accession => $genome->assembly_accession,
+      assembly_name => $genome->assembly_name,
+      geneset => $geneset,
+      release_date => $release_date
+    };
+  }
+
+  @metadata = sort { $$a{'species'} cmp $$b{'species'} } @metadata;
+  my $json = JSON->new->canonical->pretty->encode(\@metadata);
+
+  my $filename = $self->param_required('filename');
+  path($filename)->spew($json);
+  path($filename)->chmod("g+w");
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/README.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/README.pm
@@ -36,12 +36,12 @@ sub param_defaults {
 
 sub run {
   my ($self) = @_;
-  my $root_readmes = $self->param_required('root_readmes');
-  my $gene_related = $self->param_required('gene_related');
-  my $output_dir   = $self->param_required('output_dir');
+  my $root_readmes  = $self->param_required('root_readmes');
+  my $data_category = $self->param_required('data_category');
+  my $output_dir    = $self->param_required('output_dir');
 
   my $relative_dir;
-  if ($gene_related) {
+  if ($data_category eq 'geneset') {
     $relative_dir = catdir('..', '..', '..', '..', '..');
   } else {
     $relative_dir= catdir('..', '..', '..', '..');

--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/README.txt
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/README.txt
@@ -9,7 +9,7 @@ The structure of the FTP directory is show below.
 Square brackets indicate directories or files that are not available
 for all species.
 
-Species
+species
   |-- <species>
       |-- <assembly>
           |-- geneset

--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/RNASeq_Exists.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/RNASeq_Exists.pm
@@ -52,7 +52,12 @@ sub run {
 
       foreach my $path (@paths){
         if (! -e $path) {
-          push @missing, $path;
+          # .csi files are permitted in place of .bai files, but
+          # this is not encoded in the core API.
+          (my $new_path = $path) =~ s/bai$/csi/;
+          if (! -e $new_path) {
+            push @missing, $path;
+          }
         }
       }
     }

--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/RNASeq_Exists.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/RNASeq_Exists.pm
@@ -1,0 +1,76 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::Production::Pipeline::FileDump::RNASeq_Exists;
+
+use strict;
+use warnings;
+
+use base qw(Bio::EnsEMBL::Production::Pipeline::FileDump::Base);
+
+use File::Spec::Functions qw/catdir/;
+
+sub run {
+  my ($self) = @_;
+
+  my $output_dir = $self->param_required('output_dir');
+  my $species    = $self->param_required('species');
+
+  my $dba = Bio::EnsEMBL::Registry->get_DBAdaptor($species, 'rnaseq');
+  my $rnaseq_exists = defined $dba;
+
+  if ($rnaseq_exists) {
+    my $dfa = $dba->get_adaptor('DataFile');
+    my $data_files = $dfa->fetch_all;
+
+    my @missing;
+    foreach my $data_file (@$data_files) {
+      my $name = $data_file->name;
+      my @paths;
+      
+      my $extensions = $dfa->DataFile_to_extensions($data_file);
+      foreach my $ext (@{$extensions}) {
+        my $filename = catdir($output_dir, "$name.$ext");
+        push(@paths, $filename);
+      }
+
+      foreach my $path (@paths){
+        if (! -e $path) {
+          push @missing, $path;
+        }
+      }
+    }
+    if (scalar(@missing)) {
+      $self->throw('Missing data files: '.join(',', @missing));
+    }
+  }
+
+  $self->param('rnaseq_exists', $rnaseq_exists);
+}
+
+sub write_output {
+  my ($self) = @_;
+  my $rnaseq_exists = $self->param_required('rnaseq_exists');
+
+  if ($rnaseq_exists) {
+    $self->dataflow_output_id({}, 2);
+  }
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Symlink.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Symlink.pm
@@ -30,7 +30,7 @@ sub run {
   my ($self) = @_;
 
   my $dump_dir        = $self->param_required('dump_dir');
-  my $gene_related    = $self->param_required('gene_related');
+  my $data_category   = $self->param_required('data_category');
   my $output_dir      = $self->param_required('output_dir');
   my $output_filename = $self->param_required('output_filename');
 
@@ -40,7 +40,7 @@ sub run {
   }
 
   my $relative_dir;
-  if ($gene_related) {
+  if ($data_category eq 'geneset') {
     $relative_dir = catdir('..', '..', '..', '..', '..');
   } else {
     $relative_dir = catdir('..', '..', '..', '..');

--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Symlink_RNASeq.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Symlink_RNASeq.pm
@@ -1,0 +1,58 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::Production::Pipeline::FileDump::Symlink_RNASeq;
+
+use strict;
+use warnings;
+use base ('Bio::EnsEMBL::Production::Pipeline::FileDump::Base');
+
+use File::Spec::Functions qw/catdir/;
+use Path::Tiny;
+
+sub run {
+  my ($self) = @_;
+
+  my $dump_dir   = $self->param_required('dump_dir');
+  my $output_dir = $self->param_required('output_dir');
+  my $web_dir    = $self->param_required('web_dir');
+
+  if (-e $output_dir) {
+    my $dba = $self->dba;
+    my $mca = $dba->get_adaptor('MetaContainer');
+    my $production_name = $mca->get_production_name;
+    my $assembly_default = $mca->single_value_by_key('assembly.default');
+
+    my $data_files_dir = catdir(
+      $web_dir,
+      'data_files',
+      $production_name,
+      $assembly_default
+    );
+    path($data_files_dir)->mkpath();
+    path($data_files_dir)->chmod("g+w");
+
+    my $relative_dir = catdir('..', '..', '..', '..');
+    $output_dir =~ s/$dump_dir/$relative_dir/;
+
+    $self->create_symlink($output_dir, catdir($data_files_dir, 'rnaseq'));
+  }
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Xref_TSV.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Xref_TSV.pm
@@ -111,7 +111,7 @@ sub print_xrefs {
           my $xref_id    = $xref->primary_id;
           my $xref_label = $xref->display_id;
           my $xref_db    = $xref->db_display_name;
-          my $xref_desc  = $xref->description;
+          my $xref_desc  = $xref->description || '';
           my $info_type  = $xref->info_type;
 
           my $ensembl_identity = '';

--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Xref_TSV.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Xref_TSV.pm
@@ -70,6 +70,27 @@ sub run {
   }
 }
 
+sub timestamp {
+  my ($self, $dba) = @_;
+
+  $self->throw("Missing dba parameter: timestamp method") unless defined $dba;
+
+  my $sql = qq/
+    SELECT MAX(DATE_FORMAT(update_time, "%Y%m%d")) FROM
+      information_schema.tables
+    WHERE
+      table_schema = database() AND
+      table_name LIKE "%xref"
+  /;
+  my $result = $dba->dbc->sql_helper->execute_simple(-SQL => $sql);
+
+  if (scalar(@$result)) {
+    return $result->[0];
+  } else {
+    return Time::Piece->new->date("");
+  }
+}
+
 sub print_header {
   my ($self, $fh) = @_;
   

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FileDumpCore_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FileDumpCore_conf.pm
@@ -40,6 +40,9 @@ sub default_options {
       'Geneset_GTF',
       'Xref_TSV',
     ],
+    rnaseq_types => [
+      'Symlink_RNASeq',
+    ],
 
     blast_index => 1,
 	};

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FileDumpCore_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FileDumpCore_conf.pm
@@ -41,8 +41,10 @@ sub default_options {
       'Xref_TSV',
     ],
     rnaseq_types => [
-      'Symlink_RNASeq',
+      'RNASeq_Exists',
     ],
+
+    dump_metadata => 1,
 
     blast_index => 1,
 	};

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FileDumpCore_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FileDumpCore_conf.pm
@@ -28,8 +28,6 @@ sub default_options {
   return {
     %{$self->SUPER::default_options},
 
-    dump_dir => '/hps/nobackup2/production/ensembl/ensprod/release_dumps',
-
     genome_types => [
       'Assembly_Chain',
       'Chromosome_TSV',

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FileDump_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FileDump_conf.pm
@@ -44,12 +44,10 @@ sub default_options {
     genome_types  => [], # Possible values: 'Assembly_Chain', 'Chromosome_TSV', 'Genome_FASTA'
     geneset_types => [], # Possible values: 'Geneset_EMBL', 'Geneset_FASTA', 'Geneset_GFF3', 'Geneset_GTF', 'Xref_TSV'
     rnaseq_types  => [], # Possible values: 'Symlink_RNASeq'
-    mysql_types   => ['MySQL_TXT'],
 
-    dump_mysql => 0,
-
-    overwrite => 0,
-
+    dump_metadata  => 0,
+    dump_mysql     => 0,
+    overwrite      => 0,
     per_chromosome => 0,
 
     # External programs
@@ -90,7 +88,11 @@ sub pipeline_wide_parameters {
   my ($self) = @_;
   return {
     %{$self->SUPER::pipeline_wide_parameters},
-    overwrite => $self->o('overwrite'),
+    dump_dir      => $self->o('dump_dir'),
+    ftp_root      => $self->o('ftp_root'),
+    dump_metadata => $self->o('dump_metadata'),
+    dump_mysql    => $self->o('dump_mysql'),
+    overwrite     => $self->o('overwrite'),
   };
 }
 
@@ -117,7 +119,11 @@ sub pipeline_analyses {
       -input_ids         => [ {} ],
       -parameters        => {},
       -flow_into         => {
-                              '1' => ['DbFactory'],
+                              '1' => WHEN('#dump_metadata#' =>
+                                       ['Metadata_JSON', 'DbFactory'],
+                                     ELSE
+                                       ['DbFactory']
+                                     )
                             }
     },
     {
@@ -132,26 +138,14 @@ sub pipeline_analyses {
                               run_all      => $self->o('run_all'),
                               dbname       => $self->o('dbname'),
                               meta_filters => $self->o('meta_filters'),
-                              dump_mysql   => $self->o('dump_mysql'),
                             },
       -flow_into         => {
                               '2' => WHEN('#dump_mysql#' =>
-                                       ['MySQLFactory'],
+                                       ['MySQL_TXT', 'SpeciesFactory'],
                                      ELSE
                                        ['SpeciesFactory']
                                      )
                              },
-    },
-    {
-      -logic_name        => 'MySQLFactory',
-      -module            => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
-      -max_retry_count   => 1,
-      -analysis_capacity => 20,
-      -parameters        => {},
-      -flow_into         => {
-                              '1->A' => $self->o('mysql_types'),
-                              'A->1' => ['SpeciesFactory']
-                            },
     },
     {
       -logic_name        => 'SpeciesFactory',
@@ -163,7 +157,7 @@ sub pipeline_analyses {
                               '2' => [
                                 'GenomeDirectoryPaths',
                                 'GenesetDirectoryPaths',
-                                'RNASeqDirectoryPaths'
+                                'RNASeqDirectoryPaths',
                               ],
                             }
     },
@@ -173,13 +167,12 @@ sub pipeline_analyses {
       -max_retry_count   => 1,
       -analysis_capacity => 20,
       -parameters        => {
-                              dump_dir      => $self->o('dump_dir'),
-                              ftp_root      => $self->o('ftp_root'),
-                              data_category => 'genome',
+                              data_category  => 'genome',
+                              analysis_types => $self->o('genome_types'),
                             },
       -flow_into         => {
-                              '1->A' => $self->o('genome_types'),
-                              'A->1' => ['README']
+                              '3->A' => $self->o('genome_types'),
+                              'A->3' => ['README']
                             },
     },
     {
@@ -188,13 +181,12 @@ sub pipeline_analyses {
       -max_retry_count   => 1,
       -analysis_capacity => 20,
       -parameters        => {
-                              dump_dir      => $self->o('dump_dir'),
-                              ftp_root      => $self->o('ftp_root'),
-                              data_category => 'geneset',
+                              data_category  => 'geneset',
+                              analysis_types => $self->o('geneset_types'),
                             },
       -flow_into         => {
-                              '1->A' => $self->o('geneset_types'),
-                              'A->1' => ['README']
+                              '3->A' => $self->o('geneset_types'),
+                              'A->3' => ['README']
                             },
     },
     {
@@ -203,12 +195,33 @@ sub pipeline_analyses {
       -max_retry_count   => 1,
       -analysis_capacity => 20,
       -parameters        => {
-                              dump_dir      => $self->o('dump_dir'),
-                              ftp_root      => $self->o('ftp_root'),
-                              data_category => 'rnaseq',
+                              data_category  => 'rnaseq',
+                              analysis_types => $self->o('rnaseq_types'),
                             },
       -flow_into         => {
-                              '1' => $self->o('rnaseq_types'),
+                              '3' => $self->o('rnaseq_types'),
+                            }
+    },
+    {
+      -logic_name        => 'Metadata_JSON',
+      -module            => 'Bio::EnsEMBL::Production::Pipeline::FileDump::Metadata_JSON',
+      -max_retry_count   => 1,
+      -parameters        => {},
+	    -rc_name           => '1GB',
+      -flow_into         => {
+                              '2' => WHEN('defined #ftp_root#' => ['Sync_Metadata'])
+                            }
+    },
+    {
+      -logic_name        => 'MySQL_TXT',
+      -module            => 'Bio::EnsEMBL::Production::Pipeline::FileDump::MySQL_TXT',
+      -max_retry_count   => 1,
+      -hive_capacity     => 10,
+      -parameters        => {},
+	    -rc_name           => '1GB',
+      -flow_into         => {
+                              '2->A' => ['MySQL_Compress'],
+                              'A->3' => ['Checksum']
                             },
     },
     {
@@ -329,17 +342,15 @@ sub pipeline_analyses {
                             },
     },
     {
-      -logic_name        => 'MySQL_TXT',
-      -module            => 'Bio::EnsEMBL::Production::Pipeline::FileDump::MySQL_TXT',
+      -logic_name        => 'RNASeq_Exists',
+      -module            => 'Bio::EnsEMBL::Production::Pipeline::FileDump::RNASeq_Exists',
       -max_retry_count   => 1,
       -hive_capacity     => 10,
-      -parameters        => {
-                              dump_dir => $self->o('dump_dir'),
-                            },
+      -parameters        => {},
 	    -rc_name           => '1GB',
       -flow_into         => {
-                              '2->A' => ['MySQL_Compress'],
-                              'A->3' => ['Checksum']
+                              '2->A' => ['Symlink_RNASeq'],
+                              'A->2' => ['Verify_Unzipped']
                             },
     },
     {
@@ -502,9 +513,7 @@ sub pipeline_analyses {
       -max_retry_count   => 1,
       -analysis_capacity => 10,
       -batch_size        => 10,
-      -parameters        => {
-                              dump_dir => $self->o('dump_dir'),
-                            },
+      -parameters        => {},
     },
     {
       -logic_name        => 'Symlink_RNASeq',
@@ -512,9 +521,7 @@ sub pipeline_analyses {
       -max_retry_count   => 1,
       -analysis_capacity => 10,
       -batch_size        => 10,
-      -parameters        => {
-                              dump_dir => $self->o('dump_dir'),
-                            },
+      -parameters        => {},
     },
     {
       -logic_name        => 'Symlink_Xref_TSV',
@@ -522,9 +529,7 @@ sub pipeline_analyses {
       -max_retry_count   => 1,
       -analysis_capacity => 10,
       -batch_size        => 10,
-      -parameters        => {
-                              dump_dir => $self->o('dump_dir'),
-                            },
+      -parameters        => {},
     },
     {
       -logic_name        => 'README',
@@ -554,6 +559,17 @@ sub pipeline_analyses {
       -flow_into         => WHEN('defined #ftp_dir#' => ['Sync'])
     },
     {
+      -logic_name        => 'Verify_Unzipped',
+      -module            => 'Bio::EnsEMBL::Production::Pipeline::FileDump::Verify',
+      -max_retry_count   => 1,
+      -analysis_capacity => 10,
+      -batch_size        => 10,
+      -parameters        => {
+                              check_unzipped => 0,
+                            },
+      -flow_into         => WHEN('defined #ftp_dir#' => ['Sync'])
+    },
+    {
       -logic_name        => 'Sync',
       -module            => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
       -max_retry_count   => 1,
@@ -561,6 +577,16 @@ sub pipeline_analyses {
       -batch_size        => 10,
       -parameters        => {
                               cmd => 'mkdir -p #ftp_dir#; rsync -aLW #output_dir#/ #ftp_dir#',
+                            },
+    },
+    {
+      -logic_name        => 'Sync_Metadata',
+      -module            => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+      -max_retry_count   => 1,
+      -analysis_capacity => 10,
+      -batch_size        => 10,
+      -parameters        => {
+                              cmd => 'rsync -aLW #output_filename# #ftp_root#',
                             },
     },
   ];

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FileDump_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FileDump_conf.pm
@@ -164,32 +164,32 @@ sub pipeline_analyses {
     },
     {
       -logic_name        => 'GenomeFactory',
-      -module            => 'Bio::EnsEMBL::Production::Pipeline::FileDump::DumpFactory',
+      -module            => 'Bio::EnsEMBL::Production::Pipeline::FileDump::DirectoryPaths',
       -max_retry_count   => 1,
       -analysis_capacity => 20,
       -parameters        => {
-                              dump_dir     => $self->o('dump_dir'),
-                              ftp_root     => $self->o('ftp_root'),
-                              gene_related => 0,
+                              dump_dir      => $self->o('dump_dir'),
+                              ftp_root      => $self->o('ftp_root'),
+                              data_category => 'genome',
                             },
       -flow_into         => {
-                              '2->A' => $self->o('genome_types'),
-                              'A->2' => ['README']
+                              '1->A' => $self->o('genome_types'),
+                              'A->1' => ['README']
                             },
     },
     {
       -logic_name        => 'GenesetFactory',
-      -module            => 'Bio::EnsEMBL::Production::Pipeline::FileDump::DumpFactory',
+      -module            => 'Bio::EnsEMBL::Production::Pipeline::FileDump::DirectoryPaths',
       -max_retry_count   => 1,
       -analysis_capacity => 20,
       -parameters        => {
-                              dump_dir     => $self->o('dump_dir'),
-                              ftp_root     => $self->o('ftp_root'),
-                              gene_related => 1,
+                              dump_dir      => $self->o('dump_dir'),
+                              ftp_root      => $self->o('ftp_root'),
+                              data_category => 'geneset',
                             },
       -flow_into         => {
-                              '2->A' => $self->o('geneset_types'),
-                              'A->2' => ['README']
+                              '1->A' => $self->o('geneset_types'),
+                              'A->1' => ['README']
                             },
     },
     {


### PR DESCRIPTION
## Description
Some modifications for the Rapid Release ftp pipeline:
- restrict xref timestamp to xref-related tables
- refactor directory creation code - it was based on data being either 'genome' or 'geneset' related, but we have 'rnaseq' now, and will have others in future, so create the concept of a 'data_category' to capture this in an extensible way.
- set line width for geneset FASTA files to 60.
- presence of rnaseq files is checked, and symlinked directory structure created for web
- new json file for reporting species, based on the 'is_current' release in the metadata db