### PR TITLE
Added release parameter to ensembl_genomes_release.

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/JSON/DumpGenomeJson.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/JSON/DumpGenomeJson.pm
@@ -91,7 +91,7 @@ sub write_json {
   my $genome_dba =
     $self->param('metadata_dba')->get_GenomeInfoAdaptor();
   if ($compara_name ne 'multi') {
-    $genome_dba->set_ensembl_genomes_release();
+        $genome_dba->set_ensembl_genomes_release($self->param('release'));
   }
   my $mds = $genome_dba->fetch_by_name($self->production_name());
   my $md;


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Description

Json dumps not settings release param causes the script to us the "is_current", which can have unattended side effects. 

## Use case

FTP dumps json part. 

## Benefits

Can use whatever release number instead of `is_current` one. 

## Possible Drawbacks

None

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
