### PR TITLE
Fix typo in AddFamilyMembers.pm

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/LoadFamily/AddFamilyMembers.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/LoadFamily/AddFamilyMembers.pm
@@ -109,7 +109,7 @@ sub run {
       Bio::EnsEMBL::Compara::GeneMember->new_from_Gene(
         -GENE          => $gene,
         -GENOME_DB     => $genome_db,
-        -BIOTYPE_GROUP => $gene->get_Biotype->biotype_group();
+        -BIOTYPE_GROUP => $gene->get_Biotype->biotype_group()
       );
     # If there are duplicate stable IDs, trap fatal error from compara
     # method, so we can skip it and carry on with others.


### PR DESCRIPTION
Fix typo that upon pipeline creation (`init_pipeline.pl`) would lead to the following error:
```
The runnable module 'Bio::EnsEMBL::Production::Pipeline::LoadFamily::AddFamilyMembers' cannot be loaded or compiled:
syntax error at [...]/ensembl-production/modules/Bio/EnsEMBL/Production/Pipeline/LoadFamily/AddFamilyMembers.pm line 112, near ");"
Global symbol "$gene_member" requires explicit package name at [...]/ensembl-production/modules/Bio/EnsEMBL/Production/Pipeline/LoadFamily/AddFamilyMembers.pm line 117.
```