### PR TITLE
Further updates to RR ftp pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Base.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Base.pm
@@ -24,6 +24,8 @@ use warnings;
 use feature 'say';
 use base ('Bio::EnsEMBL::Hive::Process');
 
+use File::Spec::Functions qw/catdir splitdir/;
+
 sub param_defaults {
   my ($self) = @_;
 
@@ -241,6 +243,24 @@ sub create_symlink {
       $self->throw("Failed to create symlink from $from to $to");
     }
   }
+}
+
+sub repo_location {
+  my ($self) = @_;
+
+  my $repo_name = 'ensembl-production';
+
+  foreach my $location (@INC) {
+    my @dirs = splitdir($location);
+    if (scalar(@dirs) >= 2) {
+      if ($dirs[-2] eq $repo_name) {
+        pop @dirs;
+        return catdir(@dirs);
+      }
+    }
+  }
+
+  die "$repo_name was not found in \@INC:\n" . join("\n", @INC);
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/README.txt
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/README.txt
@@ -14,7 +14,8 @@ species
       |-- <assembly>
           |-- geneset
               |-- <geneset>
-                  |-- README
+                  |-- md5sum.txt
+                  |-- README.txt
                   |-- <species>-<assembly>-<geneset>-cdna.fa.gz
                   |-- <species>-<assembly>-<geneset>-cds.fa.gz
                   |-- <species>-<assembly>-<geneset>-genes.embl.gz
@@ -23,7 +24,8 @@ species
                   |-- <species>-<assembly>-<geneset>-pep.fa.gz
                   |-- <species>-<assembly>-<geneset>-xref.tsv.gz
           |-- genome
-              |-- README
+              |-- md5sum.txt
+              |-- README.txt
               |-- [assembly_mapping]
                   |-- *.chain.gz
               |-- [<species>-<assembly>-chromosomes.tsv.gz]
@@ -31,10 +33,12 @@ species
               |-- <species>-<assembly>-softmasked.fa.gz
               |-- <species>-<assembly>-unmasked.fa.gz
           |-- [rnaseq]
-              |-- README
+              |-- md5sum.txt
+              |-- README.txt
               |-- *.bam
-              |-- *.bam.bai
+              |-- [*.bam.bai]
               |-- *.bam.bw
+              |-- [*.bam.csi]
 
 
 ========================================================================

--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/RNASeq_Exists.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/RNASeq_Exists.pm
@@ -66,6 +66,18 @@ sub run {
     }
   }
 
+  # Ensure checksum and README filenames are consistent.
+  my $md5sum_to_fix = catdir($output_dir, 'md5sum.txt.1');
+  my $md5sum = catdir($output_dir, 'md5sum.txt');
+  if (-e $md5sum_to_fix) {
+    path($md5sum_to_fix)->move($md5sum);
+  }
+  my $readme_to_fix = catdir($output_dir, 'README.1');
+  my $readme = catdir($output_dir, 'README.txt');
+  if (-e $readme_to_fix) {
+    path($readme_to_fix)->move($readme);
+  }
+
   $self->param('rnaseq_exists', $rnaseq_exists);
 }
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/RNASeq_Exists.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/RNASeq_Exists.pm
@@ -25,6 +25,7 @@ use warnings;
 use base qw(Bio::EnsEMBL::Production::Pipeline::FileDump::Base);
 
 use File::Spec::Functions qw/catdir/;
+use Path::Tiny;
 
 sub run {
   my ($self) = @_;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Xref_TSV.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Xref_TSV.pm
@@ -106,12 +106,13 @@ sub print_header {
 sub print_xrefs {
   my ($self, $fh, $genes, $external_dbs) = @_;
 
-  my %xrefs;
-
   while (my $gene = shift @{$genes}) {
+    my $g_id = $gene->stable_id;
+    my %xrefs;
+
     foreach my $external_db (@$external_dbs) {
       my $xref_list = $gene->get_all_DBEntries($external_db);
-      push @{$xrefs{$gene->stable_id}{'-'}{'-'}}, @$xref_list;
+      push @{$xrefs{'-'}{'-'}}, @$xref_list;
     }
 
     my $transcripts = $gene->get_all_Transcripts;
@@ -120,15 +121,12 @@ sub print_xrefs {
 
       foreach my $external_db (@$external_dbs) {
         my $xref_list = $transcript->get_all_DBLinks($external_db);
-        push @{$xrefs{$gene->stable_id}{$transcript->stable_id}{$tn_id}}, @$xref_list;
+        push @{$xrefs{$transcript->stable_id}{$tn_id}}, @$xref_list;
       }
     }
-  }
-
-  foreach my $g_id (sort keys %xrefs) {
-    foreach my $tt_id (sort keys %{$xrefs{$g_id}}) {
-      foreach my $tn_id (sort keys %{$xrefs{$g_id}{$tt_id}}) {
-        foreach my $xref (sort {$a->primary_id cmp $b->primary_id} @{$xrefs{$g_id}{$tt_id}{$tn_id}}) {
+    foreach my $tt_id (sort keys %xrefs) {
+      foreach my $tn_id (sort keys %{$xrefs{$tt_id}}) {
+        foreach my $xref (sort {$a->primary_id cmp $b->primary_id} @{$xrefs{$tt_id}{$tn_id}}) {
           my $xref_id    = $xref->primary_id;
           my $xref_label = $xref->display_id;
           my $xref_db    = $xref->db_display_name;


### PR DESCRIPTION
## Description
A collection of modest updates:
- metadata report now uses taxonomy db for species names, as connecting to core db was problematic
- xref dumping is more memory-efficient
- checksum and readme files for rnaseq are consistent (no ".1" suffix)
- README file is stored in a single location on the public ftp, and symlinks are created in all geneset and genome sub-directories

## Testing
Modified pipeline/modules run successfully.
