### PR TITLE
GFF3 dump - standalone fix

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/GFF3/DumpFile.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/GFF3/DumpFile.pm
@@ -159,8 +159,8 @@ sub run {
 
   $self->info("Dumping GFF3 README for %s", $self->param('species'));
   $self->_create_README();
-  $self->core_dbc()->disconnect_if_idle();
-  $self->hive_dbc()->disconnect_if_idle();
+  $self->core_dbc()->disconnect_if_idle() if defined $self->core_dbc;
+  $self->hive_dbc()->disconnect_if_idle() if defined $self->hive_dbc;
 }
 
 sub print_to_file {


### PR DESCRIPTION
## Description
The module for dumping GFF3 was failing in standalone mode, because it was expecting a hive database; check if such exists before trying to run a method against it.