### PR TITLE
RR file dump pipeline sends emails about missing RNA-seq

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/RNASeq_Exists.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/RNASeq_Exists.pm
@@ -40,7 +40,7 @@ sub run {
     my $dfa = $dba->get_adaptor('DataFile');
     my $data_files = $dfa->fetch_all;
 
-    my @missing;
+    my @missing = ();
     foreach my $data_file (@$data_files) {
       my $name = $data_file->name;
       my @paths;
@@ -62,9 +62,8 @@ sub run {
         }
       }
     }
-    if (scalar(@missing)) {
-      $self->throw('Missing data files: '.join(',', @missing));
-    }
+    $self->param('rnaseq_db', $dba->dbc->dbname);
+    $self->param('missing', \@missing);
   }
 
   # Ensure checksum and README filenames are consistent.
@@ -88,6 +87,15 @@ sub write_output {
 
   if ($rnaseq_exists) {
     $self->dataflow_output_id({}, 2);
+
+    my $rnaseq_db = $self->param_required('rnaseq_db');
+    my $missing   = $self->param_required('missing');
+    if (scalar(@$missing)) {
+      $self->dataflow_output_id({
+        'missing'   => $missing,
+        'rnaseq_db' => $rnaseq_db
+      }, 3);
+    }
   }
 }
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/RNASeq_Missing.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/RNASeq_Missing.pm
@@ -1,0 +1,51 @@
+=head1 LICENSE
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2020] EMBL-European Bioinformatics Institute
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+Bio::EnsEMBL::Production::Pipeline::FileDump::RNASeq_Missing
+
+=head1 DESCRIPTION
+Send an email listing missing rnaseq files.
+
+=cut
+
+package Bio::EnsEMBL::Production::Pipeline::FileDump::RNASeq_Missing;
+
+use strict;
+use warnings;
+use feature 'say';
+
+use base ('Bio::EnsEMBL::Hive::RunnableDB::NotifyByEmail');
+
+sub fetch_input {
+  my ($self) = @_;
+
+  my $missing = $self->param_required('missing');
+  my $rnaseq_db = $self->param_required('rnaseq_db');
+
+  my $subject = "Missing rnaseq files ($rnaseq_db)";
+  $self->param('subject', $subject);
+
+  my $text =
+    "The Rapid Release file dumping pipeline could not find the ".
+    "files below, which are expected based on the data in the ".
+    "$rnaseq_db database. Please copy the files to these ".
+    "locations, or amend the data in the rnaseq database. The ".
+    "files will be synchronised the next time the file dumping ".
+    "pipeline is run.\n\n";
+  $text .= "Missing files:\n" . join("\n", @$missing);
+
+  $self->param('text', $text);
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FileDump_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FileDump_conf.pm
@@ -50,6 +50,8 @@ sub default_options {
     overwrite      => 0,
     per_chromosome => 0,
 
+    rnaseq_email => $self->o('email'),
+
     # External programs
     blastdb_exe          => 'makeblastdb',
     gtf_to_genepred_exe  => 'gtfToGenePred',
@@ -361,8 +363,19 @@ sub pipeline_analyses {
 	    -rc_name           => '1GB',
       -flow_into         => {
                               '2->A' => ['Symlink_RNASeq'],
-                              'A->2' => ['Verify_Unzipped']
+                              'A->2' => ['Verify_Unzipped'],
+                              '3'    => ['RNASeq_Missing'],
                             },
+    },
+    {
+      -logic_name        => 'RNASeq_Missing',
+      -module            => 'Bio::EnsEMBL::Production::Pipeline::FileDump::RNASeq_Missing',
+      -max_retry_count   => 1,
+      -hive_capacity     => 10,
+      -batch_size        => 10,
+      -parameters        => {
+                              email => $self->o('rnaseq_email'),
+                            }
     },
     {
       -logic_name        => 'Genome_FASTA_mem',


### PR DESCRIPTION
## Description
The file dumping pipeline for Rapid Release uses the database to define expected rnaseq files, in order to create symlinks used by web and to sync to the public site; if they did't exist, the pipeline was failing. This doesn't really fit the RR paradigm - we won't necessarily be able to fix it immediately, and imperfect data is OK. So the pipeline now warns about missing files, but then proceeds with whatever is there, and completes normally.

By default, for each species that lacks rnaseq an email is sent, listing the missing files. It is send by default to the 'email' parameter value, which will be whoever initialised the pipeline, if not explicitly set. But the email about the rnaseq files can be sent to a specific individual or team, by using the 'rnaseq_email' parameter.

## Benefits
More robust pipeline; and an email with missing files is easier to read that the output of a failed hive job.

## Possible Drawbacks
Lots of emails if you misconfigure the pipeline (or if you have lots of missing files, but hopefully the latter is an incentive to ensure they are in the correct place in the first instance!)

## Testing
No unit test, but sample pipeline run successfully.