### PR TITLE
Fix ##sequence-region metadata when tidying GFF3

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_GFF3.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_GFF3.pm
@@ -179,7 +179,7 @@ sub tidy {
 
   my $temp_filename = "$filename.sorted";
 
-  my $cmd = "$gt_gff3_exe -tidy -sort -retainids -force -o $temp_filename $filename";
+  my $cmd = "$gt_gff3_exe -tidy -sort -retainids -fixregionboundaries -force -o $temp_filename $filename";
   my ($rc, $output) = $self->run_cmd($cmd);
 
   if ($rc) {

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_conf.pm
@@ -75,7 +75,7 @@ sub default_options {
 
         ## gff3 parameters
         'gt_exe'                 => 'gt',
-        'gff3_tidy'              => $self->o('gt_exe') . ' gff3 -tidy -sort -retainids -force',
+        'gff3_tidy'              => $self->o('gt_exe') . ' gff3 -tidy -sort -retainids -fixregionboundaries -force',
         'gff3_validate'          => $self->o('gt_exe') . ' gff3validator',
 
         'feature_type'           => [ 'Gene', 'Transcript', 'SimpleFeature' ], #'RepeatFeature'


### PR DESCRIPTION
## Description
Fix ##sequence-region metadata when tidying GFF3 (AFAIK, this only matters for human chrY, in which a gene is annotated partly in a PAR).

## Benefits
GFF3 dumps for human chrY are valid.

## Possible Drawbacks
Tidying is potentially slower - but wasn't noticeably so when tested.