### PR TITLE
fix Stable Ids Index creation sql command

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/StableID/sql/index.sql
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/StableID/sql/index.sql
@@ -13,5 +13,5 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-CREATE UNIQUE INDEX stable_id_db_type ON stable_id_lookup(stable_id, db_type, object_type);
-CREATE UNIQUE INDEX stable_id_object_type ON stable_id_lookup(stable_id, object_type);
+CREATE INDEX stable_id_db_type ON stable_id_lookup(stable_id, db_type, object_type);
+CREATE INDEX stable_id_object_type ON stable_id_lookup(stable_id, object_type);

--- a/modules/Bio/EnsEMBL/Production/Pipeline/StableID/sql/index.sql
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/StableID/sql/index.sql
@@ -13,5 +13,5 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-CREATE KEY stable_id_db_type ON stable_id_lookup(stable_id, db_type, object_type);
-CREATE KEY stable_id_object_type ON stable_id_lookup(stable_id, object_type);
+CREATE UNIQUE INDEX stable_id_db_type ON stable_id_lookup(stable_id, db_type, object_type);
+CREATE UNIQUE INDEX stable_id_object_type ON stable_id_lookup(stable_id, object_type);


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

KEY MYSQL KEY word doesn't work with sta-5 MySQL version

## Description

Fix by using UNIQUE index instead

## Use case

Build indexes after ensembl_stable_ids is built.

## Benefits

No more error while building indexes.

## Possible Drawbacks

None

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
