### PR TITLE
New pipeline for RNA gene xref annotation

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/RNAGeneXref_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/RNAGeneXref_conf.pm
@@ -1,0 +1,223 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::Production::Pipeline::PipeConfig::RNAGeneXref_conf;
+
+use strict;
+use warnings;
+
+use base ('Bio::EnsEMBL::Production::Pipeline::PipeConfig::Base_conf');
+
+use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
+use Bio::EnsEMBL::Hive::Version 2.4;
+
+use File::Spec::Functions qw(catdir);
+
+sub default_options {
+  my ($self) = @_;
+  return {
+    %{$self->SUPER::default_options},
+
+    species      => [],
+    antispecies  => [],
+    division     => [],
+    run_all      => 0,
+    meta_filters => {},
+
+    rnacentral_ebi_path => '/ebi/ftp/pub/databases/RNAcentral/current_release/md5',
+    rnacentral_ftp_uri  => 'ftp://ftp.ebi.ac.uk/pub/databases/RNAcentral/current_release/md5',
+    rnacentral_file     => 'md5.tsv.gz',
+
+    rnacentral_file_local => catdir($self->o('pipeline_dir'), $self->o('rnacentral_file')),
+
+    rnacentral_logic_name => 'rnacentral_checksum',
+
+    analyses =>
+    [
+      {
+        logic_name => $self->o('rnacentral_logic_name'),
+        db         => 'RNACentral',
+      },
+    ],
+
+    # Remove existing analyses; if =0 then existing analyses
+    # will remain, with the logic_name suffixed by '_bkp'.
+    delete_existing => 1,
+
+    # Config/history files for storing record of datacheck run.
+    config_file  => undef,
+    history_file => undef,
+  };
+}
+
+# Ensures that species output parameter gets propagated implicitly.
+sub hive_meta_table {
+  my ($self) = @_;
+
+  return {
+    %{$self->SUPER::hive_meta_table},
+    'hive_use_param_stack' => 1,
+  };
+}
+
+sub pipeline_create_commands {
+  my ($self) = @_;
+
+  my $rnacentral_table_sql = q/
+    CREATE TABLE rnacentral (
+      urs VARCHAR(13) NOT NULL,
+      md5sum VARCHAR(32) NOT NULL COLLATE latin1_swedish_ci
+    );
+  /;
+
+  return [
+    @{$self->SUPER::pipeline_create_commands},
+    'mkdir -p '.$self->o('pipeline_dir'),
+    $self->db_cmd($rnacentral_table_sql),
+  ];
+}
+
+sub pipeline_analyses {
+  my $self = shift @_;
+
+  return [
+    {
+      -logic_name      => 'RNAGeneXref',
+      -module          => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+      -max_retry_count => 0,
+      -input_ids       => [ {} ],
+      -parameters      => {},
+      -flow_into       => {
+                            '1->A' => ['FetchRNACentral'],
+                            'A->1' => ['DbFactory'],
+                          }
+    },
+
+    {
+      -logic_name      => 'FetchRNACentral',
+      -module          => 'Bio::EnsEMBL::Production::Pipeline::ProteinFeatures::FetchFile',
+      -max_retry_count => 1,
+      -parameters      => {
+                            ebi_path    => $self->o('rnacentral_ebi_path'),
+                            ftp_uri     => $self->o('rnacentral_ftp_uri'),
+                            remote_file => $self->o('rnacentral_file'),
+                            local_file  => $self->o('rnacentral_file_local'),
+                          },
+      -flow_into       => ['LoadRNACentral'],
+    },
+
+    {
+      -logic_name      => 'LoadRNACentral',
+      -module          => 'Bio::EnsEMBL::Production::Pipeline::RNAGeneXref::LoadRNACentral',
+      -max_retry_count => 1,
+      -parameters      => {
+                            rnacentral_file_local => $self->o('rnacentral_file_local'),
+                          },
+    },
+
+    {
+      -logic_name      => 'DbFactory',
+      -module          => 'Bio::EnsEMBL::Production::Pipeline::Common::DbFactory',
+      -max_retry_count => 1,
+      -parameters      => {
+                            species         => $self->o('species'),
+                            antispecies     => $self->o('antispecies'),
+                            division        => $self->o('division'),
+                            run_all         => $self->o('run_all'),
+                            meta_filters    => $self->o('meta_filters'),
+                          },
+      -flow_into       => {
+                            '2->A' => ['BackupTables'],
+                            'A->2' => ['RunDatachecks'],
+                          }
+    },
+
+    {
+      -logic_name        => 'BackupTables',
+      -module            => 'Bio::EnsEMBL::Production::Pipeline::Common::DatabaseDumper',
+      -max_retry_count   => 1,
+      -analysis_capacity => 20,
+      -parameters        => {
+                              table_list  => [
+                                'analysis',
+                                'analysis_description',
+                                'object_xref',
+                                'xref',
+                              ],
+                              output_file => catdir($self->o('pipeline_dir'), '#dbname#', 'pre_pipeline_bkp.sql.gz'),
+                            },
+      -flow_into         => ['AnalysisSetup'],
+    },
+
+    {
+      -logic_name        => 'AnalysisSetup',
+      -module            => 'Bio::EnsEMBL::Production::Pipeline::Common::AnalysisSetup',
+      -max_retry_count   => 0,
+      -analysis_capacity => 20,
+      -parameters        => {
+                              logic_name         => $self->o('rnacentral_logic_name'),
+                              db                 => 'RNACentral',
+                              db_version         => 'RNACentral',
+                              db_backup_required => 1,
+                              db_backup_file     => catdir($self->o('pipeline_dir'), '#dbname#', 'pre_pipeline_bkp.sql.gz'),
+                              delete_existing    => $self->o('delete_existing'),
+                              linked_tables      => ['object_xref'],
+                              production_lookup  => 1,
+                            },
+      -flow_into 	       => ['SpeciesFactory'],
+    },
+
+    {
+      -logic_name        => 'SpeciesFactory',
+      -module            => 'Bio::EnsEMBL::Production::Pipeline::Common::DbAwareSpeciesFactory',
+      -max_retry_count   => 1,
+      -analysis_capacity => 20,
+      -parameters        => {},
+      -flow_into         => {
+                              '2' => ['RNACentralXref'],
+                            }
+    },
+
+    {
+      -logic_name        => 'RNACentralXref',
+      -module            => 'Bio::EnsEMBL::Production::Pipeline::RNAGeneXref::RNACentralXref',
+      -max_retry_count   => 0,
+      -analysis_capacity => 50,
+      -parameters        => {
+                              logic_name => $self->o('rnacentral_logic_name'),
+                            },
+    },
+
+    {
+      -logic_name        => 'RunDatachecks',
+      -module            => 'Bio::EnsEMBL::DataCheck::Pipeline::RunDataChecks',
+      -max_retry_count   => 1,
+      -analysis_capacity => 10,
+      -parameters        => {
+                              datacheck_names  => ['ForeignKeys'],
+                              config_file      => $self->o('config_file'),
+                              history_file     => $self->o('history_file'),
+                              failures_fatal   => 1,
+                            },
+    },
+
+  ];
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/RNAGeneXref_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/RNAGeneXref_conf.pm
@@ -53,6 +53,7 @@ sub default_options {
       {
         logic_name => $self->o('rnacentral_logic_name'),
         db         => 'RNACentral',
+        local_file => $self->o('rnacentral_file_local'),
       },
     ],
 
@@ -162,7 +163,20 @@ sub pipeline_analyses {
                               ],
                               output_file => catdir($self->o('pipeline_dir'), '#dbname#', 'pre_pipeline_bkp.sql.gz'),
                             },
-      -flow_into         => ['AnalysisSetup'],
+      -flow_into         => ['AnalysisConfiguration'],
+    },
+
+    {
+      -logic_name        => 'AnalysisConfiguration',
+      -module            => 'Bio::EnsEMBL::Production::Pipeline::RNAGeneXref::AnalysisConfiguration',
+      -max_retry_count   => 0,
+      -parameters        => {
+                              analyses => $self->o('analyses'),
+                            },
+      -flow_into 	       => {
+                              '2->A' => ['AnalysisSetup'],
+                              'A->3' => ['SpeciesFactory'],
+                            }
     },
 
     {
@@ -171,16 +185,12 @@ sub pipeline_analyses {
       -max_retry_count   => 0,
       -analysis_capacity => 20,
       -parameters        => {
-                              logic_name         => $self->o('rnacentral_logic_name'),
-                              db                 => 'RNACentral',
-                              db_version         => 'RNACentral',
                               db_backup_required => 1,
                               db_backup_file     => catdir($self->o('pipeline_dir'), '#dbname#', 'pre_pipeline_bkp.sql.gz'),
                               delete_existing    => $self->o('delete_existing'),
                               linked_tables      => ['object_xref'],
                               production_lookup  => 1,
                             },
-      -flow_into 	       => ['SpeciesFactory'],
     },
 
     {

--- a/modules/Bio/EnsEMBL/Production/Pipeline/RNAGeneXref/AnalysisConfiguration.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/RNAGeneXref/AnalysisConfiguration.pm
@@ -1,0 +1,67 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::Production::Pipeline::RNAGeneXref::AnalysisConfiguration;
+
+use strict;
+use warnings;
+use base ('Bio::EnsEMBL::Production::Pipeline::Common::Base');
+
+use Path::Tiny;
+use POSIX qw(strftime);
+
+sub run {
+  my ($self) = @_;
+  my $analyses = $self->param_required('analyses');
+
+  my $aa = $self->core_dba->get_adaptor('Analysis');
+
+  my @filtered_analyses = ();
+
+  foreach my $analysis_config (@{$analyses}) {
+    if (-e $$analysis_config{'local_file'}) {
+      my $timestamp = path($$analysis_config{'local_file'})->stat->mtime;
+      my $datestamp = strftime "%Y-%m-%d", localtime($timestamp);
+
+      my $logic_name = $$analysis_config{'logic_name'};
+      my $analysis = $aa->fetch_by_logic_name($logic_name);
+
+      if ($datestamp ne $analysis->db_version) {
+        $$analysis_config{'db_version'} = $datestamp;
+        push @filtered_analyses, $analysis_config;
+      }
+    }
+  }
+
+  $self->param('filtered_analyses', \@filtered_analyses);
+}
+
+sub write_output {
+  my ($self) = @_;
+
+  my $analyses = $self->param('filtered_analyses');
+
+  if ( scalar(@$analyses) ) {
+    $self->dataflow_output_id( $analyses, 2 );
+
+    $self->dataflow_output_id( {}, 3 );
+  }
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/RNAGeneXref/AnalysisConfiguration.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/RNAGeneXref/AnalysisConfiguration.pm
@@ -42,8 +42,12 @@ sub run {
       my $logic_name = $$analysis_config{'logic_name'};
       my $analysis = $aa->fetch_by_logic_name($logic_name);
 
-      if ($datestamp ne $analysis->db_version) {
-        $$analysis_config{'db_version'} = $datestamp;
+      if (defined($analysis)) {
+        if ($datestamp ne $analysis->db_version) {
+          $$analysis_config{'db_version'} = $datestamp;
+          push @filtered_analyses, $analysis_config;
+        }
+      } else {
         push @filtered_analyses, $analysis_config;
       }
     }

--- a/modules/Bio/EnsEMBL/Production/Pipeline/RNAGeneXref/LoadRNACentral.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/RNAGeneXref/LoadRNACentral.pm
@@ -1,0 +1,49 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::Production::Pipeline::RNAGeneXref::LoadRNACentral;
+
+use strict;
+use warnings;
+
+use File::Basename;
+
+use base ('Bio::EnsEMBL::Production::Pipeline::Common::Base');
+
+sub run {
+  my ($self) = @_;
+  my $rnacentral_file = $self->param_required('rnacentral_file_local');
+
+  if (-e $rnacentral_file) {
+    $self->run_cmd("gunzip $rnacentral_file");
+    $rnacentral_file =~ s/\.gz$//;
+
+    my $dbh = $self->hive_dbh;
+    my $sql = "LOAD DATA LOCAL INFILE '$rnacentral_file' INTO TABLE rnacentral";
+    $dbh->do($sql) or self->throw($dbh->errstr);
+
+    my $index_1 = 'ALTER TABLE rnacentral ADD KEY md5sum_idx (md5sum) USING HASH';
+    $dbh->do($index_1) or self->throw($dbh->errstr);
+
+  } else {
+    $self->throw("Mapping file '$rnacentral_file' does not exist");
+  }
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/RNAGeneXref/LoadRNACentral.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/RNAGeneXref/LoadRNACentral.pm
@@ -29,13 +29,13 @@ use base ('Bio::EnsEMBL::Production::Pipeline::Common::Base');
 sub run {
   my ($self) = @_;
   my $rnacentral_file = $self->param_required('rnacentral_file_local');
+  (my $unzipped_file = $rnacentral_file) =~ s/\.gz$//;
 
   if (-e $rnacentral_file) {
-    $self->run_cmd("gunzip $rnacentral_file");
-    $rnacentral_file =~ s/\.gz$//;
+    $self->run_cmd("gunzip -c $rnacentral_file > $unzipped_file");
 
     my $dbh = $self->hive_dbh;
-    my $sql = "LOAD DATA LOCAL INFILE '$rnacentral_file' INTO TABLE rnacentral";
+    my $sql = "LOAD DATA LOCAL INFILE '$unzipped_file' INTO TABLE rnacentral";
     $dbh->do($sql) or self->throw($dbh->errstr);
 
     my $index_1 = 'ALTER TABLE rnacentral ADD KEY md5sum_idx (md5sum) USING HASH';

--- a/modules/Bio/EnsEMBL/Production/Pipeline/RNAGeneXref/RNACentralXref.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/RNAGeneXref/RNACentralXref.pm
@@ -1,0 +1,107 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::Production::Pipeline::RNAGeneXref::RNACentralXref;
+
+use strict;
+use warnings;
+use base ('Bio::EnsEMBL::Production::Pipeline::Common::Base');
+
+use DBI qw(:sql_types);
+use Digest::MD5 qw(md5_hex);
+use File::Spec::Functions qw(catdir);
+use Path::Tiny;
+
+sub run {
+  my ($self) = @_;
+
+  my $logic_name = $self->param_required('logic_name');
+
+  my $sql = "SELECT urs FROM rnacentral WHERE md5sum = ?";
+  my $dbh = $self->hive_dbh;
+  my $sth = $dbh->prepare($sql) or $self->throw($dbh->errstr);
+
+  my $dba  = $self->get_DBAdaptor('core');
+  my $aa   = $dba->get_adaptor('Analysis');
+  my $ba   = $dba->get_adaptor('Biotype');
+  my $ta   = $dba->get_adaptor('Transcript');
+  my $dbea = $dba->get_adaptor('DBEntry');
+
+  my $analysis = $aa->fetch_by_logic_name($logic_name);
+
+  my $snoncoding = $ba->fetch_all_by_group_object_db_type('snoncoding', 'transcript');
+  my $lnoncoding = $ba->fetch_all_by_group_object_db_type('lnoncoding', 'transcript');
+  my @rna_biotypes = map { $_->name } (@$snoncoding, @$lnoncoding);
+
+  $dba->dbc && $dba->dbc->disconnect_if_idle();
+
+  my $transcripts = $ta->fetch_all_by_biotype(\@rna_biotypes);
+  foreach my $transcript (@$transcripts) {
+    my $urs = $self->fetch_urs($sth, md5_hex($transcript->seq->seq));
+
+    if (defined $urs) {
+      $self->add_xref($urs, $analysis, $dbea, $transcript->dbID);
+    }
+  }
+}
+
+sub fetch_urs {
+  my ($self, $sth, $md5sum) = @_;
+
+  $sth->bind_param(1, $md5sum, SQL_CHAR);
+  $sth->execute();
+
+  my $urs;
+  my $results = $sth->fetchall_arrayref;
+
+  if (scalar(@$results)) {
+    $urs = $$results[0][0];
+    if (scalar(@$results) > 1) {
+      $self->warning("Multiple URSs found for $md5sum");
+    }
+  }
+
+  return $urs;
+}
+
+sub add_xref {
+  my ($self, $urs, $analysis, $dbea, $transcript_id) = @_;
+
+  my $xref = $self->create_xref($urs, $analysis);
+  $dbea->store($xref, $transcript_id, 'Transcript');
+
+  return $xref;
+}
+
+sub create_xref {
+  my ($self, $urs, $analysis) = @_;
+
+	my $xref = Bio::EnsEMBL::DBEntry->new(
+    -PRIMARY_ID => $urs,
+		-DISPLAY_ID => $urs,
+		-DBNAME     => 'RNACentral',
+		-INFO_TYPE  => 'CHECKSUM',
+    -VERSION    => 1
+  );
+	$xref->analysis($analysis);
+
+  return $xref;
+}
+
+1;


### PR DESCRIPTION
## Description
A new, small pipeline to add RNAcentral checksum-based xrefs to the RNA genes in a core db. This is the analog of UniParc xref functionality which is now in the ProteinFeatures pipeline (#541).

## Use case
It is intended for Rapid Release only (although it could be used for non-vert divisions, because I don't think RNAcentral xrefs are part of their SOP), because GOA provide their annotations against RNAcentral accessions, so we need those to join things up and maximise our GO terms. It is quick to run: loading the checksums takes ~8 mins, and the annotation itself ~5 mins per species.

## Benefits
Annotate RNA genes with a "hub" xref, which can be used to link through to all the individual RNA resources. 
Maximise our ability to use GO annotations provided by the GOA team.

## Possible Drawbacks
It's still another pipeline that we need to run, even if it is simple and quick.

## Testing
Pipeline initialised and run to completion for a subset of RR species. Some of those had RNAcentral xrefs already, and this pipeline annotates almost the same set, a difference of 1 or 2 xrefs. The differences aren't a problem, xrefs can change slightly over time (this pipeline won't replace any xrefs that exist from other sources anyway) - rather, the message is that the new pipeline is getting the expected level of annotation.