### PR TITLE
Pipeline mirror load

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/MirrorLoad/DeleteDBs.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/MirrorLoad/DeleteDBs.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
 Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2020] EMBL-European Bioinformatics Institute
+Copyright [2016-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/Production/Pipeline/MirrorLoad/DeleteDBs.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/MirrorLoad/DeleteDBs.pm
@@ -34,8 +34,8 @@ sub fetch_input {
   my $self = shift @_;
   $self->SUPER::fetch_input(); 
   $self->param('db_conn', $self->param('src_uri') );
-  #my $sql_cmd = [ 'DROP DATABASE '. $self->param('db_name').';' ];
-  #$self->param('sql', $sql_cmd);
+  my $sql_cmd = [ 'DROP DATABASE '. $self->param('db_name').';' ];
+  $self->param('sql', $sql_cmd);
  
 }
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/MirrorLoad/DeleteDBs.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/MirrorLoad/DeleteDBs.pm
@@ -1,0 +1,58 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::Production::Pipeline::MirrorLoad::DeleteDBs;
+
+use strict;
+use warnings;
+
+use base qw/Bio::EnsEMBL::Production::Pipeline::Common::Base/;
+use Bio::EnsEMBL::Registry;
+use Carp qw/croak/;
+
+sub run {
+
+	my ( $self ) = @_;
+
+        my %hosts = (
+         "EnsemblPlants" => ['m3-w'],
+         "EnsemblVertebrates" => ['m1-w'],
+         "EnsemblVertebrates_grch37" => ['m2-w'],
+         "EnsemblMetazoa" => ['m3-w'],
+         "EnsemblProtists" => ['m3-w'],
+         "EnsemblBacteria" => ['m4-w'],  
+         "EnsemblPan" => ['m1-w', 'm2-w', 'm3-w', 'm4-w'],
+         "mart" => ['mysql-ens-mirror-mart-1-ensprod'],       
+        );
+        
+        foreach my $host (@{ $hosts{$self->param('division')} }){
+        
+		my $dbname = $self->param('db_name');
+		my $cmd = "$host -e \" DROP database  $dbname\"  " ;
+		if ( $self->run_system_command($cmd) != 0 ) {
+		 	croak "cannot delete database $dbname: $!";
+		}
+		$self->warning($cmd);
+        }  
+} 
+
+1;
+
+
+                           

--- a/modules/Bio/EnsEMBL/Production/Pipeline/MirrorLoad/DeleteDBs.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/MirrorLoad/DeleteDBs.pm
@@ -22,35 +22,22 @@ package Bio::EnsEMBL::Production::Pipeline::MirrorLoad::DeleteDBs;
 use strict;
 use warnings;
 
-use base qw/Bio::EnsEMBL::Production::Pipeline::Common::Base/;
-use Bio::EnsEMBL::Registry;
-use Carp qw/croak/;
 
-sub run {
+use base (
+  'Bio::EnsEMBL::Hive::RunnableDB::SqlCmd',
+  'Bio::EnsEMBL::Production::Pipeline::Common::Base'
+);
 
-	my ( $self ) = @_;
 
-        my %hosts = (
-         "EnsemblPlants" => ['m3-w'],
-         "EnsemblVertebrates" => ['m1-w'],
-         "EnsemblVertebrates_grch37" => ['m2-w'],
-         "EnsemblMetazoa" => ['m3-w'],
-         "EnsemblProtists" => ['m3-w'],
-         "EnsemblBacteria" => ['m4-w'],  
-         "EnsemblPan" => ['m1-w', 'm2-w', 'm3-w', 'm4-w'],
-         "mart" => ['mysql-ens-mirror-mart-1-ensprod'],       
-        );
-        
-        foreach my $host (@{ $hosts{$self->param('division')} }){
-        
-		my $dbname = $self->param('db_name');
-		my $cmd = "$host -e \" DROP database  $dbname\"  " ;
-		if ( $self->run_system_command($cmd) != 0 ) {
-		 	croak "cannot delete database $dbname: $!";
-		}
-		$self->warning($cmd);
-        }  
-} 
+sub fetch_input {
+
+  my $self = shift @_;
+  $self->SUPER::fetch_input(); 
+  $self->param('db_conn', $self->param('src_uri') );
+  #my $sql_cmd = [ 'DROP DATABASE '. $self->param('db_name').';' ];
+  #$self->param('sql', $sql_cmd);
+ 
+}
 
 1;
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/MirrorLoad/ListDatabase.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/MirrorLoad/ListDatabase.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
 Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2020] EMBL-European Bioinformatics Institute
+Copyright [2016-2021] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -290,7 +290,7 @@ sub copy_division_dbs{
 	my ( $self, $divisions, $host_servers, $division ) = @_;
 
 	#copy all vert/nonvert  dbs
-	my $dbname='%core%,%funcgen%,%otherfeatures%,%rnaseq%';
+	my $dbname='%core%,%funcgen%,%otherfeatures%,%rnaseq%cdna%variation';
 	$self->dataflow_output_id( {
                 'source_db_uri' =>  $host_servers->{$division}->[0] . $dbname,
                 'target_db_uri' =>  $host_servers->{$division}->[1],
@@ -318,7 +318,7 @@ sub copy_marts{
 	my ( $self, $divisions, $host_servers ) = @_;
         my %marts = ('EnsemblPlants' => 'plants_%mart%', 'EnsemblMetazoa'=>'metazoa_%mart%',
                       'EnsemblFungi' => 'fungi_%mart%', 'EnsemblProtists' => 'protists_%mart%',
-                      'EnsemblVertebrates' => '%marts%',
+                      'EnsemblVertebrates' => '%mart%',
                      ); #ontology_mart is copied from vert divsion %mart%
 
         foreach my $division (@{$self->get_divisions()}){

--- a/modules/Bio/EnsEMBL/Production/Pipeline/MirrorLoad/ListDatabase.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/MirrorLoad/ListDatabase.pm
@@ -1,0 +1,266 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::Production::Pipeline::MirrorLoad::ListDatabase;
+
+use strict;
+use warnings;
+
+use base qw/Bio::EnsEMBL::Production::Pipeline::Common::Base/;
+use Bio::EnsEMBL::Registry;
+use Bio::EnsEMBL::MetaData::DBSQL::MetaDataDBAdaptor;
+use Bio::EnsEMBL::MetaData::Base qw(process_division_names fetch_and_set_release);
+use List::MoreUtils qw(uniq);
+use Data::Dumper;
+
+sub run {
+
+	my ( $self ) = @_;
+
+        #process division names 
+        my $all_divisions = $self->get_divisions();
+	
+	#list grch37 bds
+	if( $self->param('process_grch37') || $self->param('run_all') ){
+
+		my $division_databases = $self->get_all_functional_dbs('multi_grch37', $all_divisions, $self->param('release') );
+		$self->set_output_flow($division_databases, 'multi_grch37');
+        } 
+	
+	#list only mart
+        if( $self->param('process_mart') || $self->param('run_all') ){
+                my $ens_release = $self->param('release');
+               #we retain only 2 release for marts so we delete previous release mart 
+                #if( ! $self->param('tocopy' ) ){ $ens_release = $self->param('release') + 1 ;}
+
+		my $division_databases = $self->get_all_mart_and_pan_db('multi', $all_divisions, $ens_release, 1, 0);
+		$self->set_output_flow($division_databases, 'multi');
+	}
+
+	#list all functional dbs
+	if( !( $self->param('process_grch37') || $self->param('process_mart') ) || $self->param('run_all') ){
+
+
+                my $division_databases = $self->get_all_functional_dbs('multi', $all_divisions, $self->param('release') );
+                $self->set_output_flow($division_databases, 'multi');
+
+		#list pan dbs
+		$division_databases = $self->get_all_mart_and_pan_db('multi', $all_divisions, $self->param('release'), 0, 1);
+		$self->set_output_flow($division_databases, 'multi');
+		
+		#get compara db
+		$division_databases = $self->get_all_compara_db('multi', $all_divisions, $self->param('release'));
+                $self->set_output_flow($division_databases, 'multi');	
+        }
+        
+}
+
+sub get_divisions{
+
+        my ($self) = @_; 
+        my $all_divisions = [];
+	my $all_processed_divsions = [];
+
+        my ($rdba,$gdba,$release,$release_info) = $self->get_metadata_db('multi', $self->param('release'));
+
+        if ( scalar(@{$self->param('division')}) ) {
+                $all_divisions = $self->param('division');
+        }
+        else {
+                $all_divisions = $gdba->list_divisions();
+        }
+
+	foreach my $div (@{$all_divisions}){
+		my ($division,$division_name)=process_division_names($div);
+		push(@{$all_processed_divsions}, $division_name)
+	}
+
+	return $all_processed_divsions
+
+}
+
+sub get_metadata_db{
+
+        my ( $self, $species, $ens_release ) = @_;
+
+        my $metadata_dba =  Bio::EnsEMBL::Registry->get_DBAdaptor( $species , "metadata" );
+
+        my $gcdba = $metadata_dba->get_GenomeComparaInfoAdaptor();
+        my $gdba = $metadata_dba->get_GenomeInfoAdaptor();
+        my $dbdba = $metadata_dba->get_DatabaseInfoAdaptor();
+        my $rdba = $metadata_dba->get_DataReleaseInfoAdaptor();
+        my ($release,$release_info);
+        ($rdba,$gdba,$release,$release_info) = fetch_and_set_release( $ens_release, $rdba,$gdba);
+        
+        return ($rdba,$gdba,$release,$release_info,$dbdba,$gcdba)         
+
+} 
+
+sub get_all_functional_dbs{
+
+	my ( $self, $species, $all_divisions, $ens_release ) = @_;
+        my ($rdba,$gdba,$release,$release_info) = $self->get_metadata_db($species, $ens_release);
+        my %division_databases ; 
+        foreach my $division_name (@{$all_divisions}){
+                my $genomes = $gdba->fetch_all_by_division($division_name);
+        	foreach my $genome (@$genomes){
+        		foreach my $database (@{$genome->databases()}){
+                		#$self->warning($database->dbname);
+                        	push (@{$division_databases{$division_name} },$database->dbname);
+			}
+		}
+	}
+
+	return \%division_databases;	
+}
+
+
+sub get_all_mart_and_pan_db{
+
+        my ( $self, $species, $all_divisions, $ens_release, $only_marts, $only_pan ) = @_;
+        my ($rdba,$gdba,$release,$release_info, $dbdba) = $self->get_metadata_db($species, $ens_release);
+        my %division_databases ;
+        foreach my $division_name (@{$all_divisions}){
+                my $genomes = $gdba->fetch_all_by_division($division_name);
+               foreach my $mart_database (@{$dbdba->fetch_databases_DataReleaseInfo($release_info,$division_name)}){
+                       my $division_type = $division_name;
+                       if( $mart_database->dbname =~ /mart/g){
+                           if($only_marts){
+                                $division_type = ($division_name eq 'EnsemblVertebrates') ? 'vert_mart' : 'nonvert_mart';
+                                push (@{$division_databases{$division_type}},$mart_database->dbname);
+                           }
+                       }else{
+			  if($only_pan){
+	                         push (@{$division_databases{$division_type}},$mart_database->dbname);
+	                  }    	
+                       }
+                }
+
+        }
+
+        return \%division_databases;
+
+}
+
+sub get_all_compara_db{
+
+        my ( $self, $species, $all_divisions, $ens_release ) = @_;
+	my ($rdba,$gdba,$release,$release_info, $dbdba, $gcdba) = $self->get_metadata_db($species, $ens_release);
+	my %division_databases ;
+        foreach my $division_name (@{$all_divisions}){
+        	foreach my $compara_database (@{$gcdba->fetch_division_databases($division_name,$release_info)}){
+			push (@{$division_databases{$division_name}},$compara_database);
+                        #$self->warning($compara_database);
+        	}
+	}
+
+	return \%division_databases;                        
+}
+
+sub set_output_flow{
+	my ( $self, $division_databases, $type  ) = @_;
+
+	if($self->param('tocopy')){
+		$self->set_outflow_for_copy($division_databases, $type);
+		return ;
+	}
+        
+        foreach my $keys (keys %{$division_databases}){
+                
+               foreach my $division_database (sort(uniq(@{$division_databases->{$keys}}))){
+                        $self->dataflow_output_id( {
+                                division =>  ( $type eq 'multi_grch37' ) ?  $keys.'_grch37':  $keys,
+                                'db_name' =>  $division_database,
+				'type'   => $type,
+                        }, 2);
+                }
+        }		
+
+} 
+
+sub set_outflow_for_copy{
+
+	my ( $self, $division_databases, $type  ) = @_;
+	
+	my %hosts = (
+         "EnsemblPlants" =>  ['mysql-ens-sta-3' , 'mysql-ens-mirror-3'] ,
+         "EnsemblVertebrates" => ['mysql-ens-sta-1', 'mysql-ens-mirror-1'],
+         "EnsemblVertebrates_grch37" => ['mysql-ens-sta-2', 'mysql-ens-mirror-2'], 
+         "EnsemblMetazoa" => ['mysql-ens-sta-3', 'mysql-ens-mirror-3'] ,
+         "EnsemblProtists" => ['mysql-ens-sta-3', 'mysql-ens-mirror-3'] ,
+         "EnsemblBacteria" => ['mysql-ens-sta-3', 'mysql-ens-mirror-4'],
+         "EnsemblPan" => ['mysql-ens-sta-1,mysql-ens-sta-2,mysql-ens-sta-3,mysql-ens-sta-4', 'mysql-ens-mirror-1,mysql-ens-mirror-2,mysql-ens-mirror-3,mysql-ens-mirror-4'] ,
+         "vert_mart" =>  ['mysql-ens-sta-1', 'mysql-ens-mirror-mart-1'] , 
+	 "nonvert_mart" => ['mysql-ens-sta-3', 'mysql-ens-mirror-mart-1'] ,	 
+        );
+
+
+	foreach my $keys (keys %hosts){
+			
+		if( $self->param('release') % 2 != 0 ){	
+
+                	${$hosts{$keys}}[0] =~ s/sta-(\d)/sta-$1-b/g;
+
+		}
+
+	}
+
+
+        foreach my $keys (keys %{$division_databases}){
+
+               foreach my $division_database (sort(uniq(@{$division_databases->{$keys}}))){
+			if( $keys=~ /EnsemblPan/ ){
+				my @src = split(',', ${$hosts{$keys}}[0]);
+				my @target_host = split(',', ${$hosts{$keys}}[1]);
+				foreach my $i (0..$#src){
+
+					my $src_uri = `echo \$($src[$i] details url)`;
+					my $target_host= `echo \$($target_host[$i] details url)`;	
+                        		$self->dataflow_output_id( {
+                                 		division =>  ( $type eq 'multi_grch37' ) ?  $keys.'_grch37':  $keys,
+                                		'db_name' =>  $division_database,
+                                		'type'   => $type,
+                               			'source_db_uri' =>  $src_uri . $division_database,
+                               			'target_db_uri' => $target_host . $division_database,
+                        		}, 2);
+
+				}	
+
+				next;
+			}
+
+                	my $src_uri = `echo \$(${$hosts{$keys}}[0] details url)`;				
+			my $target_uri = `echo \$(${$hosts{$keys}}[1] details url)`;
+
+                        $self->dataflow_output_id( {
+                                 division =>  ( $type eq 'multi_grch37' ) ?  $keys.'_grch37':  $keys,
+                                'db_name' =>  $division_database,
+                                'type'   => $type,
+			       'source_db_uri' => $src_uri . $division_database,
+                               'target_db_uri' => $target_uri . $division_database,
+                        }, 2);
+                }
+        }
+
+}
+
+1;
+
+
+                           

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/MirrorLoad_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/MirrorLoad_conf.pm
@@ -1,0 +1,126 @@
+=head1 DESCRIPTION  
+
+=head1 LICENSE
+    Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+    Copyright [2016-2020] EMBL-European Bioinformatics Institute
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+         http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and limitations under the License.
+=head1 CONTACT
+    Please subscribe to the Hive mailing list:  http://listserver.ebi.ac.uk/mailman/listinfo/ehive-users  to discuss Hive-related questions or to be notified of our updates
+=cut
+
+
+package Bio::EnsEMBL::Production::Pipeline::PipeConfig::MirrorLoad_conf;
+
+use strict;
+use warnings;
+use Data::Dumper;
+use strict;
+use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
+use base ('Bio::EnsEMBL::Production::Pipeline::PipeConfig::Base_conf');
+use Bio::EnsEMBL::ApiVersion qw/software_version/;
+
+
+sub resource_classes {
+    my ($self) = @_;
+    return { 'default' => { 'LSF' => '-q production-rh74' } };
+}
+
+sub default_options {
+    my ($self) = @_;
+    return {
+        %{$self->SUPER::default_options},
+        'pipeline_name'    => "mirror_load_database",
+        'copy_service_uri' => "http://production-services.ensembl.org/api/dbcopy/requestjob",
+        'division'        => [],
+        'run_all'         => 0, 
+        'process_mart'    => 0,
+        'process_grch37'  => 0,     
+        'email_subject' => $self->o('pipeline_name').'  pipeline has finished',
+        'ENS_DELETE_VERSION' => ( software_version() - 3 ),
+    }
+}
+
+#$self->db_cmd('')
+
+=head2 pipeline_analyses
+=cut
+
+sub pipeline_analyses {
+    my ($self) = @_;
+    return [
+
+       {
+            -logic_name => 'ListDatabasesToDelete',
+            -module     => 'Bio::EnsEMBL::Production::Pipeline::Common::SpeciesFactory',
+            -module     => 'Bio::EnsEMBL::Production::Pipeline::Common::DbFactory',
+            -module     => 'Bio::EnsEMBL::Production::Pipeline::MirrorLoad::ListDatabase',
+            -input_ids  => [ {} ], # required for automatic seeding
+            -parameters => {
+                division             => $self->o('division'),
+                run_all              => $self->o('run_all'),
+                release              => $self->o('ENS_DELETE_VERSION'),
+	        process_mart         => $self->o('process_mart'),
+                process_grch37       => $self->o('process_grch37'),
+                tocopy               => 0,  
+             },
+            -flow_into  => { '2->A' => [ 'DeleteDBs' ],
+		             'A->1' => [ 'ListDatabasesToCopy' ]		
+                           },
+
+        },
+        {
+            -logic_name => 'DeleteDBs',
+            -module     => 'Bio::EnsEMBL::Production::Pipeline::MirrorLoad::DeleteDBs',
+            -parameters => {
+             },
+
+        }, 
+        {
+            -logic_name => 'ListDatabasesToCopy',
+            -module     => 'Bio::EnsEMBL::Production::Pipeline::MirrorLoad::ListDatabase',
+            -parameters => {
+                division             => $self->o('division'),
+                run_all              => $self->o('run_all'),
+                release              => software_version(),
+                process_mart         => $self->o('process_mart'),
+                process_grch37       => $self->o('process_grch37'),
+                tocopy               => 1, 
+             },
+
+            -flow_into  => { '2->A' => [ 'CopyToMirror' ],
+			     'A->1' => [ 'email_notification' ]	
+		           }
+        },
+        {
+            -logic_name      => 'CopyToMirror',
+            -module          => 'ensembl.production.hive.ProductionDBCopy',
+            -language        => 'python3',
+            -rc_name         => 'default',
+            -max_retry_count => 0,
+            -parameters      => {
+                'endpoint'      => $self->o('copy_service_uri'),
+                'method'        => 'post',
+            },
+            -meadow_type     => 'LOCAL',
+	},
+
+        {
+           -logic_name => 'email_notification',
+           -module     => 'Bio::EnsEMBL::Hive::RunnableDB::NotifyByEmail',
+           -parameters => {
+                           'email'   => $self->o('email'),
+                           'subject' => 'Mirror Load ',
+                           'text'    => 'All db loaded to mirror ',
+                          },
+        },
+		
+		
+    ];
+}
+1;
+


### PR DESCRIPTION
In release cycle after non-core handover and processing all the mart we copy the databases from staging  servers to mirror. 

This pipeline help to delete the old release(n-3) from mirrors and copy the new release dbs from staging to mirrors 

Major Steps in Pipeline:

    ListDatabasesToDelete
        Used MetaDataDBAdaptor to list all the databases for ante-penultimate DBs (release - 3)

    DeleteDBs
        Delete ante-penultimate DBs (release - 3)   from mirror

    ListDatabaseToCopy
        Used MetaDataDBAdaptor to list all the databases for given release

    CopyToMirror
        Copy given db from staging server to mirror based on division

-Test case:
copy vertebrate marts to mirror-mart-1
init_pipeline.pl MirrorLoad_conf.pm $($HIVE_SRV details hive) -registry $registry  -division vertebrates  -process_mart 1 -hive_force_init 1 -ensembl_release 104

Document : https://www.ebi.ac.uk/seqdb/confluence/display/GTI/Mirror+Load+Pipeline