### PR TITLE
Use lftp instead of ftp for ENA xref upload

### DIFF
--- a/scripts/ftp/upload_ena_xrefs.sh
+++ b/scripts/ftp/upload_ena_xrefs.sh
@@ -28,16 +28,7 @@ if [ ! -d "$base_dir" ]; then
 fi
 
 function upload_file {
-    file=$(basename $1)
-    dir=$(dirname $1)
-    ftp -n -v ftp-private.ebi.ac.uk <<EOF
-lcd $dir
-user enaftp submit1
-prompt
-cd xref
-binary
-put $file
-EOF
+    lftp -e "put -O xref $1; bye" -u enaftp,submit1 ftp-private.ebi.ac.uk
 }
 
 for division in bacteria plants fungi metazoa protists; do


### PR DESCRIPTION
## Description

Use [lftp](https://lftp.yar.ru/) instead of `ftp` in `upload_ena_xrefs.sh`

## Benefits

If the connection is lost (e.g. slow server timing out), LFTP will automatically re-connect and restart the upload from where it was left.

Usage is also cleaner.

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [x] TravisCI passed on your branch
