### PR TITLE
GAPD pipeline fails for species  dioscorea_rotundata, as regex for tg…

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/GPAD/LoadFile.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/GPAD/LoadFile.pm
@@ -96,7 +96,7 @@ sub run {
           $go_evidence=$annotation_propertie;
         }
         elsif ($annotation_propertie =~ m/tgt_protein/){
-          $annotation_propertie =~ s/tgt_protein=[\w\-]+://;
+          $annotation_propertie =~ s/tgt_protein=[\w\-\d\.]+://;
           $tgt_protein=$annotation_propertie;
         }
         elsif ($annotation_propertie =~ m/tgt_transcript/){


### PR DESCRIPTION
GPAD pipeline fails at analysis Loadfile for species dioscorea_rotundata, as  tgt_protein annotation contains numeric value example: v2.0 ; and current regex accepts only word  

regex changed to match digit . 