### PR TITLE
use species scientific name instead of display name

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Base.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Base.pm
@@ -84,14 +84,15 @@ sub species_name {
   $self->throw("Missing dba parameter: species_name method") unless defined $dba;
 
   my $mca = $dba->get_adaptor("MetaContainer");
-  my $species_name = $mca->single_value_by_key('species.display_name');
+  #my $species_name = $mca->single_value_by_key('species.display_name');
+  my $species_name = $mca->single_value_by_key('species.scientific_name');
   if (defined $species_name and $species_name ne '') {
-    $species_name =~ s/^([\w ]+) [\-\(].+/$1/;
+    #$species_name =~ s/^([\w ]+) [\-\(].+/$1/;
+    #$species_name =~s/\s?\(\s?\w+.*//;  
     $species_name =~ s/ /_/g;
   } else {
     $self->throw("No species.display_name");
   }
-
   return $species_name;
 }
 


### PR DESCRIPTION
 New FTP Dump Pipeline creates the directories with species display name from meta table to dump the data.
While executing this pipeline for Rapid release 16 we observed The regex used to replace the comman name enclosed in the parenthesis and gca is failing for few cases example : **Cavia tschudii(Montane guinea pig) - GCA_004027695.1** 
for time being we suggest to use species scientific names instead of species display name 