### PR TITLE
Rapid Release ftp directory permissions

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Base_Filetype.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Base_Filetype.pm
@@ -113,6 +113,7 @@ sub filenames {
   }
   path($dir)->mkpath();
   path($dir)->chmod("g+w");
+  path($dir)->parent()->chmod("g+w");
 
   my %filenames;
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FileDump_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FileDump_conf.pm
@@ -43,7 +43,7 @@ sub default_options {
 
     genome_types  => [], # Possible values: 'Assembly_Chain', 'Chromosome_TSV', 'Genome_FASTA'
     geneset_types => [], # Possible values: 'Geneset_EMBL', 'Geneset_FASTA', 'Geneset_GFF3', 'Geneset_GTF', 'Xref_TSV'
-    rnaseq_types  => [], # Possible values: 'Symlink_RNASeq'
+    rnaseq_types  => [], # Possible values: 'RNASeq_Exists'
 
     dump_metadata  => 0,
     dump_mysql     => 0,


### PR DESCRIPTION
## Description
 Make parent directory group-writable, so that genebuild team can create an 'rnaseq' directory for an existing species.

## Use case
Genebuild team were not able to create a directory for Rapid Release rnaseq data if the species already existed.

## Testing
Module run in isolation.
