### PR TITLE
Load RNAcentral-derived GO terms in GPAD pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/GPAD/LoadFile.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/GPAD/LoadFile.pm
@@ -166,13 +166,18 @@ sub run {
       } elsif ($db =~ /RNAcentral/) {
         $self->log()->debug("Adding linkage to RNAcentral");
         $is_transcript = 1;
-        # Accession is the version with taxonomy id appended, e.g. URS0000007FBA_9606
-        # We store as URS0000007FBA, so need to remove everything from the _
-        # precursor_rna could be a list of accessions
-        my @precursor_rnas = split(",", $precursor_rna) if $precursor_rna;
-        foreach my $rna (@precursor_rnas) {
-          $rna =~ s/_[0-9]*//;
-          $db_object_id = $rna;
+        # For miRNA, we want the precursor(s), rather than the db ID,
+        # but for everything else we want the standard RNAcentral accession
+        my @db_object_ids;
+        if ($precursor_rna) {
+          @db_object_ids = split(",", $precursor_rna);
+        } else {
+          @db_object_ids = ($db_object_id)
+        }
+        foreach my $db_object_id (@db_object_ids) {
+          # The ID has the taxonomy id appended, e.g. URS0000007FBA_9606
+          # We store as URS0000007FBA, so need to remove the suffix.
+          $db_object_id =~ s/_[0-9]+$//;
           my $rnacentral_xrefs = $dbe_adaptor->fetch_all_by_name($db_object_id, 'RNAcentral');
           if (scalar(@$rnacentral_xrefs) != 0) {
             $master_xref = $rnacentral_xrefs->[0];

--- a/modules/Bio/EnsEMBL/Production/Pipeline/GPAD/LoadFile.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/GPAD/LoadFile.pm
@@ -166,8 +166,10 @@ sub run {
       } elsif ($db =~ /RNAcentral/) {
         $self->log()->debug("Adding linkage to RNAcentral");
         $is_transcript = 1;
-        # For miRNA, we want the precursor(s), rather than the db ID,
-        # but for everything else we want the standard RNAcentral accession
+        # For microRNAs, GOA link terms to the product; however, we annotate GO terms
+	# against transcripts, not mature products, i.e. precursor miRNAs. Fortunately,
+	# the accessions for the precursor(s) are in the GPAD file, so we can use those
+	# instead of the standard RNAcentral accession that we use for everything else.
         my @db_object_ids;
         if ($precursor_rna) {
           @db_object_ids = split(",", $precursor_rna);


### PR DESCRIPTION
## Description
The GOA team provide terms annotated against UniProt and RNAcentral identifiers (plus some other misc. sources) - however, a bug was introduced 4 years ago that prevented the loading of RNAcentral-derived terms, with the exception of those linked to microRNAs (which represent a very small amount of the total RNAcentral annotation). 

This fix continues to treat microRNAs differently, loading the precursors rather than the product (because we have the former not the latter in our dbs), but uses the given accession in all other cases.

## Testing
Test pipeline was run for panda - gained ~5000 GO terms linked to RNA genes.
