### PR TITLE
RNAcentral xref pipeline restructure

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProteinFeatures_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProteinFeatures_conf.pm
@@ -473,9 +473,26 @@ sub pipeline_analyses {
                             meta_filters    => $self->o('meta_filters'),
                           },
       -flow_into       => {
-                            '2->A' => ['BackupTables'],
+                            '2->A' => ['AnalysisConfiguration'],
                             'A->2' => ['RunDatachecks'],
                           }
+    },
+
+    {
+      -logic_name        => 'AnalysisConfiguration',
+      -module            => 'Bio::EnsEMBL::Production::Pipeline::ProteinFeatures::AnalysisConfiguration',
+      -max_retry_count   => 0,
+      -parameters        => {
+                              protein_feature_analyses  => $self->o('protein_feature_analyses'),
+                              interproscan_version      => $self->o('interproscan_version'),
+                              check_interpro_db_version => $self->o('check_interpro_db_version'),
+                              run_seg                   => $self->o('run_seg'),
+                              xref_analyses             => $self->o('xref_analyses'),
+                            },
+      -flow_into 	       => {
+                              '2->A' => ['BackupTables'],
+                              'A->3' => ['RemoveOrphans'],
+                            }
     },
 
     {
@@ -496,24 +513,7 @@ sub pipeline_analyses {
                               ],
                               output_file => catdir($self->o('pipeline_dir'), '#dbname#', 'pre_pipeline_bkp.sql.gz'),
                             },
-      -flow_into         => ['AnalysisConfiguration'],
-    },
-
-    {
-      -logic_name        => 'AnalysisConfiguration',
-      -module            => 'Bio::EnsEMBL::Production::Pipeline::ProteinFeatures::AnalysisConfiguration',
-      -max_retry_count   => 0,
-      -parameters        => {
-                              protein_feature_analyses  => $self->o('protein_feature_analyses'),
-                              interproscan_version      => $self->o('interproscan_version'),
-                              check_interpro_db_version => $self->o('check_interpro_db_version'),
-                              run_seg                   => $self->o('run_seg'),
-                              xref_analyses             => $self->o('xref_analyses'),
-                            },
-      -flow_into 	       => {
-                              '2->A' => ['AnalysisSetup'],
-                              'A->3' => ['RemoveOrphans'],
-                            }
+      -flow_into         => ['AnalysisSetup'],
     },
 
     {

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProteinFeatures_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProteinFeatures_conf.pm
@@ -473,26 +473,9 @@ sub pipeline_analyses {
                             meta_filters    => $self->o('meta_filters'),
                           },
       -flow_into       => {
-                            '2->A' => ['AnalysisConfiguration'],
+                            '2->A' => ['BackupTables'],
                             'A->2' => ['RunDatachecks'],
                           }
-    },
-
-    {
-      -logic_name        => 'AnalysisConfiguration',
-      -module            => 'Bio::EnsEMBL::Production::Pipeline::ProteinFeatures::AnalysisConfiguration',
-      -max_retry_count   => 0,
-      -parameters        => {
-                              protein_feature_analyses  => $self->o('protein_feature_analyses'),
-                              interproscan_version      => $self->o('interproscan_version'),
-                              check_interpro_db_version => $self->o('check_interpro_db_version'),
-                              run_seg                   => $self->o('run_seg'),
-                              xref_analyses             => $self->o('xref_analyses'),
-                            },
-      -flow_into 	       => {
-                              '2->A' => ['BackupTables'],
-                              'A->3' => ['RemoveOrphans'],
-                            }
     },
 
     {
@@ -513,7 +496,24 @@ sub pipeline_analyses {
                               ],
                               output_file => catdir($self->o('pipeline_dir'), '#dbname#', 'pre_pipeline_bkp.sql.gz'),
                             },
-      -flow_into         => ['AnalysisSetup'],
+      -flow_into         => ['AnalysisConfiguration'],
+    },
+
+    {
+      -logic_name        => 'AnalysisConfiguration',
+      -module            => 'Bio::EnsEMBL::Production::Pipeline::ProteinFeatures::AnalysisConfiguration',
+      -max_retry_count   => 0,
+      -parameters        => {
+                              protein_feature_analyses  => $self->o('protein_feature_analyses'),
+                              interproscan_version      => $self->o('interproscan_version'),
+                              check_interpro_db_version => $self->o('check_interpro_db_version'),
+                              run_seg                   => $self->o('run_seg'),
+                              xref_analyses             => $self->o('xref_analyses'),
+                            },
+      -flow_into 	       => {
+                              '2->A' => ['AnalysisSetup'],
+                              'A->3' => ['RemoveOrphans'],
+                            }
     },
 
     {

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/RNAGeneXref_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/RNAGeneXref_conf.pm
@@ -144,9 +144,21 @@ sub pipeline_analyses {
                             meta_filters    => $self->o('meta_filters'),
                           },
       -flow_into       => {
-                            '2->A' => ['BackupTables'],
-                            'A->2' => ['RunDatachecks'],
+                            '2' => ['AnalysisConfiguration'],
                           }
+    },
+
+    {
+      -logic_name        => 'AnalysisConfiguration',
+      -module            => 'Bio::EnsEMBL::Production::Pipeline::RNAGeneXref::AnalysisConfiguration',
+      -max_retry_count   => 0,
+      -parameters        => {
+                              analyses => $self->o('analyses'),
+                            },
+      -flow_into 	       => {
+                              '2->A' => ['BackupTables'],
+                              'A->3' => ['SpeciesFactory'],
+                            }
     },
 
     {
@@ -162,21 +174,9 @@ sub pipeline_analyses {
                                 'xref',
                               ],
                               output_file => catdir($self->o('pipeline_dir'), '#dbname#', 'pre_pipeline_bkp.sql.gz'),
+                              overwrite   => 1,
                             },
-      -flow_into         => ['AnalysisConfiguration'],
-    },
-
-    {
-      -logic_name        => 'AnalysisConfiguration',
-      -module            => 'Bio::EnsEMBL::Production::Pipeline::RNAGeneXref::AnalysisConfiguration',
-      -max_retry_count   => 0,
-      -parameters        => {
-                              analyses => $self->o('analyses'),
-                            },
-      -flow_into 	       => {
-                              '2->A' => ['AnalysisSetup'],
-                              'A->3' => ['SpeciesFactory'],
-                            }
+      -flow_into         => ['AnalysisSetup'],
     },
 
     {
@@ -212,6 +212,7 @@ sub pipeline_analyses {
       -parameters        => {
                               logic_name => $self->o('rnacentral_logic_name'),
                             },
+      -flow_into         => ['RunDatachecks'],
     },
 
     {


### PR DESCRIPTION
## Description
Restructure pipeline a bit, so that we don't bother doing a backup of the tables if we are not going to process a species.

## Use case
We had a cryptic failure when annotating RNAcentral xrefs, where the data got linked to two different analyses; sometimes that can happen if a job is restarted, but it couldn't be replicated to test further. Perhaps just a transient error, but the pipeline was actually doing a bunch of work it didn't need to do (backup dumps and datachecks when no data had changed), so it couldn't hurt to eliminate that, and reduce the concurrency and load on the db.

## Testing
New pipeline initialised and run to successful completion.
