### PR TITLE
Rewrite Rapid Release Xref TSV file dump to use SQL not API 

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Base.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Base.pm
@@ -196,6 +196,8 @@ sub has_seq_region_attribs {
 sub assert_executable {
   my ($self, $exe) = @_;
 
+  $exe =~ s/\s+.+//;
+
   if ( !-x $exe ) {
     my $output = `which $exe 2>&1`;
     chomp $output;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/README.txt
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/README.txt
@@ -229,13 +229,15 @@ UniProt. The file has the following columns:
     * CHECKSUM: an exact sequence match
     * SEQUENCE_MATCH: an alignment based sequence match (not
       necessarily exact)
- * dependent_sources: For transitively-derived cross-references, the
-   external data source and identifier used as intermediary
+ * source: For transitively-derived cross-references, the
+   external data source and identifier used as intermediary.
+   For GO terms, the method of inference, e.g. IEA is also given.
+   These elements are separated by colons ':'
+   Multiple sources are separated by semi-colons ';'
  * source_identity: For alignment-derived cross-references, the
    percentage of the Ensembl sequence that matches the external sequence
  * xref_identity: For alignment-derived cross-references, the
    percentage of the external sequence that matches the Ensembl sequence
- * linkage_type: for GO terms, the method of inference, e.g. IEA
 
 
 ========================================================================

--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Xref_TSV.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Xref_TSV.pm
@@ -49,6 +49,8 @@ sub run {
   my $filename = $$filenames{$data_type};
   my $file = path($filename);
 
+  $file->spew('');
+
   $self->print_xrefs($file, $external_dbs);
 
   $file->spew($self->header, sort $file->lines);
@@ -113,14 +115,12 @@ sub print_xref_subset {
 
   my $helper  = $self->dba->dbc->sql_helper;
   my $results = $helper->execute(
-    -SQL => $sql,
-    -CALLBACK => sub {
-                   my @row = @{ shift @_ };
-                   return { join("\t", @row) };
-                 }
+    -SQL => $sql
   );
 
-  $file->spew(join("\n", @$results));
+  foreach my $result (@$results) {
+    $file->append(join("\t", @$result));
+  }
 }
 
 sub go_xref_sql {


### PR DESCRIPTION
## Description
The Xref dumping is very slow using the API; this rewrites the module to use a handful of SQL queries, which are vastly quicker (~5 mins, rather than hours), and probably easier to understand than the previous set of API calls. Memory usage is reduced too. 

These changes also fix a bug where sources for GO terms were not correctly retrieved - the API-based code was not filtering on the transcript, so the sources were reported for all transcripts. Further, only one 'linkage_type' was reported in these cases; this is a per source property, however, so the value was moved to the compound 'sources' field. And the name of the field changed too, because 'dependent_sources' could be taken to mean that these were annotations dependent on the GO term, rather than the other way around.

## Benefits
File dumping for Rapid Release is much quicker - periodic updates for protein features and GO terms, for all species, are easier within the 2-week timeframe.

## Possible Drawbacks
Less robust against schema changes, but those are very unlikely.

## Testing
Run successfully for all current RR species.
