### PR TITLE
Fix apply_patches dbname parameter matching as substring

### DIFF
--- a/scripts/apply_patches.pl
+++ b/scripts/apply_patches.pl
@@ -79,7 +79,7 @@ my $dbh = DBI->connect($dsn, $opts->{user}, $opts->{pass}) ||
 my $available_databases = [];
 if (!defined $opts->{pattern}) {
   if (defined $opts->{database}) {
-    $opts->{pattern} = $opts->{database};
+    $opts->{pattern} = '^'.$opts->{database}.'$';
   }
   else {
     $opts->{pattern} = '.*';


### PR DESCRIPTION
## Description

Prevent matching database names that include dbname parameter value as
substring.

## Use case

For example calling the script with `-dbname ensembl` will
*not* match `ensembl_production`

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch
