### PR TITLE
Updating test biotype table and related test

### DIFF
--- a/modules/t/11-searchdumps_dumpgenes.t
+++ b/modules/t/11-searchdumps_dumpgenes.t
@@ -196,7 +196,7 @@ subtest "Checking protein_coding gene", sub {
                 'name'                => 'OR2W1-001',
                 'strand'              => -1,
                 'biotype'             => 'protein_coding',
-                'so_term'             => 'mRNA'.
+                'so_term'             => 'mRNA',
                 'seq_region_name'     => '6',
                 'translations'        => [
                     {
@@ -1221,7 +1221,7 @@ subtest "Checking ncRNA gene", sub {
             'strand'              => '-1',
             'biotype'             => 'processed_pseudogene',
                
-            'so_term'             => undef, 
+            'so_term'             => 'pseudogenic_transcript',
             'version'             => '1',
             'description'         => undef,
             'gene_id'             => 'ENSG00000261370',
@@ -1326,7 +1326,7 @@ subtest "Checking ncRNA gene", sub {
             'ensembl_object_type' => 'transcript' } ],
         'version'             => '1',
         'biotype'             => 'pseudogene',
-        'so_term'             => undef,  
+        'so_term'             => 'pseudogene',
         'source'              => 'havana',
         'strand'              => '-1',
         'end'                 => '970836',

--- a/modules/t/test-genome-DBs/hp_dump/core/biotype.txt
+++ b/modules/t/test-genome-DBs/hp_dump/core/biotype.txt
@@ -1,207 +1,210 @@
-1	IG_C_gene	gene	core,otherfeatures,presite	100	\N	coding	SO:0001217	\N
-2	IG_C_gene	transcript	core,otherfeatures,presite	\N	\N	coding	SO:0000478	\N
-3	IG_D_gene	gene	core,otherfeatures,presite	100	\N	coding	SO:0001217	\N
-4	IG_D_gene	transcript	core,otherfeatures,presite	\N	\N	coding	SO:0000458	\N
-5	IG_J_gene	gene	core,otherfeatures,presite	100	\N	coding	SO:0001217	\N
-6	IG_J_gene	transcript	core,otherfeatures,presite	\N	\N	coding	SO:0000470	\N
-7	IG_J_pseudogene	gene	core,otherfeatures,presite	67	\N	pseudogene	SO:0000336	\N
-8	IG_J_pseudogene	transcript	core,otherfeatures,presite	\N	\N	pseudogene	SO:0000516	\N
-9	IG_V_gene	gene	core,otherfeatures,presite	100	\N	coding	SO:0001217	\N
-10	IG_V_gene	transcript	core,otherfeatures,presite	\N	\N	coding	SO:0000466	\N
-11	IG_V_pseudogene	gene	core,otherfeatures,presite	67	\N	pseudogene	SO:0000336	\N
-12	IG_V_pseudogene	transcript	core,otherfeatures,presite	\N	\N	pseudogene	SO:0000516	\N
-13	IG_gene	gene	vega	\N	\N	coding	SO:0001217	\N
-14	IG_gene	transcript	vega	\N	\N	coding	SO:3000000	\N
-15	IG_pseudogene	gene	core,vega,presite	67	\N	pseudogene	SO:0000336	\N
-16	IG_pseudogene	transcript	core,vega,presite	\N	\N	pseudogene	SO:0000516	\N
+1	IG_C_gene	gene	core,otherfeatures,presite	100	\N	coding	SO:0001217	protein_coding_gene
+2	IG_C_gene	transcript	core,otherfeatures,presite	\N	\N	coding	SO:0000478	C_gene_segment
+3	IG_D_gene	gene	core,otherfeatures,presite	100	\N	coding	SO:0001217	protein_coding_gene
+4	IG_D_gene	transcript	core,otherfeatures,presite	\N	\N	coding	SO:0000458	D_gene_segment
+5	IG_J_gene	gene	core,otherfeatures,presite	100	\N	coding	SO:0001217	protein_coding_gene
+6	IG_J_gene	transcript	core,otherfeatures,presite	\N	\N	coding	SO:0000470	J_gene_segment
+7	IG_J_pseudogene	gene	core,otherfeatures,presite	67	\N	pseudogene	SO:0000336	pseudogene
+8	IG_J_pseudogene	transcript	core,otherfeatures,presite	\N	\N	pseudogene	SO:0000516	pseudogenic_transcript
+9	IG_V_gene	gene	core,otherfeatures,presite	100	\N	coding	SO:0001217	protein_coding_gene
+10	IG_V_gene	transcript	core,otherfeatures,presite	\N	\N	coding	SO:0000466	V_gene_segment
+11	IG_V_pseudogene	gene	core,otherfeatures,presite	67	\N	pseudogene	SO:0000336	pseudogene
+12	IG_V_pseudogene	transcript	core,otherfeatures,presite	\N	\N	pseudogene	SO:0000516	pseudogenic_transcript
+13	IG_gene	gene	vega	\N	\N	coding	SO:0001217	protein_coding_gene
+14	IG_gene	transcript	vega	\N	\N	coding	SO:3000000	gene_segment
+15	IG_pseudogene	gene	core,vega,presite	67	\N	pseudogene	SO:0000336	pseudogene
+16	IG_pseudogene	transcript	core,vega,presite	\N	\N	pseudogene	SO:0000516	pseudogenic_transcript
 17	LRG_gene	gene	core	\N	\N	LRG	\N	\N
 18	LRG_gene	transcript	core	\N	\N	LRG	\N	\N
-19	Mt_rRNA	gene	core,presite	73	\N	snoncoding	SO:0001263	\N
-20	Mt_rRNA	transcript	core,presite	\N	\N	snoncoding	SO:0000252	\N
-21	Mt_tRNA	gene	core,presite	74	\N	snoncoding	SO:0001263	\N
-22	Mt_tRNA	transcript	core,presite	\N	\N	snoncoding	SO:0000253	\N
-23	Mt_tRNA_pseudogene	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336	\N
-24	Mt_tRNA_pseudogene	transcript	core	\N	noncoding RNA pseudogene	pseudogene	SO:0000516	\N
+19	Mt_rRNA	gene	core,presite	73	\N	snoncoding	SO:0001263	ncRNA_gene
+20	Mt_rRNA	transcript	core,presite	\N	\N	snoncoding	SO:0000252	rRNA
+21	Mt_tRNA	gene	core,presite	74	\N	snoncoding	SO:0001263	ncRNA_gene
+22	Mt_tRNA	transcript	core,presite	\N	\N	snoncoding	SO:0000253	tRNA
+23	Mt_tRNA_pseudogene	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336	pseudogene
+24	Mt_tRNA_pseudogene	transcript	core	\N	noncoding RNA pseudogene	pseudogene	SO:0000516	pseudogenic_transcript
 25	RNA-Seq_gene	gene	otherfeatures	\N	\N	undefined	\N	\N
 26	RNA-Seq_gene	transcript	otherfeatures	\N	\N	undefined	\N	\N
 27	TEC	gene	core,vega,sangervega	0	\N	undefined	\N	\N
-28	TEC	transcript	core,vega,sangervega	\N	\N	undefined	SO:0002139	\N
-29	TR_gene	gene	vega	\N	\N	coding	SO:0001217	\N
-30	TR_gene	transcript	core,vega	\N	\N	coding	SO:3000000	\N
-31	TR_pseudogene	gene	vega	\N	\N	pseudogene	SO:0000336	\N
-32	TR_pseudogene	transcript	vega	0	\N	pseudogene	SO:0000516	\N
-33	ambiguous_orf	transcript	core,vega	\N	\N	lnoncoding	SO:0001877	\N
+28	TEC	transcript	core,vega,sangervega	\N	\N	undefined	SO:0002139	unconfirmed_transcript
+29	TR_gene	gene	otherfeatures,vega	\N	\N	coding	SO:0001217	protein_coding_gene
+30	TR_gene	transcript	core,otherfeatures,vega	\N	\N	coding	SO:3000000	gene_segment
+31	TR_pseudogene	gene	otherfeatures,vega	\N	\N	pseudogene	SO:0000336	pseudogene
+32	TR_pseudogene	transcript	otherfeatures,vega	\N	\N	pseudogene	SO:0000516	pseudogenic_transcript
+33	ambiguous_orf	transcript	core,vega	\N	\N	lnoncoding	SO:0001877	lnc_RNA
 35	cdna_update	gene	cdna	\N	\N	undefined	\N	\N
 36	cdna_update	transcript	cdna	\N	\N	undefined	\N	\N
-37	cdna	gene	otherfeatures	\N	\N	undefined	SO:0000756	\N
-38	cdna	transcript	otherfeatures	\N	\N	undefined	SO:0000756	\N
-39	disrupted_domain	transcript	core,vega	\N	\N	pseudogene	SO:0000516	\N
-40	est	gene	otherfeatures	\N	\N	undefined	\N	\N
-41	est	transcript	otherfeatures	\N	\N	undefined	SO:0000345	\N
-42	lincRNA	gene	core,vega,presite	190	\N	lnoncoding	SO:0001263	\N
-43	lincRNA	transcript	core,vega,presite	\N	\N	lnoncoding	SO:0001877	\N
-44	miRNA	gene	core,otherfeatures,vega,presite	70	From RefSeq import.	snoncoding	SO:0001263	\N
-45	miRNA	transcript	core,otherfeatures,presite	\N	From RefSeq import.	snoncoding	SO:0000276	\N
-46	miRNA_pseudogene	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336	\N
-47	miRNA_pseudogene	transcript	core	\N	noncoding RNA pseudogene	pseudogene	SO:0000516	\N
-48	misc_RNA	gene	core,otherfeatures,presite	\N	\N	mnoncoding	SO:0001263	\N
-49	misc_RNA	transcript	core,otherfeatures,presite	\N	\N	mnoncoding	SO:0000655	\N
-50	misc_RNA_pseudogene	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336	\N
-51	misc_RNA_pseudogene	transcript	core	\N	noncoding RNA pseudogene	pseudogene	SO:0000516	\N
-52	ncRNA	gene	core,otherfeatures	99	\N	snoncoding	SO:0001263	\N
-53	ncRNA	transcript	core,otherfeatures	\N	\N	snoncoding	SO:0000655	\N
-54	non_coding	gene	core,otherfeatures,rnaseq,vega,presite	353	\N	lnoncoding	SO:0001263	\N
-55	non_coding	transcript	core,otherfeatures,rnaseq,vega,presite	\N	\N	lnoncoding	SO:0001877	\N
-56	nonsense_mediated_decay	transcript	core,vega,presite	\N	\N	coding	SO:0000234	\N
-57	polymorphic	gene	vega	\N	\N	coding	SO:0001217	\N
-58	polymorphic_pseudogene	gene	core,vega,presite	67	\N	coding	SO:0001217	\N
-59	polymorphic_pseudogene	transcript	core,vega,presite	\N	\N	coding	SO:0000234	\N
-60	processed_pseudogene	gene	core,vega,presite	\N	\N	pseudogene	SO:0000336	\N
-61	processed_pseudogene	transcript	core,vega,presite	\N	\N	pseudogene	SO:0000516	\N
-62	processed_transcript	gene	core,vega,presite	79	\N	lnoncoding	SO:0001263	\N
-63	processed_transcript	transcript	core,vega,presite	\N	\N	lnoncoding	SO:0001877	\N
-64	protein_coding	gene	core,otherfeatures,rnaseq,vega,presite	\N	\N	coding	SO:0001217	\N
-65	protein_coding	transcript	core,otherfeatures,rnaseq,vega,presite	\N	\N	coding	SO:0000234	\N
-66	pseudogene	gene	core,otherfeatures,vega,presite	67	\N	pseudogene	SO:0000336	\N
-67	pseudogene	transcript	core,otherfeatures,vega,presite	\N	\N	pseudogene	SO:0000516	\N
-68	rRNA	gene	core,otherfeatures,vega,presite	\N	\N	snoncoding	SO:0001263	\N
-69	rRNA	transcript	core,otherfeatures,vega,presite	\N	\N	snoncoding	SO:0000252	\N
-70	rRNA_pseudogene	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336	\N
-71	rRNA_pseudogene	transcript	core	\N	noncoding RNA pseudogene	pseudogene	SO:0000516	\N
-72	retained_intron	transcript	core,vega,presite	\N	\N	lnoncoding	SO:0001877	\N
-75	scRNA_pseudogene	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336	\N
-76	scRNA_pseudogene	transcript	core	\N	noncoding RNA pseudogene	pseudogene	SO:0000516	\N
-77	snRNA	gene	core,otherfeatures,vega,presite	68	From Havana manual annotation.	snoncoding	SO:0001263	\N
-78	snRNA	transcript	core,otherfeatures,vega,presite	\N	From Havana manual annotation.	snoncoding	SO:0000274	\N
-79	snRNA_pseudogene	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336	\N
-80	snRNA_pseudogene	transcript	core	\N	noncoding RNA pseudogene	pseudogene	SO:0000516	\N
-81	snlRNA	gene	core	78	\N	snoncoding	SO:0001263	\N
-82	snlRNA	transcript	core	\N	\N	snoncoding	SO:0000274	\N
-83	snoRNA	gene	core,otherfeatures,vega,presite	69	small nucleolar RNA.	snoncoding	SO:0001263	\N
-84	snoRNA	transcript	core,otherfeatures,vega,presite	\N	small nucleolar RNA.	snoncoding	SO:0000275	\N
-85	snoRNA_pseudogene	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336	\N
-86	snoRNA_pseudogene	transcript	core	\N	noncoding RNA pseudogene	pseudogene	SO:0000516	\N
-87	tRNA	gene	core,otherfeatures,presite	76	\N	snoncoding	SO:0001263	\N
-88	tRNA	transcript	core,otherfeatures,presite	76	\N	snoncoding	SO:0000253	\N
-89	tRNA_pseudogene	gene	core,otherfeatures	\N	noncoding RNA pseudogene	pseudogene	SO:0000336	\N
-90	tRNA_pseudogene	transcript	core,otherfeatures	\N	noncoding RNA pseudogene	pseudogene	SO:0000516	\N
-91	transcribed_processed_pseudogene	gene	core,vega,presite	\N	\N	pseudogene	SO:0000336	\N
-92	transcribed_processed_pseudogene	transcript	core,vega,presite	\N	\N	pseudogene	SO:0000516	\N
-93	transcribed_unitary_pseudogene	gene	core,vega	\N	\N	pseudogene	SO:0000336	\N
-94	transcribed_unprocessed_pseudogene	gene	core,vega,presite	\N	\N	pseudogene	SO:0000336	\N
-95	transcribed_unprocessed_pseudogene	transcript	core,vega,presite	\N	\N	pseudogene	SO:0000516	\N
-96	unitary_pseudogene	gene	core,vega,presite	\N	\N	pseudogene	SO:0000336	\N
-97	unitary_pseudogene	transcript	core,vega,presite	\N	\N	pseudogene	SO:0000516	\N
-98	unprocessed_pseudogene	gene	core,vega,presite	\N	\N	pseudogene	SO:0000336	\N
-99	unprocessed_pseudogene	transcript	core,vega,presite	\N	\N	pseudogene	SO:0000516	\N
+37	cDNA	gene	otherfeatures	\N		undefined	SO:0000756	cDNA
+38	cDNA	transcript	otherfeatures	\N		undefined	SO:0000756	cDNA
+39	disrupted_domain	transcript	core,vega	\N	\N	pseudogene	SO:0000516	pseudogenic_transcript
+40	EST	gene	otherfeatures	\N		undefined	\N	\N
+41	EST	transcript	otherfeatures	\N		undefined	SO:0000345	EST
+42	lincRNA	gene	core,vega,presite	190	\N	lnoncoding	SO:0001263	ncRNA_gene
+43	lincRNA	transcript	core,vega,presite	\N	\N	lnoncoding	SO:0001877	lnc_RNA
+44	miRNA	gene	core,otherfeatures,vega,presite	70	From RefSeq import.	snoncoding	SO:0001263	ncRNA_gene
+45	miRNA	transcript	core,otherfeatures,presite	\N	From RefSeq import.	snoncoding	SO:0000276	miRNA
+46	miRNA_pseudogene	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336	pseudogene
+47	miRNA_pseudogene	transcript	core	\N	noncoding RNA pseudogene	pseudogene	SO:0000516	pseudogenic_transcript
+48	misc_RNA	gene	core,otherfeatures,presite	\N	\N	mnoncoding	SO:0001263	ncRNA_gene
+49	misc_RNA	transcript	core,otherfeatures,presite	\N	\N	mnoncoding	SO:0000655	ncRNA
+50	misc_RNA_pseudogene	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336	pseudogene
+51	misc_RNA_pseudogene	transcript	core	\N	noncoding RNA pseudogene	pseudogene	SO:0000516	pseudogenic_transcript
+52	ncRNA	gene	core,otherfeatures	99	\N	snoncoding	SO:0001263	ncRNA_gene
+53	ncRNA	transcript	core,otherfeatures	\N	\N	snoncoding	SO:0000655	ncRNA
+54	non_coding	gene	core,otherfeatures,rnaseq,vega,presite	353	\N	lnoncoding	SO:0001263	ncRNA_gene
+55	non_coding	transcript	core,otherfeatures,rnaseq,vega,presite	\N	\N	lnoncoding	SO:0001877	lnc_RNA
+56	nonsense_mediated_decay	transcript	core,vega,presite	\N	\N	coding	SO:0000234	mRNA
+57	polymorphic	gene	vega	\N	\N	coding	SO:0001217	protein_coding_gene
+58	polymorphic_pseudogene	gene	core,vega,presite	67	\N	coding	SO:0001217	protein_coding_gene
+59	polymorphic_pseudogene	transcript	core,vega,presite	\N	\N	coding	SO:0000234	mRNA
+60	processed_pseudogene	gene	core,vega,presite	\N	\N	pseudogene	SO:0000336	pseudogene
+61	processed_pseudogene	transcript	core,vega,presite	\N	\N	pseudogene	SO:0000516	pseudogenic_transcript
+62	processed_transcript	gene	core,vega,presite	79	\N	lnoncoding	SO:0001263	ncRNA_gene
+63	processed_transcript	transcript	core,vega,presite	\N	\N	lnoncoding	SO:0001877	lnc_RNA
+64	protein_coding	gene	core,otherfeatures,rnaseq,vega,presite	\N	\N	coding	SO:0001217	protein_coding_gene
+65	protein_coding	transcript	core,otherfeatures,rnaseq,vega,presite	\N	\N	coding	SO:0000234	mRNA
+66	pseudogene	gene	core,otherfeatures,vega,presite	67	\N	pseudogene	SO:0000336	pseudogene
+67	pseudogene	transcript	core,otherfeatures,vega,presite	\N	\N	pseudogene	SO:0000516	pseudogenic_transcript
+68	rRNA	gene	core,otherfeatures,vega,presite	\N	\N	snoncoding	SO:0001263	ncRNA_gene
+69	rRNA	transcript	core,otherfeatures,vega,presite	\N	\N	snoncoding	SO:0000252	rRNA
+70	rRNA_pseudogene	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336	pseudogene
+71	rRNA_pseudogene	transcript	core	\N	noncoding RNA pseudogene	pseudogene	SO:0000516	pseudogenic_transcript
+72	retained_intron	transcript	core,vega,presite	\N	\N	lnoncoding	SO:0001877	lnc_RNA
+75	scRNA_pseudogene	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336	pseudogene
+76	scRNA_pseudogene	transcript	core	\N	noncoding RNA pseudogene	pseudogene	SO:0000516	pseudogenic_transcript
+77	snRNA	gene	core,otherfeatures,vega,presite	68	From Havana manual annotation.	snoncoding	SO:0001263	ncRNA_gene
+78	snRNA	transcript	core,otherfeatures,vega,presite	\N	From Havana manual annotation.	snoncoding	SO:0000274	snRNA
+79	snRNA_pseudogene	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336	pseudogene
+80	snRNA_pseudogene	transcript	core	\N	noncoding RNA pseudogene	pseudogene	SO:0000516	pseudogenic_transcript
+81	snlRNA	gene	core	78	\N	snoncoding	SO:0001263	ncRNA_gene
+82	snlRNA	transcript	core	\N	\N	snoncoding	SO:0000274	snRNA
+83	snoRNA	gene	core,otherfeatures,vega,presite	69	small nucleolar RNA.	snoncoding	SO:0001263	ncRNA_gene
+84	snoRNA	transcript	core,otherfeatures,vega,presite	\N	small nucleolar RNA.	snoncoding	SO:0000275	snoRNA
+85	snoRNA_pseudogene	gene	core	75	noncoding RNA pseudogene	pseudogene	SO:0000336	pseudogene
+86	snoRNA_pseudogene	transcript	core	\N	noncoding RNA pseudogene	pseudogene	SO:0000516	pseudogenic_transcript
+87	tRNA	gene	core,otherfeatures,presite	76	\N	snoncoding	SO:0001263	ncRNA_gene
+88	tRNA	transcript	core,otherfeatures,presite	76	\N	snoncoding	SO:0000253	tRNA
+89	tRNA_pseudogene	gene	core,otherfeatures	\N	noncoding RNA pseudogene	pseudogene	SO:0000336	pseudogene
+90	tRNA_pseudogene	transcript	core,otherfeatures	\N	noncoding RNA pseudogene	pseudogene	SO:0000516	pseudogenic_transcript
+91	transcribed_processed_pseudogene	gene	core,vega,presite	\N	\N	pseudogene	SO:0000336	pseudogene
+92	transcribed_processed_pseudogene	transcript	core,vega,presite	\N	\N	pseudogene	SO:0000516	pseudogenic_transcript
+93	transcribed_unitary_pseudogene	gene	core,vega	\N	\N	pseudogene	SO:0000336	pseudogene
+94	transcribed_unprocessed_pseudogene	gene	core,vega,presite	\N	\N	pseudogene	SO:0000336	pseudogene
+95	transcribed_unprocessed_pseudogene	transcript	core,vega,presite	\N	\N	pseudogene	SO:0000516	pseudogenic_transcript
+96	unitary_pseudogene	gene	core,vega,presite	\N	\N	pseudogene	SO:0000336	pseudogene
+97	unitary_pseudogene	transcript	core,vega,presite	\N	\N	pseudogene	SO:0000516	pseudogenic_transcript
+98	unprocessed_pseudogene	gene	core,vega,presite	\N	\N	pseudogene	SO:0000336	pseudogene
+99	unprocessed_pseudogene	transcript	core,vega,presite	\N	\N	pseudogene	SO:0000516	pseudogenic_transcript
 100	ccds_gene	gene	otherfeatures	\N	Imported CCDS gene models	undefined	\N	\N
 101	protein_coding_in_progress	gene	vega	\N	occurs where the ORF is lost when remapping to a different assembly and the gene is awaiting reannotation	undefined	\N	\N
-102	IG_Z_gene	gene	core,vega	100	\N	coding	SO:0001217	\N
-103	IG_M_gene	gene	core,vega	100	\N	coding	SO:0001217	\N
+102	IG_Z_gene	gene	core,vega	100	\N	coding	SO:0001217	protein_coding_gene
+103	IG_M_gene	gene	core,vega	100	\N	coding	SO:0001217	protein_coding_gene
 104	ncRNA_host	transcript	core,vega	\N	\N	lnoncoding	\N	\N
-105	TR_V_pseudogene	gene	core,presite	67	\N	pseudogene	SO:0000336	\N
-106	TR_V_gene	gene	core,presite	100	\N	coding	SO:0001217	\N
-107	IG_C_pseudogene	gene	core,otherfeatures,presite	67	\N	pseudogene	SO:0000336	\N
-108	TR_C_gene	gene	core,presite	100	\N	coding	SO:0001217	\N
-109	TR_J_gene	gene	core,presite	100	\N	coding	SO:0001217	\N
-110	TR_V_pseudogene	transcript	core,presite	\N	\N	pseudogene	SO:0000516	\N
-111	TR_V_gene	transcript	core,presite	\N	\N	coding	SO:0000466	\N
-112	IG_C_pseudogene	transcript	core,otherfeatures,presite	\N	\N	pseudogene	SO:0000516	\N
-113	TR_C_gene	transcript	core,presite	\N	\N	coding	SO:0000478	\N
-114	TR_J_gene	transcript	core,presite	\N	\N	coding	SO:0000470	\N
+105	TR_V_pseudogene	gene	core,otherfeatures,presite	67	\N	pseudogene	SO:0000336	pseudogene
+106	TR_V_gene	gene	core,otherfeatures,presite	100	\N	coding	SO:0001217	protein_coding_gene
+107	IG_C_pseudogene	gene	core,otherfeatures,presite	67	\N	pseudogene	SO:0000336	pseudogene
+108	TR_C_gene	gene	core,otherfeatures,presite	100	\N	coding	SO:0001217	protein_coding_gene
+109	TR_J_gene	gene	core,otherfeatures,presite	100	\N	coding	SO:0001217	protein_coding_gene
+110	TR_V_pseudogene	transcript	core,otherfeatures,presite	\N	\N	pseudogene	SO:0000516	pseudogenic_transcript
+111	TR_V_gene	transcript	core,otherfeatures,presite	\N	\N	coding	SO:0000466	V_gene_segment
+112	IG_C_pseudogene	transcript	core,otherfeatures,presite	\N	\N	pseudogene	SO:0000516	pseudogenic_transcript
+113	TR_C_gene	transcript	core,otherfeatures,presite	\N	\N	coding	SO:0000478	C_gene_segment
+114	TR_J_gene	transcript	core,otherfeatures,presite	\N	\N	coding	SO:0000470	J_gene_segment
 115	protein_coding_in_progress	transcript	vega	\N	occurs where the ORF is lost when remapping to a different assembly and the gene is awaiting reannotation	undefined	\N	\N
-116	IG_M_gene	transcript	core	\N	\N	coding	SO:3000000	\N
-117	IG_Z_gene	transcript	core	\N	\N	coding	SO:3000000	\N
-118	3prime_overlapping_ncRNA	transcript	core,vega,presite	\N	\N	lnoncoding	SO:0002120	\N
-123	antisense_RNA	gene	core,otherfeatures	\N	From RefSeq import	lnoncoding	SO:0001263	\N
-124	antisense_RNA	transcript	core,otherfeatures	\N	From RefSeq import	lnoncoding	SO:0001877	\N
-125	scRNA	gene	core,otherfeatures,vega	\N	From RefSeq import or Havana manual annotation.	snoncoding	SO:0001263	\N
-126	scRNA	transcript	core,otherfeatures,vega	\N	From RefSeq import or Havana manual annotation.	snoncoding	SO:0000013	\N
-127	RNase_MRP_RNA	gene	core,otherfeatures,presite	\N	From RefSeq import or Rfamscan	snoncoding	SO:0001263	\N
-128	RNase_MRP_RNA	transcript	core,otherfeatures,presite	\N	From RefSeq import or Rfamscan	snoncoding	SO:0000385	\N
-129	RNase_P_RNA	gene	core,otherfeatures,presite	\N	From RefSeq import or Rfamscan	snoncoding	SO:0001263	\N
-130	RNase_P_RNA	transcript	core,otherfeatures,presite	\N	From RefSeq import or Rfamscan	snoncoding	SO:0000386	\N
-131	telomerase_RNA	gene	core,otherfeatures,presite	\N	From RefSeq import or Rfamscan	snoncoding	SO:0001263	\N
-132	telomerase_RNA	transcript	core,otherfeatures,presite	\N	From RefSeq import or Rfamscan	snoncoding	SO:0000390	\N
-133	sense_intronic	transcript	core,vega,presite	0	\N	lnoncoding	SO:0001877	\N
-135	sense_overlapping	transcript	core,vega,presite	0	\N	lnoncoding	SO:0001877	\N
-138	sense_intronic	gene	core,vega,presite	350	\N	lnoncoding	SO:0001263	\N
-139	ambiguous_orf	gene	core,vega	351	\N	lnoncoding	SO:0001263	\N
-140	retained_intron	gene	core,vega,presite	352	\N	lnoncoding	SO:0001263	\N
+116	IG_M_gene	transcript	core	\N	\N	coding	SO:3000000	gene_segment
+117	IG_Z_gene	transcript	core	\N	\N	coding	SO:3000000	gene_segment
+118	3prime_overlapping_ncRNA	transcript	core,vega,presite	\N	\N	lnoncoding	SO:0002120	three_prime_overlapping_ncrna
+123	antisense_RNA	gene	core,otherfeatures	\N	From RefSeq import	lnoncoding	SO:0001263	ncRNA_gene
+124	antisense_RNA	transcript	core,otherfeatures	\N	From RefSeq import	lnoncoding	SO:0001877	lnc_RNA
+125	scRNA	gene	core,otherfeatures,vega	\N	From RefSeq import or Havana manual annotation.	snoncoding	SO:0001263	ncRNA_gene
+126	scRNA	transcript	core,otherfeatures,vega	\N	From RefSeq import or Havana manual annotation.	snoncoding	SO:0000013	scRNA
+127	RNase_MRP_RNA	gene	core,otherfeatures,presite	\N	From RefSeq import or Rfamscan	snoncoding	SO:0001263	ncRNA_gene
+128	RNase_MRP_RNA	transcript	core,otherfeatures,presite	\N	From RefSeq import or Rfamscan	snoncoding	SO:0000385	RNase_MRP_RNA
+129	RNase_P_RNA	gene	core,otherfeatures,presite	\N	From RefSeq import or Rfamscan	snoncoding	SO:0001263	ncRNA_gene
+130	RNase_P_RNA	transcript	core,otherfeatures,presite	\N	From RefSeq import or Rfamscan	snoncoding	SO:0000386	RNase_P_RNA
+131	telomerase_RNA	gene	core,otherfeatures,presite	\N	From RefSeq import or Rfamscan	snoncoding	SO:0001263	ncRNA_gene
+132	telomerase_RNA	transcript	core,otherfeatures,presite	\N	From RefSeq import or Rfamscan	snoncoding	SO:0000390	telomerase_RNA
+133	sense_intronic	transcript	core,vega,presite	0	\N	lnoncoding	SO:0001877	lnc_RNA
+135	sense_overlapping	transcript	core,vega,presite	0	\N	lnoncoding	SO:0001877	lnc_RNA
+138	sense_intronic	gene	core,vega,presite	350	\N	lnoncoding	SO:0001263	ncRNA_gene
+139	ambiguous_orf	gene	core,vega	351	\N	lnoncoding	SO:0001263	ncRNA_gene
+140	retained_intron	gene	core,vega,presite	352	\N	lnoncoding	SO:0001263	ncRNA_gene
 142	3prime_overlapping_ncRNA	gene	core,vega,presite	\N	\N	lnoncoding	\N	\N
 143	ncRNA_host	gene	core,vega	\N	\N	lnoncoding	\N	\N
-144	sense_overlapping	gene	core,vega,presite	355	\N	lnoncoding	SO:0001263	\N
-146	TR_D_gene	transcript	core,presite	\N	\N	coding	SO:0000458	\N
-147	TR_J_pseudogene	transcript	core,presite	\N	\N	pseudogene	SO:0000516	\N
-148	TR_D_gene	gene	core,presite	100	\N	coding	SO:0001217	\N
-149	TR_J_pseudogene	gene	core,presite	67	\N	pseudogene	SO:0000336	\N
-150	ncbi_pseudogene	gene	otherfeatures	\N	Imported annotation from RefSeq	pseudogene	SO:0000336	\N
-151	ncbi_pseudogene	transcript	otherfeatures	\N	Imported annotation from RefSeq	pseudogene	SO:0000516	\N
+144	sense_overlapping	gene	core,vega,presite	355	\N	lnoncoding	SO:0001263	ncRNA_gene
+146	TR_D_gene	transcript	core,otherfeatures,presite	\N	\N	coding	SO:0000458	D_gene_segment
+147	TR_J_pseudogene	transcript	core,otherfeatures,presite	\N	\N	pseudogene	SO:0000516	pseudogenic_transcript
+148	TR_D_gene	gene	core,otherfeatures,presite	100	\N	coding	SO:0001217	protein_coding_gene
+149	TR_J_pseudogene	gene	core,otherfeatures,presite	67	\N	pseudogene	SO:0000336	pseudogene
+150	ncbi_pseudogene	gene	otherfeatures	\N	Imported annotation from RefSeq	pseudogene	SO:0000336	pseudogene
+151	ncbi_pseudogene	transcript	otherfeatures	\N	Imported annotation from RefSeq	pseudogene	SO:0000516	pseudogenic_transcript
 152	ncbigene	gene	otherfeatures	\N	Imported annotation from RefSeq	undefined	\N	\N
-153	non_stop_decay	transcript	core,vega,presite	0	A new transcript biotype from Havana.	coding	SO:0000234	\N
-154	pre_miRNA	transcript	core	0	This is the pre miRNA information extracted from FlyBase annotations distinctive from the miRNA form for the same gene model.Gautier is happy for this to be in the short noncoding group.	snoncoding	SO:0001244	\N
-155	tmRNA	gene	core	\N	One of the classes of ncRNA genes that is only found in bacteria. Hence only required for EnsemblBacteria.	snoncoding	SO:0001263	\N
-156	tmRNA	transcript	core	0	One of the classes of ncRNA genes that is only found in bacteria. Hence only required for EnsemblBacteria.	snoncoding	SO:0000584	\N
-157	SRP_RNA	gene	core,otherfeatures	\N	The signal recognition particle (SRP) RNA is one of the classes of ncRNA genes.	snoncoding	SO:0001263	\N
-158	SRP_RNA	transcript	core,otherfeatures	0	The signal recognition particle (SRP) RNA is one of the classes of ncRNA genes.	snoncoding	SO:0000590	\N
-160	ribozyme	transcript	core,otherfeatures,presite	\N	\N	lnoncoding	SO:0001877	\N
-163	ncRNA_pseudogene	gene	otherfeatures	99	noncoding RNA pseudogene	pseudogene	SO:0000336	\N
-164	ncRNA_pseudogene	transcript	otherfeatures	99	noncoding RNA pseudogene	pseudogene	SO:0000516	\N
-165	IG_LV_gene	gene	core	100	\N	coding	SO:0001217	\N
-166	IG_LV_gene	transcript	core	\N	\N	coding	SO:3000000	\N
-167	translated_processed_pseudogene	gene	core,vega,presite	\N	\N	pseudogene	SO:0000336	\N
-168	translated_processed_pseudogene	transcript	core,vega,presite	\N	\N	pseudogene	SO:0000516	\N
-169	nontranslating_CDS	gene	core,otherfeatures	\N	An imported 'protein-coding' gene that does not translate due to one or more unannotated stop codons.	coding	SO:0001217	\N
-170	nontranslating_CDS	transcript	core,otherfeatures	\N	An imported 'protein-coding' transcript that does not translate due to one or more unannotated stop codons.	coding	SO:0000234	\N
-171	translated_unprocessed_pseudogene	gene	core,vega	\N	\N	pseudogene	SO:0000336	\N
-172	translated_unprocessed_pseudogene	transcript	core,vega	\N	\N	pseudogene	SO:0000516	\N
-173	mRNA	gene	otherfeatures	\N	From RefSeq import	coding	SO:0001217	\N
-174	mRNA	transcript	otherfeatures	\N	From RefSeq import	coding	SO:0000234	\N
-175	pre_miRNA	gene	core	\N	This is the pre miRNA information extracted from FlyBase annotations distinctive from the miRNA form for the same gene model.Gautier is happy for this to be in the short noncoding group.	snoncoding	SO:0001263	\N
+153	non_stop_decay	transcript	core,vega,presite	0	A new transcript biotype from Havana.	coding	SO:0000234	mRNA
+154	pre_miRNA	transcript	core	0	This is the pre miRNA information extracted from FlyBase annotations distinctive from the miRNA form for the same gene model.Gautier is happy for this to be in the short noncoding group.	snoncoding	SO:0001244	pre_miRNA
+155	tmRNA	gene	core	\N	One of the classes of ncRNA genes that is only found in bacteria. Hence only required for EnsemblBacteria.	snoncoding	SO:0001263	ncRNA_gene
+156	tmRNA	transcript	core	0	One of the classes of ncRNA genes that is only found in bacteria. Hence only required for EnsemblBacteria.	snoncoding	SO:0000584	tmRNA
+157	SRP_RNA	gene	core,otherfeatures	\N	The signal recognition particle (SRP) RNA is one of the classes of ncRNA genes.	snoncoding	SO:0001263	ncRNA_gene
+158	SRP_RNA	transcript	core,otherfeatures	0	The signal recognition particle (SRP) RNA is one of the classes of ncRNA genes.	snoncoding	SO:0000590	SRP_RNA
+160	ribozyme	transcript	core,otherfeatures,presite	\N	\N	lnoncoding	SO:0001877	lnc_RNA
+163	ncRNA_pseudogene	gene	otherfeatures	99	noncoding RNA pseudogene	pseudogene	SO:0000336	pseudogene
+164	ncRNA_pseudogene	transcript	otherfeatures	99	noncoding RNA pseudogene	pseudogene	SO:0000516	pseudogenic_transcript
+165	IG_LV_gene	gene	core	100	\N	coding	SO:0001217	protein_coding_gene
+166	IG_LV_gene	transcript	core	\N	\N	coding	SO:3000000	gene_segment
+167	translated_processed_pseudogene	gene	core,vega,presite	\N	\N	pseudogene	SO:0000336	pseudogene
+168	translated_processed_pseudogene	transcript	core,vega,presite	\N	\N	pseudogene	SO:0000516	pseudogenic_transcript
+169	nontranslating_CDS	gene	core,otherfeatures	\N	An imported 'protein-coding' gene that does not translate due to one or more unannotated stop codons.	coding	SO:0001217	protein_coding_gene
+170	nontranslating_CDS	transcript	core,otherfeatures	\N	An imported 'protein-coding' transcript that does not translate due to one or more unannotated stop codons.	coding	SO:0000234	mRNA
+171	translated_unprocessed_pseudogene	gene	core,vega	\N	\N	pseudogene	SO:0000336	pseudogene
+172	translated_unprocessed_pseudogene	transcript	core,vega	\N	\N	pseudogene	SO:0000516	pseudogenic_transcript
+173	mRNA	gene	otherfeatures	\N	From RefSeq import	coding	SO:0001217	protein_coding_gene
+174	mRNA	transcript	otherfeatures	\N	From RefSeq import	coding	SO:0000234	mRNA
+175	pre_miRNA	gene	core	\N	This is the pre miRNA information extracted from FlyBase annotations distinctive from the miRNA form for the same gene model.Gautier is happy for this to be in the short noncoding group.	snoncoding	SO:0001263	ncRNA_gene
 176	artifact	gene	vega	\N	Should not see this biotype in core db	undefined	\N	\N
 177	artifact	transcript	vega	\N	Should not see this biotype in core db	undefined	\N	\N
-178	lncRNA	gene	core,otherfeatures,vega,presite	190	\N	lnoncoding	SO:0001263	\N
-179	class_I_RNA	gene	core	\N	Small non-coding RNA (55-65 nt long) containing highly conserved 5' and 3' ends (16 and 8 nt, respectively) that are predicted to come together to form a stem structure. Identified in the social amoeba Dictyostelium discoideum and localized in the cytoplasm.	snoncoding	SO:0001263	\N
-180	class_I_RNA	transcript	core	\N	Small non-coding RNA (55-65 nt long) containing highly conserved 5' and 3' ends (16 and 8 nt, respectively) that are predicted to come together to form a stem structure. Identified in the social amoeba Dictyostelium discoideum and localized in the cytoplasm.	snoncoding	SO:0000990	\N
-181	class_II_RNA	gene	core	\N	Small non-coding RNA (59-60 nt long) containing 5' and 3' ends that are predicted to come together to form a stem structure. Identified in the social amoeba Dictyostelium discoideum and localized in the cytoplasm.	snoncoding	SO:0001263	\N
-182	class_II_RNA	transcript	core	\N	Small non-coding RNA (59-60 nt long) containing 5' and 3' ends that are predicted to come together to form a stem structure. Identified in the social amoeba Dictyostelium discoideum and localized in the cytoplasm.	snoncoding	SO:0000989	\N
+178	lncRNA	gene	core,otherfeatures,vega,presite	190	\N	lnoncoding	SO:0001263	ncRNA_gene
+179	class_I_RNA	gene	core	\N	Small non-coding RNA (55-65 nt long) containing highly conserved 5' and 3' ends (16 and 8 nt, respectively) that are predicted to come together to form a stem structure. Identified in the social amoeba Dictyostelium discoideum and localized in the cytoplasm.	snoncoding	SO:0001263	ncRNA_gene
+180	class_I_RNA	transcript	core	\N	Small non-coding RNA (55-65 nt long) containing highly conserved 5' and 3' ends (16 and 8 nt, respectively) that are predicted to come together to form a stem structure. Identified in the social amoeba Dictyostelium discoideum and localized in the cytoplasm.	snoncoding	SO:0000990	class_I_RNA
+181	class_II_RNA	gene	core	\N	Small non-coding RNA (59-60 nt long) containing 5' and 3' ends that are predicted to come together to form a stem structure. Identified in the social amoeba Dictyostelium discoideum and localized in the cytoplasm.	snoncoding	SO:0001263	ncRNA_gene
+182	class_II_RNA	transcript	core	\N	Small non-coding RNA (59-60 nt long) containing 5' and 3' ends that are predicted to come together to form a stem structure. Identified in the social amoeba Dictyostelium discoideum and localized in the cytoplasm.	snoncoding	SO:0000989	class_II_RNA
 183	known_ncRNA	gene	core,otherfeatures,vega,sangervega	\N	\N	snoncoding	\N	\N
-184	known_ncRNA	transcript	core,otherfeatures,vega,sangervega	\N	\N	snoncoding	SO:0000655	\N
-185	transcribed_unitary_pseudogene	transcript	core,vega	\N	\N	pseudogene	SO:0000516	\N
-186	piRNA	gene	core	\N	A small non coding RNA, part of a silencing system that prevents the spreading of selfish genetic elements.	snoncoding	SO:0001263	\N
-187	piRNA	transcript	core	\N	A small non coding RNA, part of a silencing system that prevents the spreading of selfish genetic elements.	snoncoding	SO:0001035	\N
-188	IG_D_pseudogene	gene	core,otherfeatures,presite	67	\N	pseudogene	SO:0000336	\N
-189	macro_lncRNA	gene	core,vega	388	Unspliced lncRNAs that are several kb in size	lnoncoding	SO:0001263	\N
-191	vaultRNA	gene	core,otherfeatures,vega	388	short non coding RNA genes that form part of the vault ribonucleoprotein complex	snoncoding	SO:0001263	\N
-192	scaRNA	gene	core,otherfeatures,presite	440	\N	snoncoding	SO:0001263	\N
-193	scaRNA	transcript	core,otherfeatures,presite	\N	\N	snoncoding	SO:0000013	\N
-194	sRNA	transcript	core,otherfeatures,presite	\N	\N	snoncoding	SO:0000274	\N
-195	sRNA	gene	core,otherfeatures,presite	441	\N	snoncoding	SO:0001263	\N
-198	antitoxin	transcript	core,otherfeatures,presite	\N	\N	lnoncoding	SO:0001877	\N
-199	antitoxin	gene	core,otherfeatures,presite	443	\N	lnoncoding	SO:0001263	\N
-200	ribozyme	gene	core,otherfeatures,presite	359	\N	lnoncoding	SO:0001263	\N
-202	vaultRNA	transcript	core,otherfeatures,vega	388	short non coding RNA genes that form part of the vault ribonucleoprotein complex	snoncoding	SO:0002040	\N
-203	macro_lncRNA	transcript	core,vega	388	Unspliced lncRNAs that are several kb in size	lnoncoding	SO:0001877	\N
-204	IG_D_pseudogene	transcript	core,otherfeatures,presite	67	\N	pseudogene	SO:0000516	\N
-205	guide_RNA	gene	otherfeatures	\N	From RefSeq import	snoncoding	SO:0001263	\N
-206	guide_RNA	transcript	otherfeatures	\N	From RefSeq import	snoncoding	SO:0000602	\N
-207	Y_RNA	gene	otherfeatures	\N	From RefSeq import	snoncoding	SO:0001263	\N
-208	Y_RNA	transcript	otherfeatures	\N	From RefSeq import	snoncoding	SO:0000405	\N
-209	transposable_element	transcript	core	\N	\N	no_group	SO:0000101	\N
-210	transposable_element	gene	core	\N	\N	no_group	SO:0000111	\N
+184	known_ncRNA	transcript	core,otherfeatures,vega,sangervega	\N	\N	snoncoding	SO:0000655	ncRNA
+185	transcribed_unitary_pseudogene	transcript	core,vega	\N	\N	pseudogene	SO:0000516	pseudogenic_transcript
+186	piRNA	gene	core	\N	A small non coding RNA, part of a silencing system that prevents the spreading of selfish genetic elements.	snoncoding	SO:0001263	ncRNA_gene
+187	piRNA	transcript	core	\N	A small non coding RNA, part of a silencing system that prevents the spreading of selfish genetic elements.	snoncoding	SO:0001035	piRNA
+188	IG_D_pseudogene	gene	core,otherfeatures,presite	67	\N	pseudogene	SO:0000336	pseudogene
+189	macro_lncRNA	gene	core,vega	388	Unspliced lncRNAs that are several kb in size	lnoncoding	SO:0001263	ncRNA_gene
+192	scaRNA	gene	core,otherfeatures,presite	440	\N	snoncoding	SO:0001263	ncRNA_gene
+193	scaRNA	transcript	core,otherfeatures,presite	\N	\N	snoncoding	SO:0000013	scRNA
+194	sRNA	transcript	core,otherfeatures,presite	\N	\N	snoncoding	SO:0000274	snRNA
+195	sRNA	gene	core,otherfeatures,presite	441	\N	snoncoding	SO:0001263	ncRNA_gene
+198	antitoxin	transcript	core,otherfeatures,presite	\N	\N	lnoncoding	SO:0001877	lnc_RNA
+199	antitoxin	gene	core,otherfeatures,presite	443	\N	lnoncoding	SO:0001263	ncRNA_gene
+200	ribozyme	gene	core,otherfeatures,presite	359	\N	lnoncoding	SO:0001263	ncRNA_gene
+203	macro_lncRNA	transcript	core,vega	388	Unspliced lncRNAs that are several kb in size	lnoncoding	SO:0001877	lnc_RNA
+204	IG_D_pseudogene	transcript	core,otherfeatures,presite	67	\N	pseudogene	SO:0000516	pseudogenic_transcript
+205	guide_RNA	gene	core,otherfeatures	\N	From RefSeq import	snoncoding	SO:0001263	ncRNA_gene
+206	guide_RNA	transcript	core,otherfeatures	\N	From RefSeq import	snoncoding	SO:0000602	guide_RNA
+207	Y_RNA	gene	core,otherfeatures	\N	\N	snoncoding	SO:0001263	ncRNA_gene
+208	Y_RNA	transcript	core,otherfeatures	\N	\N	snoncoding	SO:0000405	Y_RNA
+209	transposable_element	transcript	core	\N	\N	no_group	SO:0000101	transposable_element
+210	transposable_element	gene	core	\N	\N	no_group	SO:0000111	transposable_element_gene
 211	bidirectional_promoter_lncRNA	transcript	core,vega,presite	\N	\N	lnoncoding	\N	\N
-212	bidirectional_promoter_lncRNA	gene	core,vega,presite	\N	\N	lnoncoding	SO:0002185	\N
+212	bidirectional_promoter_lncRNA	gene	core,vega,presite	\N	\N	lnoncoding	SO:0002185	bidirectional_promoter_lncRNA
 215	unknown_likely_coding	gene	core	\N	Biotype introduced by UCSC in the mouse strains, for genes/transcripts that were not in the mouse reference but are likely to be new protein coding models.	coding	\N	\N
 216	unknown_likely_coding	transcript	core	\N	Biotype introduced by UCSC in the mouse strains, for genes/transcripts that were not in the mouse reference but are likely to be new protein coding models.	coding	\N	\N
 217	other	gene	otherfeatures	\N	\N	undefined	\N	\N
-218	lncRNA	transcript	core,otherfeatures,vega,presite	\N	\N	lnoncoding	SO:0001877	\N
+218	lncRNA	transcript	core,otherfeatures,vega,presite	\N	\N	lnoncoding	SO:0001877	lnc_RNA
 219	aligned_transcript	gene	otherfeatures	\N	Capture Long Seq (CLS) on human and mouse	undefined	\N	\N
 220	aligned_transcript	transcript	otherfeatures	\N	Capture Long Seq (CLS) on human and mouse	undefined	\N	\N
-221	antisense	gene	core,presite	\N	\N	lnoncoding	SO:0001263	\N
-222	antisense	transcript	core,presite	\N	\N	lnoncoding	SO:0001877	\N
-223	vault_RNA	gene	core,otherfeatures,vega	\N	short non coding RNA genes that form part of the vault ribonucleoprotein complex	snoncoding	SO:0001263	\N
-224	vault_RNA	transcript	core,otherfeatures,vega	\N	short non coding RNA genes that form part of the vault ribonucleoprotein complex	snoncoding	SO:0001877	\N
+221	antisense	gene	core,presite	\N	\N	lnoncoding	SO:0001263	ncRNA_gene
+222	antisense	transcript	core,presite	\N	\N	lnoncoding	SO:0001877	lnc_RNA
+223	vault_RNA	gene	core,otherfeatures,vega	\N	short non coding RNA genes that form part of the vault ribonucleoprotein complex	snoncoding	SO:0001263	ncRNA_gene
+224	vault_RNA	transcript	core,otherfeatures,vega	\N	short non coding RNA genes that form part of the vault ribonucleoprotein complex	snoncoding	SO:0001877	lnc_RNA
 225	rnaseq_putative_cds	transcript	core	\N	A biotype for gene/transcripts with transcriptomic data and some very weak support for the cds. This currently means that the cds is less than < 1500bp, is composed of less than 3 coding exons and has less than 40 percent coverage from an alignment of a protein existence level 1 or 2 vertebrate protein from UniProt. We believe there is potentially a cds at these positions, but the evidence is not strong enough to include it directly in the protein coding gene set 	coding	\N	\N
 226	rnaseq_putative_cds	gene	core	\N	A biotype for gene/transcripts with transcriptomic data and some very weak support for the cds. This currently means that the cds is less than < 1500bp, is composed of less than 3 coding exons and has less than 40 percent coverage from an alignment of a protein existence level 1 or 2 vertebrate protein from UniProt. We believe there is potentially a cds at these positions, but the evidence is not strong enough to include it directly in the protein coding gene set	coding	\N	\N
-227	transcribed_pseudogene	gene	otherfeatures	\N	This is for the RefSeq GFF3 import	pseudogene	\N	\N
+227	transcribed_pseudogene	gene	otherfeatures	\N	This is for the RefSeq GFF3 import.	pseudogene	\N	\N
 228	transcribed_pseudogene	transcript	otherfeatures	\N	This is for the RefSeq GFF3 import	pseudogene	\N	\N
+229	other	transcript	otherfeatures	\N	\N	undefined	\N	\N
+230	pseudogene_with_CDS	gene	core,otherfeatures	\N	pseudogene with CDS. Genes  annotated as pseudogenes, for which  we keep the CDS in case it may actually be translated,  but hypothetically, without any evidence that it actually is.	coding	SO:0000336	pseudogene
+231	pseudogene_with_CDS	transcript	core,otherfeatures	\N	pseudogenic transcript with CDS. Transcripts of genes annotated as pseudogenes, for which we keep the CDS in case it may actually be translated, but hypothetically, without any evidence that it actually is.	coding	SO:0000516	pseudogenic_transcript
+232	misc_non_coding	gene	core	\N	Miscellaneous non-coding genes, including both long non-coding sequences and nontranslating CDS.	mnoncoding	\N	\N
+233	misc_non_coding	transcript	core	\N	Miscellaneous non-coding transcripts, including both long non-coding sequences and nontranslating CDS.	mnoncoding	\N	\N


### PR DESCRIPTION
## Description
The biotype table was lacking values for the so_term, which had been introduced into the test, so the test was failing. Also corrected a typo, where a full stop instead of a comma was causing the expected hash structure to get mangled.

## Benefits
Test suite passes!
