### PR TITLE
Modify Protein Features pipeline for Codon cluster

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/Base_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/Base_conf.pm
@@ -34,13 +34,21 @@ sub default_options {
   return {
     %{$self->SUPER::default_options},
 
-    pipeline_dir => $ENV{'PWD'}.'/'.$self->o('pipeline_name'),
-
     user  => $ENV{'USER'},
     email => $ENV{'USER'}.'@ebi.ac.uk',
 
+    pipeline_dir => catdir( '/hps/nobackup/flicek/ensembl/production',
+                            $self->o('user'),
+                            $self->o('pipeline_name') ),
+
+    scratch_small_dir => catdir( '/hps/scratch',
+                                 $self->o('user'),
+                                 $self->o('pipeline_name') ),
+
+    scratch_large_dir => catdir( $self->o('nobackup_dir'), 'scratch' ),
+
     production_queue => 'production',
-    datamover_queue  => 'datamover',
+    datamover_queue => 'datamover',
   };
 }
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/Base_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/Base_conf.pm
@@ -45,7 +45,7 @@ sub default_options {
                                  $self->o('user'),
                                  $self->o('pipeline_name') ),
 
-    scratch_large_dir => catdir( $self->o('nobackup_dir'), 'scratch' ),
+    scratch_large_dir => catdir( $self->o('pipeline_dir'), 'scratch' ),
 
     production_queue => 'production',
     datamover_queue => 'datamover',

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProteinFeatures_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProteinFeatures_conf.pm
@@ -47,8 +47,8 @@ sub default_options {
     max_dirs_per_directory  => $self->o('max_files_per_directory'),
 
     # InterPro settings
-    interproscan_version      => '5.51-85.0',
-    interproscan_exe          => 'interproscan.sh',
+    interproscan_path         => '/hps/software/interproscan',
+    interproscan_version      => 'current',
    	run_interproscan          => 1,
     local_computation         => 0,
     check_interpro_db_version => 0,
@@ -94,9 +94,7 @@ sub default_options {
       {
         logic_name      => 'cdd',
         db              => 'CDD',
-        db_version      => '3.18',
         program         => 'InterProScan',
-        program_version => $self->o('interproscan_version'),
         ipscan_name     => 'CDD',
         ipscan_xml      => 'CDD',
         ipscan_lookup   => 1,
@@ -104,9 +102,7 @@ sub default_options {
       {
         logic_name      => 'gene3d',
         db              => 'Gene3D',
-        db_version      => '4.3.0',
         program         => 'InterProScan',
-        program_version => $self->o('interproscan_version'),
         ipscan_name     => 'Gene3D',
         ipscan_xml      => 'GENE3D',
         ipscan_lookup   => 1,
@@ -114,9 +110,7 @@ sub default_options {
       {
         logic_name      => 'hamap',
         db              => 'HAMAP',
-        db_version      => '2020_05',
         program         => 'InterProScan',
-        program_version => $self->o('interproscan_version'),
         ipscan_name     => 'Hamap',
         ipscan_xml      => 'HAMAP',
         ipscan_lookup   => 1,
@@ -124,9 +118,7 @@ sub default_options {
       {
         logic_name      => 'hmmpanther',
         db              => 'PANTHER',
-        db_version      => '15.0',
         program         => 'InterProScan',
-        program_version => $self->o('interproscan_version'),
         ipscan_name     => 'PANTHER',
         ipscan_xml      => 'PANTHER',
         ipscan_lookup   => 1,
@@ -134,9 +126,7 @@ sub default_options {
       {
         logic_name      => 'pfam',
         db              => 'Pfam',
-        db_version      => '33.1',
         program         => 'InterProScan',
-        program_version => $self->o('interproscan_version'),
         ipscan_name     => 'Pfam',
         ipscan_xml      => 'PFAM',
         ipscan_lookup   => 1,
@@ -144,9 +134,7 @@ sub default_options {
       {
         logic_name      => 'pfscan',
         db              => 'Prosite_profiles',
-        db_version      => '2019_11',
         program         => 'InterProScan',
-        program_version => $self->o('interproscan_version'),
         ipscan_name     => 'ProSiteProfiles',
         ipscan_xml      => 'PROSITE_PROFILES',
         ipscan_lookup   => 1,
@@ -154,9 +142,7 @@ sub default_options {
       {
         logic_name      => 'pirsf',
         db              => 'PIRSF',
-        db_version      => '3.10',
         program         => 'InterProScan',
-        program_version => $self->o('interproscan_version'),
         ipscan_name     => 'PIRSF',
         ipscan_xml      => 'PIRSF',
         ipscan_lookup   => 1,
@@ -164,9 +150,7 @@ sub default_options {
       {
         logic_name      => 'prints',
         db              => 'PRINTS',
-        db_version      => '42.0',
         program         => 'InterProScan',
-        program_version => $self->o('interproscan_version'),
         ipscan_name     => 'PRINTS',
         ipscan_xml      => 'PRINTS',
         ipscan_lookup   => 1,
@@ -174,9 +158,7 @@ sub default_options {
       {
         logic_name      => 'scanprosite',
         db              => 'Prosite_patterns',
-        db_version      => '2019_11',
         program         => 'InterProScan',
-        program_version => $self->o('interproscan_version'),
         ipscan_name     => 'ProSitePatterns',
         ipscan_xml      => 'PROSITE_PATTERNS',
         ipscan_lookup   => 1,
@@ -184,9 +166,7 @@ sub default_options {
       {
         logic_name      => 'sfld',
         db              => 'SFLD',
-        db_version      => '4',
         program         => 'InterProScan',
-        program_version => $self->o('interproscan_version'),
         ipscan_name     => 'SFLD',
         ipscan_xml      => 'SFLD',
         ipscan_lookup   => 1,
@@ -194,9 +174,7 @@ sub default_options {
       {
         logic_name      => 'smart',
         db              => 'Smart',
-        db_version      => '7.1',
         program         => 'InterProScan',
-        program_version => $self->o('interproscan_version'),
         ipscan_name     => 'SMART',
         ipscan_xml      => 'SMART',
         ipscan_lookup   => 1,
@@ -204,9 +182,7 @@ sub default_options {
       {
         logic_name      => 'superfamily',
         db              => 'SuperFamily',
-        db_version      => '1.75',
         program         => 'InterProScan',
-        program_version => $self->o('interproscan_version'),
         ipscan_name     => 'SUPERFAMILY',
         ipscan_xml      => 'SUPERFAMILY',
         ipscan_lookup   => 1,
@@ -214,9 +190,7 @@ sub default_options {
       {
         logic_name      => 'tigrfam',
         db              => 'TIGRfam',
-        db_version      => '15.0',
         program         => 'InterProScan',
-        program_version => $self->o('interproscan_version'),
         ipscan_name     => 'TIGRFAM',
         ipscan_xml      => 'TIGRFAM',
         ipscan_lookup   => 1,
@@ -224,9 +198,7 @@ sub default_options {
       {
         logic_name      => 'mobidblite',
         db              => 'MobiDBLite',
-        db_version      => '2.0',
         program         => 'InterProScan',
-        program_version => $self->o('interproscan_version'),
         ipscan_name     => 'MobiDBLite',
         ipscan_xml      => 'MOBIDB_LITE',
         ipscan_lookup   => 0,
@@ -234,9 +206,7 @@ sub default_options {
       {
         logic_name      => 'ncoils',
         db              => 'ncoils',
-        db_version      => '2.2.1',
         program         => 'InterProScan',
-        program_version => $self->o('interproscan_version'),
         ipscan_name     => 'Coils',
         ipscan_xml      => 'COILS',
         ipscan_lookup   => 0,
@@ -244,9 +214,7 @@ sub default_options {
       {
         logic_name      => 'signalp',
         db              => 'SignalP',
-        db_version      => '4.1',
         program         => 'InterProScan',
-        program_version => $self->o('interproscan_version'),
         ipscan_name     => 'SignalP_EUK',
         ipscan_xml      => 'SIGNALP_EUK',
         ipscan_lookup   => 0,
@@ -254,9 +222,7 @@ sub default_options {
       {
         logic_name      => 'tmhmm',
         db              => 'TMHMM',
-        db_version      => '2.0c',
         program         => 'InterProScan',
-        program_version => $self->o('interproscan_version'),
         ipscan_name     => 'TMHMM',
         ipscan_xml      => 'TMHMM',
         ipscan_lookup   => 0,
@@ -339,18 +305,21 @@ sub pipeline_create_commands {
   return [
     @{$self->SUPER::pipeline_create_commands},
     'mkdir -p '.$self->o('pipeline_dir'),
+    'mkdir -p '.$self->o('scratch_large_dir'),
     $self->db_cmd($uniparc_table_sql),
     $self->db_cmd($uniprot_table_sql),
   ];
 }
 
 sub pipeline_wide_parameters {
- my ($self) = @_;
+  my ($self) = @_;
 
- return {
-   %{$self->SUPER::pipeline_wide_parameters},
-   'email_report' => $self->o('email_report'),
- };
+  return {
+    %{$self->SUPER::pipeline_wide_parameters},
+    pipeline_dir => $self->o('pipeline_dir'),
+    scratch_dir  => $self->o('scratch_large_dir'),
+    email_report => $self->o('email_report'),
+  };
 }
 
 sub pipeline_analyses {
@@ -363,13 +332,13 @@ sub pipeline_analyses {
       -max_retry_count => 0,
       -input_ids       => [ {} ],
       -parameters      => {
+                            interproscan_path    => $self->o('interproscan_path'),
                             interproscan_version => $self->o('interproscan_version'),
-                            interproscan_exe     => $self->o('interproscan_exe'),
                             local_computation    => $self->o('local_computation'),
                           },
       -flow_into       => {
-                            '1->A' => ['FetchFiles'],
-                            'A->1' => ['DbFactory'],
+                            '3->A' => ['FetchFiles'],
+                            'A->3' => ['AnnotateProteinFeatures'],
                           },
     },
 
@@ -466,6 +435,16 @@ sub pipeline_analyses {
     },
 
     {
+      -logic_name      => 'AnnotateProteinFeatures',
+      -module          => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+      -max_retry_count => 0,
+      -flow_into       => {
+                            '1->A' => ['DbFactory'],
+                            'A->1' => ['TidyScratch'],
+                          }
+    },
+
+    {
       -logic_name      => 'DbFactory',
       -module          => 'Bio::EnsEMBL::Production::Pipeline::Common::DbFactory',
       -max_retry_count => 1,
@@ -498,7 +477,7 @@ sub pipeline_analyses {
                                 'protein_feature',
                                 'xref',
                               ],
-                              output_file => catdir($self->o('pipeline_dir'), '#dbname#', 'pre_pipeline_bkp.sql.gz'),
+                              output_file => catdir('#pipeline_dir#', '#dbname#', 'pre_pipeline_bkp.sql.gz'),
                             },
       -flow_into         => ['AnalysisConfiguration'],
     },
@@ -509,7 +488,6 @@ sub pipeline_analyses {
       -max_retry_count   => 0,
       -parameters        => {
                               protein_feature_analyses  => $self->o('protein_feature_analyses'),
-                              interproscan_version      => $self->o('interproscan_version'),
                               check_interpro_db_version => $self->o('check_interpro_db_version'),
                               run_seg                   => $self->o('run_seg'),
                               xref_analyses             => $self->o('xref_analyses'),
@@ -527,7 +505,7 @@ sub pipeline_analyses {
       -analysis_capacity => 20,
       -parameters        => {
                               db_backup_required => 1,
-                              db_backup_file     => catdir($self->o('pipeline_dir'), '#dbname#', 'pre_pipeline_bkp.sql.gz'),
+                              db_backup_file     => catdir('#pipeline_dir#', '#dbname#', 'pre_pipeline_bkp.sql.gz'),
                               delete_existing    => $self->o('delete_existing'),
                               linked_tables      => ['protein_feature', 'object_xref'],
                               production_lookup  => 1,
@@ -594,7 +572,7 @@ sub pipeline_analyses {
       -max_retry_count   => 0,
       -analysis_capacity => 20,
       -parameters        => {
-                              proteome_dir => catdir($self->o('pipeline_dir'), '#species#'),
+                              proteome_dir => catdir('#pipeline_dir#', '#species#'),
                               header_style => 'dbID',
                               overwrite    => 1,
                             },
@@ -615,7 +593,7 @@ sub pipeline_analyses {
       -max_retry_count   => 0,
       -analysis_capacity => 20,
       -parameters        => {
-                              proteome_dir => catdir($self->o('pipeline_dir'), '#species#'),
+                              proteome_dir => catdir('#pipeline_dir#', '#species#'),
                               header_style => 'dbID',
                               overwrite    => 1,
                             },
@@ -734,7 +712,6 @@ sub pipeline_analyses {
       {
         input_file                => '#split_file#',
         run_mode                  => 'lookup',
-        interproscan_exe          => $self->o('interproscan_exe'),
         interproscan_applications => '#interproscan_lookup_applications#',
         run_interproscan          => $self->o('run_interproscan'),
       },
@@ -754,7 +731,6 @@ sub pipeline_analyses {
       {
         input_file                => '#split_file#',
         run_mode                  => 'lookup',
-        interproscan_exe          => $self->o('interproscan_exe'),
         interproscan_applications => '#interproscan_lookup_applications#',
         run_interproscan          => $self->o('run_interproscan'),
       },
@@ -773,7 +749,6 @@ sub pipeline_analyses {
       {
         input_file                => '#split_file#',
         run_mode                  => 'nolookup',
-        interproscan_exe          => $self->o('interproscan_exe'),
         interproscan_applications => '#interproscan_nolookup_applications#',
         run_interproscan          => $self->o('run_interproscan'),
       },
@@ -793,7 +768,6 @@ sub pipeline_analyses {
       {
         input_file                => '#split_file#',
         run_mode                  => 'nolookup',
-        interproscan_exe          => $self->o('interproscan_exe'),
         interproscan_applications => '#interproscan_nolookup_applications#',
         run_interproscan          => $self->o('run_interproscan'),
       },
@@ -812,7 +786,6 @@ sub pipeline_analyses {
       {
         input_file                => '#split_file#',
         run_mode                  => 'local',
-        interproscan_exe          => $self->o('interproscan_exe'),
         interproscan_applications => '#interproscan_local_applications#',
         run_interproscan          => $self->o('run_interproscan'),
       },
@@ -832,7 +805,6 @@ sub pipeline_analyses {
       {
         input_file                => '#split_file#',
         run_mode                  => 'local',
-        interproscan_exe          => $self->o('interproscan_exe'),
         interproscan_applications => '#interproscan_local_applications#',
         run_interproscan          => $self->o('run_interproscan'),
       },
@@ -906,6 +878,16 @@ sub pipeline_analyses {
                               subject => 'Protein features pipeline: report for #dbname#',
                             },
     },
+
+    {
+      -logic_name        => 'TidyScratch',
+      -module            => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+      -max_retry_count   => 1,
+      -parameters        => {
+                              cmd => 'rm -rf #scratch_dir#',
+                            },
+    },
+
   ];
 }
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProteinFeatures_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProteinFeatures_conf.pm
@@ -752,7 +752,7 @@ sub pipeline_analyses {
         interproscan_applications => '#interproscan_nolookup_applications#',
         run_interproscan          => $self->o('run_interproscan'),
       },
-      -rc_name           => '4GB_4CPU',
+      -rc_name           => '4GB_8CPU',
       -flow_into         => {
                                '3' => ['StoreProteinFeatures'],
                               '-1' => ['InterProScanNoLookup_HighMem'],
@@ -771,7 +771,7 @@ sub pipeline_analyses {
         interproscan_applications => '#interproscan_nolookup_applications#',
         run_interproscan          => $self->o('run_interproscan'),
       },
-      -rc_name           => '16GB_4CPU',
+      -rc_name           => '16GB_8CPU',
       -flow_into         => {
                                '3' => ['StoreProteinFeatures'],
                             },
@@ -789,7 +789,7 @@ sub pipeline_analyses {
         interproscan_applications => '#interproscan_local_applications#',
         run_interproscan          => $self->o('run_interproscan'),
       },
-      -rc_name           => '4GB_4CPU',
+      -rc_name           => '4GB_8CPU',
       -flow_into         => {
                                '3' => ['StoreProteinFeatures'],
                                '0' => ['InterProScanLocal_HighMem'],
@@ -808,7 +808,7 @@ sub pipeline_analyses {
         interproscan_applications => '#interproscan_local_applications#',
         run_interproscan          => $self->o('run_interproscan'),
       },
-      -rc_name           => '32GB_4CPU',
+      -rc_name           => '32GB_8CPU',
       -flow_into         => {
                                '3' => ['StoreProteinFeatures'],
                             },
@@ -896,9 +896,9 @@ sub resource_classes {
 
   return {
     %{$self->SUPER::resource_classes},
-     '4GB_4CPU' => {'LSF' => '-q '.$self->o('production_queue').' -n 4 -M  4000 -R "rusage[mem=4000]"'},
-    '16GB_4CPU' => {'LSF' => '-q '.$self->o('production_queue').' -n 4 -M 16000 -R "rusage[mem=16000]"'},
-    '32GB_4CPU' => {'LSF' => '-q '.$self->o('production_queue').' -n 4 -M 32000 -R "rusage[mem=32000]"'},
+     '4GB_8CPU' => {'LSF' => '-q '.$self->o('production_queue').' -n 8 -M  4000 -R "rusage[mem=4000]"'},
+    '16GB_8CPU' => {'LSF' => '-q '.$self->o('production_queue').' -n 8 -M 16000 -R "rusage[mem=16000]"'},
+    '32GB_8CPU' => {'LSF' => '-q '.$self->o('production_queue').' -n 8 -M 32000 -R "rusage[mem=32000]"'},
   }
 }
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/ProteinFeatures/AnalysisConfiguration.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/ProteinFeatures/AnalysisConfiguration.pm
@@ -28,16 +28,30 @@ use POSIX qw(strftime);
 
 sub run {
   my ($self) = @_;
-  my $pf_analyses          = $self->param_required('protein_feature_analyses');
+  my $interproscan_exe     = $self->param_required('interproscan_exe');
   my $interproscan_version = $self->param_required('interproscan_version');
+  my $pf_analyses          = $self->param_required('protein_feature_analyses');
   my $check_db_version     = $self->param_required('check_interpro_db_version');
   my $run_seg              = $self->param_required('run_seg');
   my $xref_analyses        = $self->param_required('xref_analyses');
 
   my $aa = $self->core_dba->get_adaptor('Analysis');
 
+  my $db_versions = $self->get_db_versions($interproscan_exe);
+
   my $filtered_analyses = [];
   foreach my $analysis_config (@{$pf_analyses}) {
+    # Set analysis versions
+    if (exists $$analysis_config{'program'} && $$analysis_config{'program'} eq 'InterProScan') {
+      my $ipscan_name = $$analysis_config{'ipscan_name'};
+      if (exists $$db_versions{$ipscan_name}) {
+        $$analysis_config{'db_version'} = $$db_versions{$ipscan_name};
+        $$analysis_config{'program_version'} = $interproscan_version;
+      } else {
+        $self->throw("Could not retrieve version for $ipscan_name");
+      }
+    }
+    
     # If the analysis doesn't already exist, then need to create it.
     # For InterPro sources with the current InterProScan version,
     # and for seg, don't re-annotate - it would only reproduce exactly
@@ -56,7 +70,7 @@ sub run {
         $self->warning("Skipping $logic_name - annotation exists");
       } elsif ($analysis->program_version eq $interproscan_version) {
         $self->warning("Skipping $logic_name - annotation exists for InterProScan $interproscan_version");
-      } elsif ($check_db_version && ($$analysis_config{'db_version'} eq $analysis->db_version)) {
+      } elsif ($check_db_version && ($analysis->db_version eq $$analysis_config{'db_version'})) {
         $self->warning("Skipping $logic_name - annotation exists for db version ".$analysis->db_version);
       } else {
         push @$filtered_analyses, $analysis_config;
@@ -116,6 +130,17 @@ sub run {
   $self->param('lookup', \@lookup);
   $self->param('nolookup', \@nolookup);
   $self->param('all', \@all);
+}
+
+sub get_db_versions {
+  my ($self, $interproscan_exe) = @_;
+
+  my $interpro_cmd = "$interproscan_exe --help";
+  my $info = `$interpro_cmd` or $self->throw("Failed to run ".$interpro_cmd);
+
+  my %db_versions = $info =~ /^\s+(\S+) \((\S+)\) \: /gm;
+
+  return \%db_versions;
 }
 
 sub write_output {

--- a/modules/Bio/EnsEMBL/Production/Pipeline/ProteinFeatures/InterProScan.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/ProteinFeatures/InterProScan.pm
@@ -64,7 +64,7 @@ sub run {
       
       my $tempdir = tempdir(DIR => $scratch_dir, CLEANUP => 1);
       
-      my $options = "--iprlookup --goterms --pathways ";
+      my $options = "--iprlookup --goterms ";
       $options .= "-f TSV, XML -t $seq_type --tempdir $tempdir ";
       $options .= '--applications '.join(',', @$applications).' ';
       my $input_option  = "-i $input_file ";

--- a/modules/Bio/EnsEMBL/Production/Pipeline/ProteinFeatures/InterProScanVersionCheck.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/ProteinFeatures/InterProScanVersionCheck.pm
@@ -24,23 +24,34 @@ use warnings;
 use base ('Bio::EnsEMBL::Production::Pipeline::Common::Base');
 
 use File::Fetch;
+use File::Spec::Functions qw(catdir);
 use Path::Tiny;
+
+sub param_defaults {
+  my ($self) = @_;
+  
+  return {
+    %{$self->SUPER::param_defaults},
+    interproscan_version => 'current',
+  };
+}
 
 sub run {
   my ($self) = @_;
+  my $interproscan_path    = $self->param_required('interproscan_path');
   my $interproscan_version = $self->param_required('interproscan_version');
-  my $interproscan_exe     = $self->param_required('interproscan_exe');
   my $local_computation    = $self->param_required('local_computation');
+
   my $service_version_file = 'http://www.ebi.ac.uk/interpro/match-lookup/version';
 
+  my $interproscan_exe = catdir($interproscan_path, "interproscan-$interproscan_version", 'interproscan.sh');
   my $interpro_cmd = "$interproscan_exe --version";
   my $version_info = `$interpro_cmd` or $self->throw("Failed to run ".$interpro_cmd);
 
   if ($version_info =~ /InterProScan version (\S+)/) {
     my $cmd_version = $1;
-    if ($cmd_version ne $interproscan_version) {
-      $self->throw("InterProScan version mismatch\nConf file: $interproscan_version\n$interproscan_exe: $cmd_version");
-    } elsif (! $local_computation) {
+
+    if (! $local_computation) {
       my $temp_dir = Path::Tiny->tempdir();
       my $ff = File::Fetch->new(uri => $service_version_file);
       my $file = $ff->fetch(to => $temp_dir->stringify);
@@ -54,9 +65,29 @@ sub run {
         $self->throw("Could not find version in service file:\n$service_version_file\n$data");
       }
     }
+
+    # To guard against the 'current' version changing during pipeline
+    # execution, we explicitly use the version in the excutable path.
+    $interproscan_exe = catdir($interproscan_path, "interproscan-$cmd_version", 'interproscan.sh');
+    $interpro_cmd = "$interproscan_exe --version";
+    `$interpro_cmd` or $self->throw("Failed to run ".$interpro_cmd);
+
+    $self->param('interproscan_exe', $interproscan_exe);
+    $self->param('interproscan_version', $cmd_version);
+
   } else {
     $self->throw("Could not find version in output from $interpro_cmd:\n$version_info");
   }
+}
+
+sub write_output {
+  my ($self) = @_;
+
+  $self->dataflow_output_id(
+    {
+        interproscan_exe     => $self->param('interproscan_exe'),
+        interproscan_version => $self->param('interproscan_version'),
+    }, 3 );
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/ProteinFeatures/InterProScanVersionCheck.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/ProteinFeatures/InterProScanVersionCheck.pm
@@ -44,7 +44,7 @@ sub run {
 
   my $service_version_file = 'http://www.ebi.ac.uk/interpro/match-lookup/version';
 
-  my $interproscan_exe = catdir($interproscan_path, "interproscan-$interproscan_version", 'interproscan.sh');
+  my $interproscan_exe = catdir($interproscan_path, $interproscan_version, 'interproscan.sh');
   my $interpro_cmd = "$interproscan_exe --version";
   my $version_info = `$interpro_cmd` or $self->throw("Failed to run ".$interpro_cmd);
 


### PR DESCRIPTION
## Description
On Codon we have a centrally-managed version of InterProScan, which is much easier for us to manage, but needs a little bit of adaptation in the pipeline. (https://www.ebi.ac.uk/panda/jira/browse/ENSPROD-6789)

## Use case
For a given instance of the pipeline, we want to run the same version of interproscan; but the interproscan team might update the 'current' symlink mid-pipeline. So, resolve the 'current' link to a distinct version at the start of the pipeline, and pass that version to subsequent modules that need the path to the executable.

A corollary of the above point is that the specific version does not need to be hard-coded in the config file.

Versions of the Interpro source dbs are also no longer hard-coded in the conf, but are instead determined by running interproscan.sh with no parameters, to get a list of the dbs and their versions.

A more general Codon issue is defining where data is stored on the filesystem - some default paths are defined in the Base pipeline config, so that we can make all of our pipelines consistent.

## Benefits
Protein Features pipeline works on Codon.
We never have to upgrade InterProScan again!

## Possible Drawbacks
None I'm aware of.

## Testing
Pipeline succesffuly run to completion for two vertebrates.