### PR TITLE
GFF3 export, formatted for ENA submission.

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Base_Filetype.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Base_Filetype.pm
@@ -54,6 +54,10 @@ sub fetch_input {
 
   if ($self->param_is_defined('custom_filenames')) {
     $filenames = $self->param('custom_filenames');
+
+    foreach my $file (values %{$filenames}) {
+      $self->create_dir(path($file)->parent);
+    }
   } else {
     my $overwrite = $self->param_required('overwrite');
 
@@ -112,17 +116,7 @@ sub filenames {
     $dir = $self->param('output_dir');
   }
 
-  # If the parent dir does not exist, we will need to
-  # update the group permissions, so that other teams
-  # can write to it once we have created it.
-  my $parent_exists = path($dir)->parent()->exists();
-
-  path($dir)->mkpath();
-  path($dir)->chmod("g+w");
-
-  if (! $parent_exists) {
-    path($dir)->parent()->chmod("g+w");
-  }
+  $self->create_dir($dir);
 
   my %filenames;
 
@@ -152,6 +146,22 @@ sub filenames {
   }
 
   return \%filenames;
+}
+
+sub create_dir {
+  my ($self, $dir) = @_;
+
+  # If the parent dir does not exist, we will need to
+  # update the group permissions, so that other teams
+  # can write to it once we have created it.
+  my $parent_exists = path($dir)->parent()->exists();
+
+  path($dir)->mkpath();
+  path($dir)->chmod("g+w");
+
+  if (! $parent_exists) {
+    path($dir)->parent()->chmod("g+w");
+  }
 }
 
 sub timestamp {

--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_GFF3.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_GFF3.pm
@@ -41,7 +41,7 @@ sub param_defaults {
     per_chromosome       => 0,
     feature_types        => ['Gene', 'Transcript'],
     include_utr          => 1,
-    header               => undef,
+    header               => 1,
     gt_gff3_exe          => 'gt gff3',
     gt_gff3validator_exe => 'gt gff3validator',
   };

--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_GFF3.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_GFF3.pm
@@ -40,6 +40,7 @@ sub param_defaults {
     file_type            => 'gff3',
     per_chromosome       => 0,
     feature_types        => ['Gene', 'Transcript'],
+    header               => undef,
     gt_gff3_exe          => 'gt gff3',
     gt_gff3validator_exe => 'gt gff3validator',
   };
@@ -51,6 +52,7 @@ sub run {
   my $data_type      = $self->param_required('data_type');
   my $per_chromosome = $self->param_required('per_chromosome');
   my $feature_types  = $self->param_required('feature_types');
+  my $header         = $self->param_required('header');
   my $filenames      = $self->param_required('filenames');
 
   my $dba = $self->dba;
@@ -69,18 +71,18 @@ sub run {
   my $filename = $$filenames{$data_type};
 
   if ($per_chromosome && scalar(@$chr)) {
-    $self->print_to_file($chr, 'chr', $filename, '>', $dba, \%adaptors, $provider);
+    $self->print_to_file($chr, 'chr', $filename, '>', $header, $dba, \%adaptors, $provider);
     if (scalar(@$non_chr)) {
-      $self->print_to_file($non_chr, 'non_chr', $filename, '>>', $dba, \%adaptors, $provider);
+      $self->print_to_file($non_chr, 'non_chr', $filename, '>>', $header, $dba, \%adaptors, $provider);
     }
   } else {
-    $self->print_to_file([@$chr, @$non_chr], undef, $filename, '>', $dba, \%adaptors, $provider);
+    $self->print_to_file([@$chr, @$non_chr], undef, $filename, '>', $header, $dba, \%adaptors, $provider);
   }
 
   if (scalar(@$non_ref)) {
     my $non_ref_filename = $self->generate_non_ref_filename($filename);
     path($filename)->copy($non_ref_filename);
-    $self->print_to_file($non_ref, undef, $non_ref_filename, '>>', $dba, \%adaptors, $provider);
+    $self->print_to_file($non_ref, undef, $non_ref_filename, '>>', $header, $dba, \%adaptors, $provider);
   }
 
   my $output_filenames = $self->param('output_filenames');
@@ -91,9 +93,9 @@ sub run {
 }
 
 sub print_to_file {
-  my ($self, $slices, $region, $filename, $mode, $dba, $adaptors, $provider) = @_;
+  my ($self, $slices, $region, $filename, $mode, $header, $dba, $adaptors, $provider) = @_;
 
-  my $header = $mode eq '>' ? 1 : 0;
+  $header = $mode eq '>' ? 1 : 0 unless defined $header;
   my $serializer = $self->gff3_serializer($filename, $mode, $header, $slices, $dba);
 
   my $non_chr_serializer;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_GFF3.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_GFF3.pm
@@ -40,6 +40,7 @@ sub param_defaults {
     file_type            => 'gff3',
     per_chromosome       => 0,
     feature_types        => ['Gene', 'Transcript'],
+    include_utr          => 1,
     header               => undef,
     gt_gff3_exe          => 'gt gff3',
     gt_gff3validator_exe => 'gt gff3validator',
@@ -158,6 +159,7 @@ sub fetch_features {
 
 sub exon_features {
   my ($self, $transcripts) = @_;
+  my $include_utr = $self->param_required('include_utr');
 
   my @cds_features;
   my @exon_features;
@@ -166,8 +168,10 @@ sub exon_features {
   foreach my $transcript (@$transcripts) {
     push @cds_features, @{ $transcript->get_all_CDS(); };
     push @exon_features, @{ $transcript->get_all_ExonTranscripts() };
-    push @utr_features, @{ $transcript->get_all_five_prime_UTRs()};
-    push @utr_features, @{ $transcript->get_all_three_prime_UTRs()};
+    if ($include_utr) {
+      push @utr_features, @{ $transcript->get_all_five_prime_UTRs()};
+      push @utr_features, @{ $transcript->get_all_three_prime_UTRs()};
+    }
   }
 
   return [@exon_features, @cds_features, @utr_features];

--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_GFF3_ENA.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_GFF3_ENA.pm
@@ -1,0 +1,334 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2021] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::Production::Pipeline::FileDump::Geneset_GFF3_ENA;
+
+use strict;
+use warnings;
+no  warnings 'redefine';
+use base qw(Bio::EnsEMBL::Production::Pipeline::FileDump::Geneset_GFF3);
+
+# Using Ensembl code to add a GFF3 header causes problems because it
+# defaults to using the seq_region names, not INSDC synonyms, and it's
+# hard to override this. Instead, don't write a header, and rely on
+# the gt tidying to add in the appropriate details.
+
+sub param_defaults {
+  my ($self) = @_;
+
+  return {
+    %{$self->SUPER::param_defaults},
+    header => 0,
+  };
+}
+
+# The serializer will put everything from 'summary_as_hash' into
+# the GFF3 attributes. But we want a highly customised set of
+# attributes for ENA, so explicitly specify them for all features.
+
+sub Bio::EnsEMBL::Slice::summary_as_hash {
+  my $self = shift;
+  my %summary;
+
+  my $seq_region_name =
+    Bio::EnsEMBL::Production::Pipeline::FileDump::Geneset_GFF3_ENA::insdc_name($self);
+
+  $summary{'seq_region_name'} = $seq_region_name;
+  $summary{'source'}          = $self->source || $self->coord_system->version;
+  $summary{'start'}           = $self->start;
+  $summary{'end'}             = $self->end;
+  $summary{'strand'}          = 0;
+  $summary{'id'}              = $seq_region_name;
+  $summary{'Is_circular'}     = $self->is_circular ? "true" : undef;
+
+  if ($self->is_chromosome) {
+    # Rely on the Ensembl convention which uses chromosome as seq_region name.
+    $summary{'chromosome'} = $self->seq_region_name;
+  }
+
+  my $codon_table = $self->get_all_Attributes("codon_table");
+  if (@{$codon_table}) {
+    # Could set this to 1 by default, but seems sensible to have the
+    # assumption that it is standard unless defined otherwise.
+    $summary{'transl_table'} = $codon_table->[0]->value;
+  }
+
+  return \%summary;
+}
+
+sub Bio::EnsEMBL::Gene::summary_as_hash {
+  my $self = shift;
+  my %summary;
+
+  my $seq_region_name =
+    Bio::EnsEMBL::Production::Pipeline::FileDump::Geneset_GFF3_ENA::insdc_name($self);
+
+  $summary{'seq_region_name'} = $seq_region_name;
+  $summary{'source'}          = $self->source;
+  $summary{'start'}           = $self->seq_region_start;
+  $summary{'end'}             = $self->seq_region_end;
+  $summary{'strand'}          = $self->strand;
+  $summary{'id'}              = $self->stable_id;
+  $summary{'Name'}            = $self->stable_id_version;
+  $summary{'gene_id'}         = $self->stable_id_version;
+  $summary{'gene_biotype'}    = $self->biotype;
+  
+  return \%summary;
+}
+
+sub Bio::EnsEMBL::Transcript::summary_as_hash {
+  my $self = shift;
+  my %summary;
+
+  my $parent_gene = $self->get_Gene();
+  my $seq_region_name =
+    Bio::EnsEMBL::Production::Pipeline::FileDump::Geneset_GFF3_ENA::insdc_name($self);
+
+  $summary{'seq_region_name'} = $seq_region_name;
+  $summary{'source'}          = $self->source;
+  $summary{'start'}           = $self->seq_region_start;
+  $summary{'end'}             = $self->seq_region_end;
+  $summary{'strand'}          = $self->strand;
+  $summary{'id'}              = $self->stable_id;
+  $summary{'Name'}            = $self->stable_id_version;
+  $summary{'Parent'}          = $parent_gene->stable_id;
+  $summary{'transcript_id'}   = $self->stable_id_version;
+  $summary{'biotype'}         = $self->biotype;
+
+  my $seq_edits = 
+    Bio::EnsEMBL::Production::Pipeline::FileDump::Geneset_GFF3_ENA::transcript_seq_edits($self);
+
+  if (defined $seq_edits) {
+    # Terminology for 'exception' taken from NCBI:
+    # https://www.ncbi.nlm.nih.gov/datasets/docs/reference-docs/file-formats/about-ncbi-gff3/
+    $summary{'exception'} = "unclassified transcription discrepancy";
+    $summary{'Note'} = "transcript-level exceptions: ".join(',', @$seq_edits);
+  }
+
+  return \%summary;
+}
+
+sub Bio::EnsEMBL::ExonTranscript::summary_as_hash {
+  my $self = shift;
+  my %summary;
+
+  my $seq_region_name =
+    Bio::EnsEMBL::Production::Pipeline::FileDump::Geneset_GFF3_ENA::insdc_name($self);
+
+  $summary{'seq_region_name'} = $seq_region_name;
+  $summary{'source'}          = $self->transcript->source;
+  $summary{'start'}           = $self->seq_region_start;
+  $summary{'end'}             = $self->seq_region_end;
+  $summary{'strand'}          = $self->strand;
+  $summary{'id'}              = $self->stable_id_version;
+  $summary{'Name'}            = $self->stable_id_version;
+  $summary{'Parent'}          = $self->transcript->stable_id;
+  $summary{'exon_id'}         = $self->stable_id_version;
+  # Instead of 'rank' use 'exon_number', to match NCBI spec.
+  $summary{'exon_number'}     = $self->rank;
+
+  return \%summary;
+}
+
+sub Bio::EnsEMBL::CDS::summary_as_hash {
+  my $self = shift;
+  my %summary;
+
+  my $seq_region_name =
+    Bio::EnsEMBL::Production::Pipeline::FileDump::Geneset_GFF3_ENA::insdc_name($self);
+
+  $summary{'seq_region_name'} = $seq_region_name;
+  $summary{'source'}          = $self->transcript->source;
+  $summary{'start'}           = $self->seq_region_start;
+  $summary{'end'}             = $self->seq_region_end;
+  $summary{'strand'}          = $self->strand;
+  $summary{'phase'}           = $self->phase;
+  $summary{'id'}              = $self->translation_id;
+  $summary{'Name'}            = $self->transcript->translation->stable_id_version;
+  $summary{'Parent'}          = $self->transcript->stable_id;
+  $summary{'protein_id'}      = $self->transcript->translation->stable_id_version;
+
+  my ($ena_seq_edits, $ncbi_seq_edits) = 
+    Bio::EnsEMBL::Production::Pipeline::FileDump::Geneset_GFF3_ENA::translation_seq_edits($self->transcript->translation);
+
+  if (defined $ena_seq_edits) {
+    # Terminology for 'exception' taken from NCBI:
+    # https://www.ncbi.nlm.nih.gov/datasets/docs/reference-docs/file-formats/about-ncbi-gff3/
+    $summary{'exception'} = "unclassified translation discrepancy";
+    $summary{'transl_except'} = join(',', @$ena_seq_edits);
+    $summary{'Note'} = "NCBI-format exceptions: ".join(',', @$ncbi_seq_edits);
+  }
+
+  return \%summary;
+}
+
+sub insdc_name {
+  my $obj = shift;
+
+  my $seq_region_name;
+  my $synonyms = $obj->slice->get_all_synonyms('INSDC');
+  if (@$synonyms) {
+    foreach (@$synonyms) {
+      if ($_->name =~ /^[A-Z0-9]+\.\d+$/) {
+        $seq_region_name = $_->name;
+        last;
+      }
+    }
+    if (! defined $seq_region_name) {
+      die 'No INSDC accession for '.$obj->seq_region_name;
+    }
+  } else {
+    $seq_region_name = $obj->seq_region_name;
+    if ($seq_region_name !~ /^[A-Z0-9]+\.\d+$/) {
+      die 'No INSDC accession for '.$obj->seq_region_name;
+    }
+  }
+
+  return $seq_region_name;
+}
+
+sub transcript_seq_edits {
+  my $transcript = shift;
+
+  # ENA have not requested transcript-level sequence edits,
+  # and these should probably not occur with new genesets.
+  # But doesn't hurt to put the details in.
+  my $seq_edits = $transcript->get_all_SeqEdits();
+  return unless scalar @$seq_edits;
+
+  my $mrna = $transcript->spliced_seq();
+
+  my @seq_edits;
+
+  foreach (sort { $a->start <=> $b->start } @$seq_edits) {
+    my ($start, $end, $in) = ($_->start, $_->end, $_->alt_seq);
+    my $del = '';
+    if ($in eq '' || $end < $start) {
+      $del = substr($mrna, $start - 1, $end - $start + 1);
+    }
+
+    my @genomic_coords = $transcript->cdna2genomic($start, $end);
+
+    my ($seq_edit);
+
+    if (scalar(@genomic_coords) == 0) {
+      die "Could not map seq_edit for ".$transcript->stable_id;
+    } elsif (scalar(@genomic_coords) == 1) {
+      my $coord_start = $genomic_coords[0]->start;
+      my $coord_end = $genomic_coords[0]->end;
+      if ($coord_start == $coord_end) {
+        $seq_edit = "${coord_start}|$del>$in";
+      } elsif ($transcript->strand == 1) {
+        $seq_edit = "${coord_start}-${coord_end}|$del>$in";
+      } else {
+        $seq_edit = "${coord_end}-${coord_start}|$del>$in";
+      }
+    } else {
+      my @coords;
+      foreach my $coord (@genomic_coords) {
+        my $coord_start = $coord->start;
+        my $coord_end = $coord->end;
+        if ($coord_start == $coord_end) {
+          push @coords, $coord_start;
+        } else {
+          if ($transcript->strand == 1) {
+            push @coords, "${coord_start}-${coord_end}";
+          } else {
+            push @coords, "${coord_end}-${coord_start}";
+          }
+        }
+      }
+      $seq_edit = join(',', @coords)."|$del>$in";
+    }
+
+    push @seq_edits, $seq_edit;
+  }
+
+  return \@seq_edits;
+}
+
+sub translation_seq_edits {
+  my $translation = shift;
+
+  my $seq_edits = $translation->get_all_SeqEdits();
+  return unless scalar @$seq_edits;
+
+  $translation->transcript->edits_enabled(0);
+  my $aa = $translation->seq();
+
+  # ENA have requested a format that deviates from the NCBI spec;
+  # but it seems like having the latter format might be useful
+  # too, and it's virtually no extra effort to do so.
+  my @ena_seq_edits;
+  my @ncbi_seq_edits;
+
+  foreach (sort { $a->start <=> $b->start } @$seq_edits) {
+    my ($start, $end, $in) = ($_->start, $_->end, $_->alt_seq);
+    my $del = '';
+    if ($in eq '' || $end <= $start) {
+      $del = substr($aa, $start - 1, $end - $start + 1);
+    }
+
+    my @genomic_coords = $translation->transcript->pep2genomic($start, $end);
+
+    my ($ena_seq_edit, $ncbi_seq_edit);
+
+    if (scalar(@genomic_coords) == 0) {
+      die "Could not map seq_edit for ".$translation->stable_id;
+    } elsif (scalar(@genomic_coords) == 1) {
+      my $coord_start = $genomic_coords[0]->start;
+      my $coord_end = $genomic_coords[0]->end;
+      if ($translation->transcript->strand == 1) {
+        $ena_seq_edit = "${coord_start}-${coord_end}|$del>$in";
+        $ncbi_seq_edit = "pos:${coord_start}..${coord_end},aa:$in";
+      } else {
+        $ena_seq_edit = "${coord_end}-${coord_start}|$del>$in";
+        $ncbi_seq_edit = "pos:${coord_end}..${coord_start},aa:$in";
+      }
+    } else {
+      my @ena_coords;
+      my @ncbi_coords;
+      foreach my $coord (@genomic_coords) {
+        my $coord_start = $coord->start;
+        my $coord_end = $coord->end;
+        if ($coord_start == $coord_end) {
+          push @ena_coords, $coord_start;
+          push @ncbi_coords, $coord_start;
+        } else {
+          if ($translation->transcript->strand == 1) {
+            push @ena_coords, "${coord_start}-${coord_end}";
+            push @ncbi_coords, "${coord_start}..${coord_end}";
+          } else {
+            push @ena_coords, "${coord_end}-${coord_start}";
+            push @ncbi_coords, "${coord_end}..${coord_start}";
+          }
+        }
+      }
+      $ena_seq_edit = join(',', @ena_coords)."|$del>$in";
+      $ncbi_seq_edit = "pos:join(".join(',', @ncbi_coords)."),aa:$in";
+    }
+
+    push @ena_seq_edits, $ena_seq_edit;
+    push @ncbi_seq_edits, $ncbi_seq_edit;
+  }
+
+  return(\@ena_seq_edits, \@ncbi_seq_edits);
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_GFF3_ENA.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_GFF3_ENA.pm
@@ -34,7 +34,8 @@ sub param_defaults {
 
   return {
     %{$self->SUPER::param_defaults},
-    header => 0,
+    data_type => 'genes_ena',
+    header    => 0,
   };
 }
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_GFF3_ENA.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_GFF3_ENA.pm
@@ -138,7 +138,6 @@ sub Bio::EnsEMBL::ExonTranscript::summary_as_hash {
   $summary{'end'}             = $self->seq_region_end;
   $summary{'strand'}          = $self->strand;
   $summary{'id'}              = $self->stable_id_version;
-  $summary{'Name'}            = $self->stable_id_version;
   $summary{'Parent'}          = $self->transcript->stable_id;
   $summary{'exon_id'}         = $self->stable_id_version;
   # Instead of 'rank' use 'exon_number', to match NCBI spec.

--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_GFF3_ENA.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_GFF3_ENA.pm
@@ -34,8 +34,9 @@ sub param_defaults {
 
   return {
     %{$self->SUPER::param_defaults},
-    data_type => 'genes_ena',
-    header    => 0,
+    data_type   => 'genes_ena',
+    header      => 0,
+    include_utr => 0,
   };
 }
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FileDumpENA_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FileDumpENA_conf.pm
@@ -17,7 +17,7 @@ limitations under the License.
 
 =cut
 
-package Bio::EnsEMBL::Production::Pipeline::PipeConfig::FileDumpCore_conf;
+package Bio::EnsEMBL::Production::Pipeline::PipeConfig::FileDumpENA_conf;
 
 use strict;
 use warnings;
@@ -28,28 +28,12 @@ sub default_options {
   return {
     %{$self->SUPER::default_options},
 
-    genome_types => [
-      'Assembly_Chain',
-      'Chromosome_TSV',
-      'Genome_FASTA',
-    ],
     geneset_types => [
-      'Geneset_EMBL',
-      'Geneset_FASTA',
-      'Geneset_GFF3',
-      'Geneset_GTF',
-      'Xref_TSV',
+      'Geneset_GFF3_ENA',
     ],
-    rnaseq_types => [
-      'RNASeq_Exists',
-    ],
-
-    dump_metadata => 1,
-
-    blast_index => 1,
 
     run_datachecks   => 1,
-    datacheck_groups => ['rapid_release'],
+    datacheck_groups => ['ena_submission'],
   };
 }
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FileDump_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FileDump_conf.pm
@@ -347,6 +347,22 @@ sub pipeline_analyses {
                             },
     },
     {
+      -logic_name        => 'Geneset_GFF3_ENA',
+      -module            => 'Bio::EnsEMBL::Production::Pipeline::FileDump::Geneset_GFF3_ENA',
+      -max_retry_count   => 1,
+      -hive_capacity     => 10,
+      -parameters        => {
+                              per_chromosome       => $self->o('gff3_per_chromosome'),
+                              gt_gff3_exe          => $self->o('gt_gff3_exe'),
+                              gt_gff3validator_exe => $self->o('gt_gff3validator_exe'),
+                            },
+      -rc_name           => '1GB',
+      -flow_into         => {
+                              '-1' => ['Geneset_GFF3_ENA_mem'],
+                              '2'  => ['Geneset_Compress']
+                            },
+    },
+    {
       -logic_name        => 'Geneset_GTF',
       -module            => 'Bio::EnsEMBL::Production::Pipeline::FileDump::Geneset_GTF',
       -max_retry_count   => 1,
@@ -458,6 +474,22 @@ sub pipeline_analyses {
                               overwrite            => 1,
                             },
 	    -rc_name           => '8GB',
+      -flow_into         => {
+                              '2' => ['Geneset_Compress']
+                            },
+    },
+    {
+      -logic_name        => 'Geneset_GFF3_ENA_mem',
+      -module            => 'Bio::EnsEMBL::Production::Pipeline::FileDump::Geneset_GFF3_ENA',
+      -max_retry_count   => 1,
+      -hive_capacity     => 10,
+      -parameters        => {
+                              per_chromosome       => $self->o('gff3_per_chromosome'),
+                              gt_gff3_exe          => $self->o('gt_gff3_exe'),
+                              gt_gff3validator_exe => $self->o('gt_gff3validator_exe'),
+                              overwrite            => 1,
+                            },
+      -rc_name           => '8GB',
       -flow_into         => {
                               '2' => ['Geneset_Compress']
                             },

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FileDump_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FileDump_conf.pm
@@ -42,7 +42,7 @@ sub default_options {
     ftp_root => undef,
 
     genome_types  => [], # Possible values: 'Assembly_Chain', 'Chromosome_TSV', 'Genome_FASTA'
-    geneset_types => [], # Possible values: 'Geneset_EMBL', 'Geneset_FASTA', 'Geneset_GFF3', 'Geneset_GTF', 'Xref_TSV'
+    geneset_types => [], # Possible values: 'Geneset_EMBL', 'Geneset_FASTA', 'Geneset_GFF3', 'Geneset_GFF3_ENA', 'Geneset_GTF', 'Xref_TSV'
     rnaseq_types  => [], # Possible values: 'RNASeq_Exists'
 
     dump_metadata  => 0,
@@ -51,6 +51,15 @@ sub default_options {
     per_chromosome => 0,
 
     rnaseq_email => $self->o('email'),
+
+    # Pre-dump datachecks
+    run_datachecks   => 0,
+    config_file      => undef,
+    history_file     => undef,
+    output_dir       => undef,
+    datacheck_names  => [],
+    datacheck_groups => [],
+    datacheck_types  => [],
 
     # External programs
     blastdb_exe          => 'makeblastdb',
@@ -90,11 +99,12 @@ sub pipeline_wide_parameters {
   my ($self) = @_;
   return {
     %{$self->SUPER::pipeline_wide_parameters},
-    dump_dir      => $self->o('dump_dir'),
-    ftp_root      => $self->o('ftp_root'),
-    dump_metadata => $self->o('dump_metadata'),
-    dump_mysql    => $self->o('dump_mysql'),
-    overwrite     => $self->o('overwrite'),
+    dump_dir       => $self->o('dump_dir'),
+    ftp_root       => $self->o('ftp_root'),
+    dump_metadata  => $self->o('dump_metadata'),
+    dump_mysql     => $self->o('dump_mysql'),
+    overwrite      => $self->o('overwrite'),
+    run_datachecks => $self->o('run_datachecks'),
   };
 }
 
@@ -142,7 +152,31 @@ sub pipeline_analyses {
                               meta_filters => $self->o('meta_filters'),
                             },
       -flow_into         => {
-                              '2' => WHEN('#dump_mysql#' =>
+                              '2' => WHEN(
+                                       '#run_datachecks#' => ['RunDataChecks'],
+                                       '#dump_mysql# && !#run_datachecks#' => ['MySQL_TXT', 'SpeciesFactory'],
+                                     ELSE
+                                       ['SpeciesFactory']
+                                     )
+                             },
+    },
+    {
+      -logic_name        => 'RunDataChecks',
+      -module            => 'Bio::EnsEMBL::DataCheck::Pipeline::RunDataChecks',
+      -max_retry_count   => 1,
+      -analysis_capacity => 10,
+      -parameters        => {
+                              registry_file      => $self->o('registry'),
+                              history_file       => $self->o('history_file'),
+                              output_dir         => $self->o('output_dir'),
+                              config_file        => $self->o('config_file'),
+                              datacheck_names    => $self->o('datacheck_names'),
+                              datacheck_groups   => $self->o('datacheck_groups'),
+                              datacheck_types    => $self->o('datacheck_types'),
+                              failures_fatal     => 1,
+                            },
+      -flow_into         => {
+                              '3' => WHEN('#dump_mysql#' =>
                                        ['MySQL_TXT', 'SpeciesFactory'],
                                      ELSE
                                        ['SpeciesFactory']


### PR DESCRIPTION
### Generate GFF3 in the format required for ENA submission.
This differs from our normal export in a few ways; the versioned stable IDs for all features are set as 'Name' attributes (only gene is required to have a name, but it doesn't hurt to be consistent).

The versioned INSDC accessions are used to identify sequences; if a region is a chromosome, the name is given by the 'chromosome' attribute. Circular regions have the 'Is_circular' attribute; and if a region needs anything other than the standard Codon table, there is a 'transl_table' attribute.

Some aspects of the file are in line with the NCBI spec: gene_id, transcript_id, protein_id attributes all contain the versioned stable ID; exon order is given by the 'exon_number' attribute rather than 'rank'. The biotype of a gene is given by a 'gene_biotype' attribute, rather than 'biotype'.

Two types of sequence edits are represented in the file.
- Protein-level edits are indicated by setting the 'exception' attribute (from the NCBI spec), with the edits in the format requested by ENA in the 'transl_except' attribute. This format is different from the NCBI spec, so in a belt-and-braces approach, the NCBI-format edits are given in a 'Note attribute'.
- Transcript-level edits are also indicated by setting the 'exception' attribute. Information on transcript-level edits was not requested by ENA, but is provided, in the same format as requested for proteins, in a 'Note' attribute.

The ENA requirements necessitated a bit of additional flexibility in the generic dump files from which we inherit.
- For custom paths, directories are now created if they do not exist (which is the existing behaviour if the paths are to be the standard RR format).
- The general GFF3 export has an extra parameter, to indicate whether the GFF3Serializer should add GFF3 headers and metadata. Usually we want this, but not for the ENA format, because it defaults to using the seq_region names, not INSDC synonyms, and it's hard to override this. Instead, we rely on the 'gt' tidying step to add in the necessary details.

The pipeline to dump the GFF3 files can largely inherit from the generic dumping pipeline; the functionality needed to run pre-dump datachecks, to verify that we have INSDC sequence accessions, is added to the generic pipeline, because that is generally useful (and also makes inheritance more straightforward). The companion datacheck PR is https://github.com/Ensembl/ensembl-datacheck/pull/388.