### PR TITLE
Modify Protein Features pipeline, 'seg' execution.

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProteinFeatures_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProteinFeatures_conf.pm
@@ -260,7 +260,7 @@ sub default_options {
     delete_existing => 1,
 
     # seg analysis is not part of InterProScan, so is always run locally.
-    run_seg    => 1,
+    run_seg    => 0,
     seg_exe    => 'seg',
     seg_params => '-l -n',
 


### PR DESCRIPTION
## Description
We need a bit more flexibility in 'seg' execution, so that we can always force it to run, even if there are already features annotated. The use case is for human and mouse, where we might have partial annotation, and we want to re-annotate everything.

The assumption of the pipeline now reflects usage, and treats 'seg' the same as the InterPro sources, in that it is always run of features do not exist. By default, it is not run if features exist, but this can be overriden by setting the 'run_seg' paramter to 1.

## Benefits
Can deal with all use cases for _seg_ annotation.

## Possible Drawbacks
Logic of pipeline has slightly changed interpretation of the parameter, which isn't ideal; but this parameter would rarely, if ever, be used when running pipelines, so this shouldn't affect anyone.

## Testing
Pipeline run for human and mouse.