### PR TITLE
Increase memory for GFF3 ENA format dumps.

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FileDump_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FileDump_conf.pm
@@ -356,7 +356,7 @@ sub pipeline_analyses {
                               gt_gff3_exe          => $self->o('gt_gff3_exe'),
                               gt_gff3validator_exe => $self->o('gt_gff3validator_exe'),
                             },
-      -rc_name           => '1GB',
+      -rc_name           => '2GB',
       -flow_into         => {
                               '-1' => ['Geneset_GFF3_ENA_mem'],
                               '2'  => ['Geneset_Compress']


### PR DESCRIPTION
Some jobs were hitting the memlimit during the step where the file is renamed after being sorted. For reasons I couldn't make out, this was not being properly detected and spawning a subsequent 'high_mem' job. But might as well increase the default memory to avoid teh problem in the first place.
