### PR TITLE
Add StoreProteinFeatures_HighMem to PF pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProteinFeatures_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProteinFeatures_conf.pm
@@ -851,6 +851,21 @@ sub pipeline_analyses {
       -parameters        => {
                               analyses => $self->o('protein_feature_analyses')
                             },
+      -flow_into         => {
+                              '-1' => ['StoreProteinFeatures_HighMem'],
+                            },
+    },
+    
+    {
+      -logic_name        => 'StoreProteinFeatures_HighMem',
+      -module            => 'Bio::EnsEMBL::Production::Pipeline::ProteinFeatures::StoreProteinFeatures',
+      -analysis_capacity => 10,
+      -batch_size        => 50,
+      -max_retry_count   => 1,
+      -parameters        => {
+                              analyses => $self->o('protein_feature_analyses')
+                            },
+      -rc_name           => '4GB',
     },
 
     {


### PR DESCRIPTION
Several `StoreProteinFeatures` jobs regularly fail with MEMLIMIT.
Species involved: mouse, drosophila, suricata

## Benefits

`StoreProteinFeatures` jobs that would fail with MEMLIMIT will be automatically passed to `StoreProteinFeatures_HighMem` and ran.

## Possible Drawbacks

Nothing comes to mind

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [x] Have you run the entire test suite and no regression was detected?
- [x] TravisCI passed on your branch