### PR TITLE
Update FTP Checker pipeline for Codon execution.

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/FtpChecker/CheckCoreFtp.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FtpChecker/CheckCoreFtp.pm
@@ -59,18 +59,6 @@ my $expected_files = {
 							'{species}*.json',
 							 'CHECKSUMS*'
 						       ]},
-		      "tsv" => {"dir" => "{division}/tsv/{species_dir}/", "expected" =>[
-							'{species_uc}*.ena.tsv.gz',
-							'{species_uc}*.entrez.tsv.gz',
-							'{species_uc}*.karyotype.tsv.gz',
-							'{species_uc}*.refseq.tsv.gz',
-							'{species_uc}*.uniprot.tsv.gz',
-							 'README_ENA*.tsv',
-							 'README_entrez*.tsv',
-							 'README_refseq*.tsv',
-							 'README_uniprot*.tsv',
-							 'CHECKSUMS*'
-						       ]},
 		      "fasta_pep" => {"dir" => "{division}/fasta/{species_dir}/pep/", "expected" =>[
 							'{species_uc}.*.fa.gz',
 							 'README*',

--- a/modules/Bio/EnsEMBL/Production/Pipeline/FtpChecker/ReportFailures.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FtpChecker/ReportFailures.pm
@@ -39,15 +39,19 @@ sub fetch_input {
 
   $self->write_failures_file($failures_file);
 
-  my $text =
-    "The $pipeline_name pipeline has completed successfully.\n\n".
-    "Failures were stored in: $failures_file\n";
+  my $text = "The $pipeline_name pipeline has completed successfully.\n\n";
 
-  if (-s $failures_file < 2e6) {
-    push @{$self->param('attachments')}, $failures_file;
-    $text .= "(File also attached to this email.)\n"
+  if (-z $failures_file) {
+    $text .= "There were no failures!\n";
   } else {
-    $text .= "(File not attached because it exceeds 2MB limit)";
+    $text .= "Failures were stored in: $failures_file\n";
+
+    if (-s $failures_file < 2e6) {
+      push @{$self->param('attachments')}, $failures_file;
+      $text .= "(File also attached to this email.)\n"
+    } else {
+      $text .= "(File not attached because it exceeds 2MB limit)\n";
+    }
   }
 
   $self->param('text', $text);

--- a/modules/Bio/EnsEMBL/Production/Pipeline/FtpChecker/ReportFailures.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FtpChecker/ReportFailures.pm
@@ -23,27 +23,52 @@ package Bio::EnsEMBL::Production::Pipeline::FtpChecker::ReportFailures;
 use strict;
 use warnings;
 
-use base qw/Bio::EnsEMBL::Production::Pipeline::Common::Base/;
+use base qw/
+  Bio::EnsEMBL::Hive::RunnableDB::NotifyByEmail
+  Bio::EnsEMBL::Production::Pipeline::Common::Base
+/;
 
-use Carp;
+sub fetch_input {
+  my $self = shift;
 
-sub run {
-  my ($self) = @_;
-  my $outfile = $self->param_required('failures_file');
-  open my $out, ">", $outfile || croak "Could not open $outfile for writing";
+  my $pipeline_name = $self->param_required('pipeline_name');
+  my $failures_file = $self->param_required('failures_file');
+
+  my $subject = "ftp checker pipeline completed ($pipeline_name)";
+  $self->param('subject', $subject);
+
+  $self->write_failures_file($failures_file);
+
+  my $text =
+    "The $pipeline_name pipeline has completed successfully.\n\n".
+    "Failures were stored in: $failures_file\n";
+
+  if (-s $failures_file < 2e6) {
+    push @{$self->param('attachments')}, $failures_file;
+    $text .= "(File also attached to this email.)\n"
+  } else {
+    $text .= "(File not attached because it exceeds 2MB limit)";
+  }
+
+  $self->param('text', $text);
+}
+
+sub write_failures_file {
+  my ($self, $file) = @_;
+
+  open my $out, ">", $file || $self->throw("Could not open $file");
   my $n = 0;
   $self->hive_dbc()->sql_helper()->execute_no_return(
-						     -SQL=>q/select * from failures/,
-						     -CALLBACK => sub {
-						       my $row = shift;
-						       print $out join("\t", @$row);
-						       print $out "\n";
-							 $n++;
-						       return;	       
-						     } 	    	       
-						    );
+    -SQL      => q/select * from failures/,
+    -CALLBACK => sub {
+                      my $row = shift;
+                      print $out join("\t", @$row);
+                      print $out "\n";
+                      $n++;
+                      return;         
+                     }                
+  );
   close $out;
-  return;
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FtpChecker_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FtpChecker_conf.pm
@@ -3,17 +3,17 @@
 Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
 Copyright [2016-2021] EMBL-European Bioinformatics Institute
 
-Licensed under the Apache License, Version 2.0 (the "License"); you
-may not use this file except in compliance with the License.  You may
-obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
      http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-implied.  See the License for the specific language governing
-permissions and limitations under the License.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 
 =cut
 
@@ -21,126 +21,112 @@ package Bio::EnsEMBL::Production::Pipeline::PipeConfig::FtpChecker_conf;
 
 use strict;
 use warnings;
-use Data::Dumper;
-use base qw/Bio::EnsEMBL::Hive::PipeConfig::EnsemblGeneric_conf/;
 
-sub resource_classes {
-  my ($self) = @_;
-  return {
-      'default' => { 'LSF' => '-q production' }
-  };
-}
+use base ('Bio::EnsEMBL::Production::Pipeline::PipeConfig::Base_conf');
 
-=head2 default_options
-
-    Description : Implements default_options() interface method of
-    Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf that is used to
-    initialize default options.
-
-=cut
+use File::Spec::Functions qw(catdir);
 
 sub default_options {
   my ($self) = @_;
   return {
-    %{ $self->SUPER::default_options()
-      },    # inherit other stuff from the base class
-    pipeline_name => 'ftp_checker',
-    species       => [],
-    division      => [],
-    run_all       => 0,
-    antispecies   => [],
-    meta_filters  => {},
-    force_update  => 0,
-    base_path     => undef,
-    failures_file  => './failures.txt',
+    %{$self->SUPER::default_options},
+
+    species      => [],
+    antispecies  => [],
+    division     => [],
+    run_all      => 0,
+    meta_filters => {},
+
+    failures_file  => catdir($self->o('pipeline_dir'), 'failures.txt'),
  };
-}
-
-sub pipeline_analyses {
-  my ($self) = @_;
-  return [ 
-	  {
-	   -logic_name => 'SpeciesFactory',
-	   -module =>
-	   'Bio::EnsEMBL::Production::Pipeline::Common::SpeciesFactory',
-           -max_retry_count => 1,
-           -input_ids       => [ {} ],
-           -parameters      => {
-				species         => $self->o('species'),
-				antispecies     => $self->o('antispecies'),
-				division        => $self->o('division'),
-				run_all         => $self->o('run_all'),
-				meta_filters    => $self->o('meta_filters'),
-				chromosome_flow => 0 },
-           -flow_into     => { 
-			      '2->A' => ['CheckCoreFtp'],
-			      '4->A' => ['CheckVariationFtp'],
-			      '5->A' => ['CheckComparaFtp'],
-			      'A->1' => ['ReportFailures'],
-			     },
-           -hive_capacity => 1
-	  }, 
-	  {
-	   -logic_name => 'CheckCoreFtp',
-	   -module =>
-	   'Bio::EnsEMBL::Production::Pipeline::FtpChecker::CheckCoreFtp',
-	   -hive_capacity => 100,
-	   -flow_into => {
-			  2 => [ '?table_name=failures']
-			 } 
-	  },
-	   {
-	    -logic_name => 'CheckVariationFtp',
-	    -module =>
-	    'Bio::EnsEMBL::Production::Pipeline::FtpChecker::CheckVariationFtp',
-	    -hive_capacity => 100,
-	    -flow_into => {
-			   2 => [ '?table_name=failures']
-			  } 
-	   },
-	   {
-	    -logic_name => 'CheckComparaFtp',
-	    -module =>
-	    'Bio::EnsEMBL::Production::Pipeline::FtpChecker::CheckComparaFtp',
-	    -hive_capacity => 100,
-	    -flow_into => {
-			   2 => [ '?table_name=failures']
-			  } 
-	   },
-	   {
-	    -logic_name => 'ReportFailures',
-	    -module =>
-	    'Bio::EnsEMBL::Production::Pipeline::FtpChecker::ReportFailures',
-	    -parameters      => {
-				failures_file    => $self->o('failures_file')
-				},
-	   }
-
-
-	 ];
-} ## end sub pipeline_analyses
-
-sub beekeeper_extra_cmdline_options {
-  my $self = shift;
-  return "-reg_conf " . $self->o("registry");
-}
-
-sub pipeline_wide_parameters {
-  my ($self) = @_;
-  return {
-	  %{ $self->SUPER::pipeline_wide_parameters()
-	   },    # inherit other stuff from the base class
-	  base_path    => $self->o('base_path')
-	 };
 }
 
 sub pipeline_create_commands {
   my ($self) = @_;
+
+  my $failures_table_sql = q/
+    CREATE TABLE failures (
+      species VARCHAR(128),
+      division VARCHAR(16),
+      type VARCHAR(16),
+      format VARCHAR(16),
+      file_path TEXT
+    );
+  /;
+
   return [
-	  @{$self->SUPER::pipeline_create_commands},  # inheriting database and hive tables' creation
-	  $self->db_cmd('CREATE TABLE failures (species varchar(128), division varchar(16), type varchar(16), format varchar(16), file_path text)')
-	 ];
+    @{$self->SUPER::pipeline_create_commands},
+    $self->db_cmd($failures_table_sql),
+  ];
+}
+
+sub pipeline_wide_parameters {
+  my ($self) = @_;
+
+  return {
+    %{$self->SUPER::pipeline_wide_parameters},
+    base_path    => $self->o('base_path'),
+    pipeline_dir => $self->o('pipeline_dir'),
+  };
+}
+
+sub pipeline_analyses {
+  my ($self) = @_;
+
+  return [
+    {
+      -logic_name      => 'SpeciesFactory',
+      -module          => 'Bio::EnsEMBL::Production::Pipeline::Common::SpeciesFactory',
+      -max_retry_count => 1,
+      -input_ids       => [ {} ],
+      -parameters      => {
+                            species      => $self->o('species'),
+                            antispecies  => $self->o('antispecies'),
+                            division     => $self->o('division'),
+                            run_all      => $self->o('run_all'),
+                            meta_filters => $self->o('meta_filters'),
+                          },
+      -flow_into       => { 
+                            '2->A' => ['CheckCoreFtp'],
+                            '4->A' => ['CheckVariationFtp'],
+                            '5->A' => ['CheckComparaFtp'],
+                            'A->1' => ['ReportFailures'],
+                          },
+    }, 
+    {
+      -logic_name    => 'CheckCoreFtp',
+      -module        => 'Bio::EnsEMBL::Production::Pipeline::FtpChecker::CheckCoreFtp',
+      -hive_capacity => 100,
+      -flow_into     => {
+                          2 => ['?table_name=failures']
+                        }, 
+    },
+    {
+      -logic_name    => 'CheckVariationFtp',
+      -module        => 'Bio::EnsEMBL::Production::Pipeline::FtpChecker::CheckVariationFtp',
+      -hive_capacity => 100,
+      -flow_into     => {
+                          2 => ['?table_name=failures']
+                        },
+    },
+    {
+      -logic_name    => 'CheckComparaFtp',
+      -module        => 'Bio::EnsEMBL::Production::Pipeline::FtpChecker::CheckComparaFtp',
+      -hive_capacity => 100,
+      -flow_into     => {
+                          2 => ['?table_name=failures']
+                        },
+    },
+    {
+      -logic_name    => 'ReportFailures',
+      -module        => 'Bio::EnsEMBL::Production::Pipeline::FtpChecker::ReportFailures',
+      -parameters    => {
+                          email         => $self->o('email'),
+                          pipeline_name => $self->o('pipeline_name'),
+                          failures_file => $self->o('failures_file'),
+                        },
+    },
+  ];
 }
 
 1;
-

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FtpChecker_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FtpChecker_conf.pm
@@ -56,6 +56,7 @@ sub pipeline_create_commands {
 
   return [
     @{$self->SUPER::pipeline_create_commands},
+    'mkdir -p '.$self->o('pipeline_dir'),
     $self->db_cmd($failures_table_sql),
   ];
 }
@@ -66,7 +67,6 @@ sub pipeline_wide_parameters {
   return {
     %{$self->SUPER::pipeline_wide_parameters},
     base_path    => $self->o('base_path'),
-    pipeline_dir => $self->o('pipeline_dir'),
   };
 }
 


### PR DESCRIPTION
## Description
Missed this config when doing earlier updates for Codon execution - Pipeline now inherits from the standard Base
config, to enable execution on the Codon cluster.

Also, a couple of improvements to the pipeline:
1. Drop TSV checking - we don't have clear expectations of these files, so we end up with lots of spurious 'failures', amongst which it's easy to miss important failures.
2. Rather than rely on the person running the pipeline to find the results file and look at it, send an email (if there are failures) with the file location, and attach file if it's not too big.

Confluence updated: https://www.ebi.ac.uk/seqdb/confluence/display/GTI/FTP+Checker+Pipeline

## Benefits
Pipeline runs on Codon; genuine failures are easier to spot.

## Testing
Test pipeline run on Codon, new functionality verified.