### PR TITLE
Add datestamp for RNA Gene xref analysis

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/RNAGeneXref/AnalysisConfiguration.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/RNAGeneXref/AnalysisConfiguration.pm
@@ -38,13 +38,13 @@ sub run {
     if (-e $$analysis_config{'local_file'}) {
       my $timestamp = path($$analysis_config{'local_file'})->stat->mtime;
       my $datestamp = strftime "%Y-%m-%d", localtime($timestamp);
+      $$analysis_config{'db_version'} = $datestamp;
 
       my $logic_name = $$analysis_config{'logic_name'};
       my $analysis = $aa->fetch_by_logic_name($logic_name);
 
       if (defined($analysis)) {
-        if ($datestamp ne $analysis->db_version) {
-          $$analysis_config{'db_version'} = $datestamp;
+        if ($$analysis_config{'db_version'} ne $analysis->db_version) {
           push @filtered_analyses, $analysis_config;
         }
       } else {


### PR DESCRIPTION
## Description
The datestamp for the RNAcentral analysis was not always getting populated, which meant that subsequent pipeline runs were potentially running redundantly, because there was no way to tell whether the data had changed. 

## Benefits
Avoid re-annotating the same data.

## Possible Drawbacks
None.

## Testing
Test pipeline run successfully.