### PR TITLE
Reinstantiate rc_name="1Gb_job" for compat with Compara resources

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GeneNameDescProjection_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GeneNameDescProjection_conf.pm
@@ -394,7 +394,7 @@ sub resource_classes {
     my ($self) = @_;
     return {
         %{$self->SUPER::resource_classes},  # inherit 'default' from the parent class
-        '1Gb_job'    => { 'LSF' => [' -q production-rh74 -C0 -M1000 -R"select[mem>1000] rusage[mem=1000]"'] },
+        '1Gb_job'    => { 'LSF' => [' -q production -M 1000 '] },
     };
 }
 1;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GeneNameDescProjection_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GeneNameDescProjection_conf.pm
@@ -390,4 +390,11 @@ sub pipeline_analyses {
   ];
 }
 
+sub resource_classes {
+    my ($self) = @_;
+    return {
+        %{$self->SUPER::resource_classes},  # inherit 'default' from the parent class
+        '1Gb_job'    => { 'LSF' => [' -q production-rh74 -C0 -M1000 -R"select[mem>1000] rusage[mem=1000]"'] },
+    };
+}
 1;


### PR DESCRIPTION
## Description

while moving to codon, we cleaned up our resources class names and made a more generic use of them in our pipeline. So we removed the resource name "1Gb_job! from our configurations files (because this is anyway the default resources allocation
While initialising Bio::EnsEMBL::Production::Pipeline::PipeConfig::GeneNameDescProjection_protists_conf I noticed the error. 

## Use case

GeneNameDEscriptionProjection pipeline. 

## Benefits

Avoid compara updates dependency located in there : https://github.com/Ensembl/ensembl-compara/pull/327

## Possible Drawbacks

None

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
