### PR TITLE
Fix regexes for gzip file names in copy_ftp_release.pl script

### DIFF
--- a/scripts/copy_ftp_release.pl
+++ b/scripts/copy_ftp_release.pl
@@ -61,8 +61,7 @@ sub rename_file {
 }
 
 my $gzip_files = [
-    qr/.*\.(${old_rel})\..*\.fa\.gz/,
-    qr/.*\.(${old_rel})\..*\.gff3\.gz/,
+    qr/.*\.(${old_rel})\..*?\.?gff3\.gz/,
     qr/.*\.(${old_rel})\.gtf\.gz/,
     qr/.*\.(${old_rel})\.emf\.gz/,
     qr/.*\.(${old_rel})\.[a-z]+\.tsv\.gz/,

--- a/scripts/copy_ftp_release.pl
+++ b/scripts/copy_ftp_release.pl
@@ -61,12 +61,12 @@ sub rename_file {
 }
 
 my $gzip_files = [
-    qr/.*\.(${old_rel})\..*?\.?gff3\.gz/,
-    qr/.*\.(${old_rel})\.gtf\.gz/,
-    qr/.*\.(${old_rel})\.emf\.gz/,
-    qr/.*\.(${old_rel})\.[a-z]+\.tsv\.gz/,
-    qr/.*\.(${old_rel})\..*\.dat\.gz/,
-    qr/.*\.gz/
+    qr/.*\.(${old_rel})\..*?\.?gff3\.gz$/,
+    qr/.*\.(${old_rel})\.gtf\.gz$/,
+    qr/.*\.(${old_rel})\.emf\.gz$/,
+    qr/.*\.(${old_rel})\.[a-z]+\.tsv\.gz$/,
+    qr/.*\.(${old_rel})\..*?\.?dat\.gz$/,
+    qr/.*\.gz$/
 ];
 
 sub process_file {


### PR DESCRIPTION
## Description

- Remove FASTA (fa.gz ext) regex from `gzip_files` as FASTA file names
  don't include the release number anymore.
- Change GTF (gtf.gz ext) regex matching characters after the release
  number un-greedily, removing ambiguity (if the names are correct).

## Benefits

Files copied using `copy_ftp_release.pl` should not have parts of the assembly mismatched with the Ensembl version numbers in the target file name. 

## Possible Drawbacks

Might not cover all possible cases.

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [x] Have you run the entire test suite and no regression was detected?
- [x] TravisCI passed on your branch
