### PR TITLE
Exclude outgroup species

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GeneNameDescProjection_plants_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GeneNameDescProjection_plants_conf.pm
@@ -40,7 +40,7 @@ sub pipeline_wide_parameters {
     my ($self) = @_;
     return {
 	%{$self->SUPER::pipeline_wide_parameters},    
-	'exclude_species' => ['ciona_savignyi', 'homo_sapiens'],	    
+	'exclude_species' => ['ciona_savignyi', 'homo_sapiens', 'caenorhabditis_elegans', 'drosophila_melanogaster', 'saccharomyces_cerevisiae'],	    
     };
 }
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GeneNameDescProjection_plants_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GeneNameDescProjection_plants_conf.pm
@@ -36,6 +36,14 @@ use strict;
 use warnings;
 use base ('Bio::EnsEMBL::Production::Pipeline::PipeConfig::GeneNameDescProjection_conf');
 
+sub pipeline_wide_parameters {
+    my ($self) = @_;
+    return {
+	'exclude_outgroup_species' => ['ciona_savignyi' ,'homo_sapiens'],	    
+    };
+}
+
+
 sub default_options {
   my ($self) = @_;
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GeneNameDescProjection_plants_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GeneNameDescProjection_plants_conf.pm
@@ -40,7 +40,7 @@ sub pipeline_wide_parameters {
     my ($self) = @_;
     return {
 	%{$self->SUPER::pipeline_wide_parameters},    
-	'exclude_outgroup_species' => ['ciona_savignyi', 'homo_sapiens'],	    
+	'exclude_species' => ['ciona_savignyi', 'homo_sapiens'],	    
     };
 }
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GeneNameDescProjection_plants_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GeneNameDescProjection_plants_conf.pm
@@ -39,7 +39,8 @@ use base ('Bio::EnsEMBL::Production::Pipeline::PipeConfig::GeneNameDescProjectio
 sub pipeline_wide_parameters {
     my ($self) = @_;
     return {
-	'exclude_outgroup_species' => ['ciona_savignyi' ,'homo_sapiens'],	    
+	%{$self->SUPER::pipeline_wide_parameters},    
+	'exclude_outgroup_species' => ['ciona_savignyi', 'homo_sapiens'],	    
     };
 }
 


### PR DESCRIPTION
GeneName Description Project Pipeline for plants fails as compara db includes  vertebrate species as outgroups. 
We do not have vertebrate species (i.e Human) on the target staging.  

compara team have provided with new param to filter the given species list , for more details on exclude_species param
 https://github.com/Ensembl/ensembl-compara/pull/322

Related JIRA tickets:
    ENSCOMPARASW-4673
    ENSPROD-6669

