### PR TITLE
Pass division parameter to rename factory

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DbCopy_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DbCopy_conf.pm
@@ -47,7 +47,9 @@ sub default_options {
     marts       => 0,
     compara     => 0,
     pan_ensembl => 0,
-    division    => [],
+
+    # Deliberately do not use the name 'division', to avoid confusion with SpeciesFactory parameter
+    multi_division => [],
 
     # Copy service
     copy_service_uri => "http://production-services.ensembl.org/api/dbcopy/requestjob",
@@ -214,7 +216,7 @@ sub pipeline_analyses {
                               marts           => $self->o('delete_marts'),
                               compara         => $self->o('delete_compara'),
                               pan_ensembl     => $self->o('delete_pan_ensembl'),
-                              division        => $self->o('division'),
+                              division        => $self->o('multi_division'),
                             },
       -flow_into         => {
                               '2' => [ 'DeleteDatabase' ],
@@ -254,7 +256,7 @@ sub pipeline_analyses {
                               ensembl_release => $self->o('ensembl_release'),
                               marts           => $self->o('marts'),
                               compara         => $self->o('compara'),
-                              division        => $self->o('division'),
+                              division        => $self->o('multi_division'),
                               pan_ensembl     => $self->o('pan_ensembl'),
                             },
       -flow_into         => {
@@ -279,6 +281,7 @@ sub pipeline_analyses {
       -max_retry_count => 1,
       -parameters      => {
                             ensembl_release => $self->o('ensembl_release'),
+                            division        => $self->o('multi_division'),
                             group           => $self->o('group'),
                             groups          => $self->o('groups'),
                           },
@@ -294,7 +297,7 @@ sub pipeline_analyses {
                               ensembl_release => $self->o('ensembl_release'),
                               marts           => $self->o('marts'),
                               compara         => $self->o('compara'),
-                              division        => $self->o('division'),
+                              division        => $self->o('multi_division'),
                               pan_ensembl     => $self->o('pan_ensembl'),
                             },
       -flow_into         => {


### PR DESCRIPTION
## Description
The renaming needs to be restricted to a subset of dbs; otherwise running the pipeline for bacteria leads to retrieval of db names for all divisions from the metadata db, which then fails for the non-bacterial dbs. Rather than ignoring those, which could lead to us overlooking true discrepancies in the expected dbs, filter based on division. Our SOP is that we will always be passing this parameter in any case, to get the relevant marts and comparas.

Also, renamed the parameter from 'division' to 'multi_division', to avoid confusion with the SpeciesFactory 'division' parameter, since the usage/behaviour is different here.

## Benefits
Avoid spurious rename failures, which should not be attempted in the first place.
Less confusing parameter name.

## Possible Drawbacks
None I can think of.

## Testing
Test pipeline initialised.