### PR TITLE
Remove timeout from ProductionDBCopy module

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/CopyDatabaseDBA_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/CopyDatabaseDBA_conf.pm
@@ -64,8 +64,8 @@ sub pipeline_analyses {
             -input_ids       => [],
             -max_retry_count => 0,
             -parameters      => {
-                'endpoint'     => $self->o('copy_service_uri'),
-                'method'       => 'post',
+                'endpoint' => $self->o('copy_service_uri'),
+                'method'   => 'post',
             },
             -meadow_type     => 'LOCAL',
             -flow_into       => {

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/CopyDatabaseDBA_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/CopyDatabaseDBA_conf.pm
@@ -34,6 +34,7 @@ sub default_options {
         %{$self->SUPER::default_options},
         'pipeline_name'    => "dba_copy_database",
         'copy_service_uri' => "http://production-services.ensembl.org/api/dbcopy/requestjob",
+        'copy_timeout'     => -1
     }
 }
 
@@ -64,8 +65,9 @@ sub pipeline_analyses {
             -input_ids       => [],
             -max_retry_count => 0,
             -parameters      => {
-                'endpoint' => $self->o('copy_service_uri'),
-                'method'   => 'post',
+                'endpoint'     => $self->o('copy_service_uri'),
+                'method'       => 'post',
+                'copy_timeout' => $self->o('copy_timeout')
             },
             -meadow_type     => 'LOCAL',
             -flow_into       => {

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/CopyDatabaseDBA_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/CopyDatabaseDBA_conf.pm
@@ -34,7 +34,6 @@ sub default_options {
         %{$self->SUPER::default_options},
         'pipeline_name'    => "dba_copy_database",
         'copy_service_uri' => "http://production-services.ensembl.org/api/dbcopy/requestjob",
-        'copy_timeout'     => -1
     }
 }
 
@@ -67,7 +66,6 @@ sub pipeline_analyses {
             -parameters      => {
                 'endpoint'     => $self->o('copy_service_uri'),
                 'method'       => 'post',
-                'copy_timeout' => $self->o('copy_timeout')
             },
             -meadow_type     => 'LOCAL',
             -flow_into       => {

--- a/src/python/ensembl/production/hive/ProductionDBCopy.py
+++ b/src/python/ensembl/production/hive/ProductionDBCopy.py
@@ -37,7 +37,6 @@ class ProductionDBCopy(HiveRESTClient):
         super().fetch_input()
 
     def run(self):
-        copy_timeout = int(self.param('copy_timeout'))
         response = self.param('response')
         if response.status_code != 201:
             raise Exception('The Copy submission failed: %s (%s)' % (response.status_code, response.json()))
@@ -70,10 +69,6 @@ class ProductionDBCopy(HiveRESTClient):
                     'The Copy failed, check: ' + self.param('endpoint') + '/' + response.json()['job_id'])
             elif job_response.json()['overall_status'] == 'Complete':
                 break
-            elif copy_timeout > 0:
-                elapsed_time = int(time.time() - submitted_time)
-                if elapsed_time > copy_timeout:
-                    raise Exception(f'Analysis timed out after {elapsed_time} seconds.')
             # Pause for 1min before checking copy status again
             time.sleep(60)
 


### PR DESCRIPTION
## Description

Remove 3 hours timeout from ProductionDBCopy module

## Benefits

Hive analysis that uses that module won't fail if the copy job takes more than 3 hours to terminate

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [x] Have you run the entire test suite and no regression was detected?
- [x] TravisCI passed on your branch
