### PR TITLE
Add use module to MySQL_TXT.pm

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/MySQL_TXT.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/MySQL_TXT.pm
@@ -23,6 +23,7 @@ use strict;
 use warnings;
 use base qw(Bio::EnsEMBL::Production::Pipeline::FileDump::Base_Filetype);
 
+use Bio::EnsEMBL::DBSQL::DBAdaptor;
 use Bio::EnsEMBL::Utils::URI qw/parse_uri/;
 use File::Spec::Functions qw/catdir/;
 use Path::Tiny;


### PR DESCRIPTION
## Description

Standalone execution was complaining without use Bio::EnsEMBL::DBSQL::DBAdaptor;

## Use case

Command used:
standaloneJob.pl Bio::EnsEMBL::Production::Pipeline::FileDump::MySQL_TXT   -db_url ${SRV_URL}${DBNAME}   -dbname ${DBNAME}   -output_dir ${OUTPUT_DIR} -dump_dir ${OUTPUT_DIR}

Error:
Standalone worker 618133 : specializing to Standalone_Dummy_Analysis(unstored)
Standalone worker 618133 : WORKER_ERROR : Can't locate object method "new" via package "Bio::EnsEMBL::DBSQL::DBAdaptor" (perhaps you forgot to load "Bio::EnsEMBL::DBSQL::DBAdaptor"?) at /hps/software/users/wormbase/parasite/reposi
tories/ensembl/branch-105/ensembl-production/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/MySQL_TXT.pm line 84.

## Benefits

Standalone execution will run without problems Bio::EnsEMBL::DBSQL::DBAdaptor;

## Testing
standaloneJob.pl Bio::EnsEMBL::Production::Pipeline::FileDump::MySQL_TXT   -db_url ${SRV_URL}${DBNAME}   -dbname ${DBNAME}   -output_dir ${OUTPUT_DIR} -dump_dir ${OUTPUT_DIR}
