### PR TITLE
Removed codon obsolete `rc_name`

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/GeneTreeHighlight/HighlightGO.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/GeneTreeHighlight/HighlightGO.pm
@@ -127,7 +127,6 @@ sub run {
    	join gene_member m using (gene_member_id)
 	join genome_db g using (genome_db_id) where e.db_name=? and g.name=?/,
 	-PARAMS=>[$db_name, $core_dba->species()]);
-
       $self->info("Updating member_xref for " . $core_dba->species() . "\n");
 
       $xref_adaptor->store_member_associations($core_dba, $db_name,

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/UpdateComparaMemberNamesDescriptions_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/UpdateComparaMemberNamesDescriptions_conf.pm
@@ -41,42 +41,33 @@ use Bio::EnsEMBL::Compara::PipeConfig::Parts::UpdateMemberNamesDescriptions;
 use Bio::EnsEMBL::Registry;
 
 sub default_options {
-  my ($self) = @_;
-  return {
-    %{$self->SUPER::default_options},
+    my ($self) = @_;
+    return {
+        %{$self->SUPER::default_options},
 
-    pipeline_name => 'compara_name_update_'.$self->o('rel_with_suffix'),
+        pipeline_name   => 'compara_name_update_' . $self->o('rel_with_suffix'),
 
-    update_capacity => '5',
-  };
+        update_capacity => '5',
+    };
 }
 
 # Ensures that output parameters get propagated implicitly.
 sub hive_meta_table {
-  my ($self) = @_;
-  return {
-    %{$self->SUPER::hive_meta_table},
-    'hive_use_param_stack' => 1,
-  };
-}
-
-sub resource_classes {
-  my ($self) = @_;
-  return {
-    %{$self->SUPER::resource_classes},
-    '500Mb_job' => { LSF => '-q production -M  500' },
-    '1Gb_job'   => { LSF => '-q production -M 1000' },
-  };
+    my ($self) = @_;
+    return {
+        %{$self->SUPER::hive_meta_table},
+        'hive_use_param_stack' => 1,
+    };
 }
 
 sub pipeline_analyses {
-  my ($self) = @_;
+    my ($self) = @_;
 
-  my $pipeline_analyses = Bio::EnsEMBL::Compara::PipeConfig::Parts::UpdateMemberNamesDescriptions::pipeline_analyses_member_names_descriptions($self);
-  $pipeline_analyses->[0]->{'-input_ids'} = [ {
-    'compara_db' => $self->o('compara_db'),
-  } ];
-  return $pipeline_analyses;
+    my $pipeline_analyses = Bio::EnsEMBL::Compara::PipeConfig::Parts::UpdateMemberNamesDescriptions::pipeline_analyses_member_names_descriptions($self);
+    $pipeline_analyses->[0]->{'-input_ids'} = [ {
+        'compara_db' => $self->o('compara_db'),
+    } ];
+    return $pipeline_analyses;
 }
 
 1;


### PR DESCRIPTION
## Requirements

## Description

Removed obsolete `rc_name` from our calls to compara pipelines. 

## Use case

Compara processing pipelines. 

## Benefits

Get rid of 500Mb and 1Gb job queues, since 1Gb is now the default.

## Possible Drawbacks

Can't run integrated Compara pipeline if they keep their `rc_name` as such. (they already removed the 1Gb, remaining is the 500Mb)

## Testing

- [NO] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [NO] Have you run the entire test suite and no regression was detected?
- [YES] TravisCI passed on your branch

Dependencies
------------

Dependent on a PR opened on ensembl-compara side to remove 500Mb_job rc_name from their code. 
