### PR TITLE
Added taxon_id to add_compara step - used in json dumps.

### DIFF
--- a/modules/Bio/EnsEMBL/Production/DBSQL/BulkFetcher.pm
+++ b/modules/Bio/EnsEMBL/Production/DBSQL/BulkFetcher.pm
@@ -915,7 +915,7 @@ sub add_homologues {
     my $homologues = {};
     $compara_dba->dbc()->sql_helper()->execute_no_return(
         -SQL      => q/
-SELECT gm1.stable_id, gm2.stable_id, g2.name, h.description, r.stable_id
+SELECT gm1.stable_id, gm2.stable_id, g2.name, h.description, r.stable_id, g2.taxon_id
 FROM homology_member hm1
  INNER JOIN homology_member hm2 ON (hm1.homology_id = hm2.homology_id)
  INNER JOIN homology h ON (hm1.homology_id = h.homology_id)
@@ -933,6 +933,7 @@ WHERE (hm1.gene_member_id <> hm2.gene_member_id)
             push @{$homologues->{ $row->[0] }}, {
                 stable_id      => $row->[1],
                 genome         => $row->[2],
+                taxonomy_id    => $row[5],
                 orthology_type => $row->[3],
                 gene_tree_id   => $row->[4] };
             return;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/JSON/genes_schema.json
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/JSON/genes_schema.json
@@ -37,7 +37,8 @@
                     "description",
                     "genome",
                     "genome_display",
-                    "stable_id"
+                    "stable_id",
+                    "taxonomy_id"
                 ],
                 "type": "object",
                 "properties": {
@@ -51,6 +52,9 @@
                         "type": "string"
                     },
                     "genome": {
+                        "type": "string"
+                    },
+                    "taxonomy_id": {
                         "type": "string"
                     }
                 }


### PR DESCRIPTION
Following a request from a external user - adding taxonomy_id to json dumps. (and side effect added as well to other dumps)

## Description

Following request in EP-6696

## Use case

Added the taxonomy id of target homologues to BulfkFetcher. 

## Benefits

Added taxon_id for cross linking back to species. 

## Possible Drawbacks

Possible a on other dumps such as Search ==> THOAS loading, since update is made in BulkFetcher used there. 


## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
