### PR TITLE
Remove object_xref related to Interpro in ProteinFeatures

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProteinFeatures_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProteinFeatures_conf.pm
@@ -542,6 +542,12 @@ sub pipeline_analyses {
                                 'DELETE i.* FROM interpro i '.
                                   'LEFT OUTER JOIN protein_feature pf ON i.id = pf.hit_name '.
                                   'WHERE pf.hit_name IS NULL ',
+                                'DELETE oxr.* FROM object_xref oxr '.
+                                  'JOIN xref xr USING (xref_id) '.
+                                  'JOIN external_db edb USING (external_db_id) '.
+                                  'LEFT JOIN interpro i ON xr.dbprimary_acc = i.interpro_ac '.
+                                  'WHERE edb.db_name = "Interpro" '
+                                  'AND i.interpro_ac IS NULL ',
                                 'DELETE x.* FROM xref x '.
                                   'INNER JOIN external_db edb USING (external_db_id) '.
                                   'LEFT OUTER JOIN interpro i ON x.dbprimary_acc = i.interpro_ac '.

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProteinFeatures_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProteinFeatures_conf.pm
@@ -546,7 +546,7 @@ sub pipeline_analyses {
                                   'JOIN xref xr USING (xref_id) '.
                                   'JOIN external_db edb USING (external_db_id) '.
                                   'LEFT JOIN interpro i ON xr.dbprimary_acc = i.interpro_ac '.
-                                  'WHERE edb.db_name = "Interpro" '
+                                  'WHERE edb.db_name = "Interpro" '.
                                   'AND i.interpro_ac IS NULL ',
                                 'DELETE x.* FROM xref x '.
                                   'INNER JOIN external_db edb USING (external_db_id) '.


### PR DESCRIPTION
## Description

Before removing Interpro xref records, remove object_xref records
related to such xrefs; as some object_xrefs might have been previously
loaded alongside those xrefs and would end up "orphaned"

## Use case

Removes those object_xrefs related to xrefs that will be removed because related to Interpro records that will be replaced.

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [x] Have you run the entire test suite and no regression was detected?
- [x] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
