### PR TITLE
Xref TSV file missing with new line

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Xref_TSV.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Xref_TSV.pm
@@ -103,7 +103,7 @@ sub print_xrefs {
     my $external_db_list = join(", ", map { "'$_'" } @$external_dbs);
     $edb_filter = " AND e.db_name in ($external_db_list) ";
   }
-
+  $file->append("\n");   
   $self->print_xref_subset( $file, $self->go_xref_sql($edb_filter) );
   $self->print_xref_subset( $file, $self->gene_xref_sql($edb_filter) );
   $self->print_xref_subset( $file, $self->transcript_xref_sql($edb_filter) );
@@ -120,6 +120,7 @@ sub print_xref_subset {
 
   foreach my $result (@$results) {
     $file->append(join("\t", @$result));
+    $file->append("\n");
   }
 }
 


### PR DESCRIPTION
Xref TSV file dumped all the information in a single line this is identified for species Phacochoerus_africanus-GCA_016906955.1-2021_09-xref.tsv but it inpacted all the species for rapid release. 

This fix will append new new line to every row.