### PR TITLE
Fix/appris load

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/AttributeAnnotation/LoadAppris.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/AttributeAnnotation/LoadAppris.pm
@@ -92,7 +92,7 @@ sub run {
   }
 
   if ( $stable_id_in_file != $appris_transcripts ) {
-    throw("Not all transcripts found in database");
+    $self->throw("Not all transcripts found in database");
   }
   
   $dba->dbc->disconnect_if_idle();

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/LoadAppris_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/LoadAppris_conf.pm
@@ -41,7 +41,7 @@ sub default_options {
   return {
     %{ $self->SUPER::default_options() },
 
-    appris_url => 'http://apprisws.bioinfo.cnio.es/forEnsembl'
+    appris_url => "http://apprisws.bioinfo.cnio.es/forEnsembl/e".$self->o('ens_version')."/",
   };
 }
 


### PR DESCRIPTION
## Description

- Download only APPRIS files for the release that is currently being processed
- Prevent `wget` errors
- Fix typo when throwing an error in `LoadAppris.pm`

## Benefits

Faster pipeline, no more `wget` errors when files can't be dowloaded or are already present

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [x] Have you run the entire test suite and no regression was detected?
- [x] TravisCI passed on your branch
