### PR TITLE
set max retry to 0 for create index analysis

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/StableIDs_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/StableIDs_conf.pm
@@ -172,6 +172,7 @@ sub pipeline_analyses {
     },
     {
       -logic_name  => 'CreateIndexes',
+      -max_retry_count   => 0,
       -module      => 'Bio::EnsEMBL::Hive::RunnableDB::DbCmd',
       -parameters  => {
                         db_conn    => $self->o('db_url'),


### PR DESCRIPTION
Pipeline(ensembl stable id generator  )fails at analysis step create_index for  any unexpected reasons and it retries to run the job as default retry set to 3 which leads to fail with subsequent error Duplicate key name 'stable_id_db_type ' as index already created with this name.
Due to this retry behavior we are unable to catch original error so by setting retry value to zero we can debug the route case 