### PR TITLE
Added transcript attributes in unified dumps

### DIFF
--- a/modules/t/11-searchdumps_dumpgenes.t
+++ b/modules/t/11-searchdumps_dumpgenes.t
@@ -189,6 +189,19 @@ subtest "Checking protein_coding gene", sub {
             {
                 'analysis'            => 'ensembl_havana_transcript',
                 'start'               => 29011990,
+		'attrib' => {
+
+                     'synonym' => 'XXbac-BPG258E24.8-001',
+                     'name' => 'XXbac-BPG258E24.8-001',
+                     'remark' => 'MANE_select',
+                     'xref_id' => 'OTTHUMT00000076053',
+                     'gencode_basic' => 'GENCODE basic',
+                     'appris' => 'principal1',
+                     'TSL' => 'tslNA (assigned to previous version 1)',
+                     'ccds_transcript' => 'CCDS4656.1',
+                     'MANE_Select' => 'NM_030903.3',
+                     'is_canonical' =>  1,
+                },
                 'coord_system'        => {
                     'version' => 'GRCh38',
                     'name'    => 'chromosome'

--- a/modules/t/11-searchdumps_dumpgenes.t
+++ b/modules/t/11-searchdumps_dumpgenes.t
@@ -189,18 +189,13 @@ subtest "Checking protein_coding gene", sub {
             {
                 'analysis'            => 'ensembl_havana_transcript',
                 'start'               => 29011990,
-		'attrib' => {
+                'attrib' => {
 
                      'synonym' => 'XXbac-BPG258E24.8-001',
                      'name' => 'XXbac-BPG258E24.8-001',
-                     'remark' => 'MANE_select',
-                     'xref_id' => 'OTTHUMT00000076053',
-                     'gencode_basic' => 'GENCODE basic',
-                     'appris' => 'principal1',
-                     'TSL' => 'tslNA (assigned to previous version 1)',
-                     'ccds_transcript' => 'CCDS4656.1',
-                     'MANE_Select' => 'NM_030903.3',
-                     'is_canonical' =>  1,
+		     'author_email' => 'v@somewhere.com',
+		     'hidden_remark' => 'CCDS4656.1',
+		     'author' => 'Havana',
                 },
                 'coord_system'        => {
                     'version' => 'GRCh38',
@@ -1229,6 +1224,13 @@ subtest "Checking ncRNA gene", sub {
         'analysis_display'    => 'Havana',
         'coord_system'        => { 'name' => 'chromosome', 'version' => 'GRCh38' },
         'transcripts'         => [ {
+ 	    'attrib' => {
+
+                'name' => 'RP11-309M23.2-001',
+		'remark' => 'ribosomal protein L14 (RPL14) pseudogene',
+                'author_email' => 'v@somewhere.com',
+                'author' => 'Havana',
+            },
             'analysis'            => 'havana',
             'analysis_display'    => 'Havana',
             'strand'              => '-1',


### PR DESCRIPTION
Transcript Attributes added to unified dumps .

New attribute "attrib" added to each trancript 
example:
 "attrib": { 'TSL': 'tslNA', 'appris': 'principal1', 'name': 'AC008175.3-001', 'xref_id': 'OTTHUMT00000102233', 'MANE_Select': 'NM_004676.2', 'is_canonical': 1, ........... }  
