### PR TITLE
Fix default branch retrieval with usage of `ensembl-git-tools`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ jobs:
             - graphviz
             - emboss
       before_install:
-        - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-git-tools.git
+        - git clone --depth 1 https://github.com/Ensembl/ensembl-git-tools.git
         - export PATH=$PATH:$PWD/ensembl-git-tools/bin
         - export ENSEMBL_BRANCH=master
         - export SECONDARY_BRANCH=main

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,61 +1,63 @@
 jobs:
   include:
-  - language: perl
-    services:
-      - mysql
-    perl:
-      - '5.14'
-    env:
-      - COVERALLS=true  DB=mysql
-    sudo: false
-    addons:
-      apt:
-        packages:
-          - unzip
-          - sendmail
-          - graphviz
-          - emboss
-    before_install:
-    - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH"
-    - export ENSEMBL_BRANCH=master
-    - export METADATA_BRANCH=main
-    - if [[ $TRAVIS_BRANCH =~ ^release\/[0-9]+$ ]]; then export ENSEMBL_BRANCH=$TRAVIS_BRANCH; export METADATA_BRANCH=$TRAVIS_BRANCH; fi
-    - echo "ENSEMBL_BRANCH=$ENSEMBL_BRANCH"
-    - echo "METADATA_BRANCH=$METADATA_BRANCH"
-    - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-test.git
-    - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl.git
-    - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-hive.git
-    - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-compara.git
-    - git clone --branch main --depth 1 https://github.com/Ensembl/ensembl-datacheck.git
-    - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-variation.git
-    - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-orm.git
-    - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-taxonomy.git
-    - git clone --branch $METADATA_BRANCH --depth 1 https://github.com/Ensembl/ensembl-metadata.git
-    - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-funcgen.git
-    - git clone --branch 1.9 --depth 1 https://github.com/samtools/htslib.git
-    - git clone --branch release-1-6-924 --depth 1 https://github.com/bioperl/bioperl-live.git
-    - cd htslib
-    - make
-    - export HTSLIB_DIR=$(pwd -P)
-    - cd ..
-    install:
-    - cpanm --sudo -v --installdeps --with-recommends --notest --cpanfile ensembl/cpanfile .
-    - cpanm --sudo -v --installdeps --notest --cpanfile ensembl-hive/cpanfile .
-    - cpanm --sudo -v --installdeps --notest --cpanfile ensembl-datacheck/cpanfile .
-    - export PERL5LIB=$PERL5LIB:$PWD/bioperl-live
-    - cpanm --sudo -v --installdeps --notest .
-    - cpanm --sudo -n Devel::Cover::Report::Coveralls
-    - cp travisci/MultiTestDB.conf.travisci  modules/t/MultiTestDB.conf
-    - mysql -u root -h localhost -e 'GRANT ALL PRIVILEGES ON *.* TO "travis"@"%"'
-    script: ./travisci/harness.sh
+    - language: perl
+      services:
+        - mysql
+      perl:
+        - '5.14'
+      env:
+        - COVERALLS=true  DB=mysql
+      sudo: false
+      addons:
+        apt:
+          packages:
+            - unzip
+            - sendmail
+            - graphviz
+            - emboss
+      before_install:
+        - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-git-tools.git
+        - export PATH=$PATH:$PWD/ensembl-git-tools/bin
+        - export ENSEMBL_BRANCH=master
+        - export SECONDARY_BRANCH=main
+        - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH"
+        - if [[ $TRAVIS_BRANCH =~ ^release\/[0-9]+$ ]]; then export ENSEMBL_BRANCH=$TRAVIS_BRANCH; export SECONDARY_BRANCH=$TRAVIS_BRANCH; fi
+        - echo "ENSEMBL_BRANCH=$ENSEMBL_BRANCH"
+        - echo "SECONDARY_BRANCH=$SECONDARY_BRANCH"
+        - git-ensembl --clone --branch $ENSEMBL_BRANCH --secondary_branch $SECONDARY_BRANCH --depth 1 ensembl-test
+        - git-ensembl --clone --branch $ENSEMBL_BRANCH --secondary_branch $SECONDARY_BRANCH --depth 1 ensembl
+        - git-ensembl --clone --branch $ENSEMBL_BRANCH --secondary_branch $SECONDARY_BRANCH --depth 1 ensembl-compara
+        - git-ensembl --clone --branch $ENSEMBL_BRANCH --secondary_branch $SECONDARY_BRANCH --depth 1 ensembl-datacheck
+        - git-ensembl --clone --branch $ENSEMBL_BRANCH --secondary_branch $SECONDARY_BRANCH --depth 1 ensembl-variation
+        - git-ensembl --clone --branch $ENSEMBL_BRANCH --secondary_branch $SECONDARY_BRANCH --depth 1 ensembl-metadata
+        - git-ensembl --clone --branch $ENSEMBL_BRANCH --secondary_branch $SECONDARY_BRANCH --depth 1 ensembl-funcgen
+        - git-ensembl --clone --branch master --secondary_branch main --depth 1 ensembl-hive
+        - git-ensembl --clone --branch master --secondary_branch main --depth 1 ensembl-orm
+        - git-ensembl --clone --branch master --secondary_branch main --depth 1 ensembl-taxonomy
+        - git clone --branch 1.9 --depth 1 https://github.com/samtools/htslib.git
+        - git clone --branch release-1-6-924 --depth 1 https://github.com/bioperl/bioperl-live.git
+        - cd htslib
+        - make
+        - export HTSLIB_DIR=$(pwd -P)
+        - cd ..
+      install:
+        - cpanm --sudo -v --installdeps --with-recommends --notest --cpanfile ensembl/cpanfile .
+        - cpanm --sudo -v --installdeps --notest --cpanfile ensembl-hive/cpanfile .
+        - cpanm --sudo -v --installdeps --notest --cpanfile ensembl-datacheck/cpanfile .
+        - export PERL5LIB=$PERL5LIB:$PWD/bioperl-live
+        - cpanm --sudo -v --installdeps --notest .
+        - cpanm --sudo -n Devel::Cover::Report::Coveralls
+        - cp travisci/MultiTestDB.conf.travisci  modules/t/MultiTestDB.conf
+        - mysql -u root -h localhost -e 'GRANT ALL PRIVILEGES ON *.* TO "travis"@"%"'
+      script: ./travisci/harness.sh
 
-  - language: python
-    python: 3.7
-    install:
-    - pip install -r requirements-test.txt
-    - pip install -e .
-    script:
-    - pytest src/python/test
+    - language: python
+      python: 3.7
+      install:
+        - pip install -r requirements-test.txt
+        - pip install -e .
+      script:
+        - pytest src/python/test
 
 notifications:
   email:


### PR DESCRIPTION
## Description

Try to fix for good potential issues with master/main branches odd configuration across  ensembl fetched repo. 

## Use case
  Don't bother with `master` or `main` being present as sources branches when building, by using `ensembl-git-tools` git commands with fall back branch. 

## Benefits

No need to specify default branch per repo and failed build when remote project doesn't have a master any more. 

## Possible Drawbacks

None

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [x] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
