### PR TITLE
Added defaut parameter to Compara GeneNameDescProjection_conf.pm

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GeneNameDescProjection_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GeneNameDescProjection_conf.pm
@@ -55,7 +55,7 @@ sub default_options {
     logic_name => 'xref_projection',
 
     store_projections => 1,
-    'exclude_species'  => [],
+    exclude_species  => [],
 
     backup_tables => [
       'analysis',

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GeneNameDescProjection_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GeneNameDescProjection_conf.pm
@@ -55,6 +55,7 @@ sub default_options {
     logic_name => 'xref_projection',
 
     store_projections => 1,
+    'exclude_species'  => [],
 
     backup_tables => [
       'analysis',

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GeneNameDescProjection_plants_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GeneNameDescProjection_plants_conf.pm
@@ -40,7 +40,7 @@ sub pipeline_wide_parameters {
     my ($self) = @_;
     return {
         %{$self->SUPER::pipeline_wide_parameters},
-        'exclude_species' => self->o('antispecies')
+        'exclude_species' => $self->o('antispecies')
     };
 }
 


### PR DESCRIPTION
## Description

Add default parameter added by compara to our production configuration
https://github.com/Ensembl/ensembl-compara/commit/d4e1fb4e15b312db95d1d7c43035d89e3025894c

Fixed typo in following updated from initial default values for plants (missing $ in self!)

## Use case

Gene Name Projection Ran by production

## Benefits

Production can run our release pipelines.

## Possible Drawbacks

None, but we need a SOP about Compara pipeline updates. 

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
