### PR TITLE
Fix package name for renamed parsers

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/Parser/RefSeqDatabaseParser.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/Parser/RefSeqDatabaseParser.pm
@@ -19,7 +19,7 @@ limitations under the License.
 
 # Parse RefSeq GPFF files to create xrefs.
 
-package Bio::EnsEMBL::Production::Pipeline::Xrefs::Parser::RefSeqGPFFParser;
+package Bio::EnsEMBL::Production::Pipeline::Xrefs::Parser::RefSeqDatabaseParser;
 
 use strict;
 use warnings;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/Parser/UniProtDatabaseParser.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/Parser/UniProtDatabaseParser.pm
@@ -26,7 +26,7 @@ limitations under the License.
 
 
 
-package Bio::EnsEMBL::Production::Pipeline::Xrefs::Parser::UniProtParser;
+package Bio::EnsEMBL::Production::Pipeline::Xrefs::Parser::UniProtDatabaseParser;
 
 use strict;
 use warnings;


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Fixing package names for new xref parsers.

## Use case

The UniProt and RefSeq parsers used for the new pre-parsing step of the xref pipeline were renamed to include "Database" so as not to be confused with the old parsers and to have some separation between the pre-parsing step and the parsing step. At renaming, however, the package name wasn't updated to reflect the new name. This PR fixes that.

## Benefits

New xref download fails without this change.

## Possible Drawbacks

None

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
