### PR TITLE
Use `dm` queue for goa dumps.

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpSpeciesForGOA_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpSpeciesForGOA_conf.pm
@@ -95,7 +95,7 @@ sub pipeline_analyses {
                 output_dir => $self->o('output_dir'),
                 release    => $self->o('release')
             },
-            -rc_name    => 'default',
+            -rc_name    => 'dm',
             -flow_into  => [ 'CreateReleaseFile' ],
         },
         {
@@ -107,7 +107,7 @@ sub pipeline_analyses {
                 release        => $self->o('release'),
                 release_file   => $self->o('release_file'),
             },
-            -rc_name    => 'default'
+            -rc_name    => 'dm'
         }
         #TODO include wait and load GPAD from HERE
     ];

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GPAD_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GPAD_conf.pm
@@ -28,277 +28,278 @@ use Bio::EnsEMBL::Hive::Version 2.5;
 use File::Spec::Functions qw(catdir);
 
 sub default_options {
-  my ($self) = @_;
+    my ($self) = @_;
 
-  return {
-    %{ $self->SUPER::default_options() },
+    return {
+        %{$self->SUPER::default_options()},
 
-    gpad_directory => '/nfs/ftp/public/contrib/goa/ensembl_projections',
-    gpad_dirname   => undef,
+        gpad_directory     => '/nfs/ftp/public/contrib/goa/ensembl_projections',
+        gpad_dirname       => undef,
 
-    species      => [],
-    antispecies  => [qw/mus_musculus_129s1svimj mus_musculus_aj mus_musculus_akrj mus_musculus_balbcj mus_musculus_c3hhej mus_musculus_c57bl6nj mus_musculus_casteij mus_musculus_cbaj mus_musculus_dba2j mus_musculus_fvbnj mus_musculus_lpj mus_musculus_nodshiltj mus_musculus_nzohlltj mus_musculus_pwkphj mus_musculus_wsbeij/],
-    division     => [],
-    run_all      => 0,
-    meta_filters => {},
+        species            => [],
+        antispecies        => [ qw/mus_musculus_129s1svimj mus_musculus_aj mus_musculus_akrj mus_musculus_balbcj mus_musculus_c3hhej mus_musculus_c57bl6nj mus_musculus_casteij mus_musculus_cbaj mus_musculus_dba2j mus_musculus_fvbnj mus_musculus_lpj mus_musculus_nodshiltj mus_musculus_nzohlltj mus_musculus_pwkphj mus_musculus_wsbeij/ ],
+        division           => [],
+        run_all            => 0,
+        meta_filters       => {},
 
-    # Remove existing GO annotations and associated analysis
-    delete_existing => 1,
+        # Remove existing GO annotations and associated analysis
+        delete_existing    => 1,
 
-    # Analysis information
-    logic_name        => 'goa_import',
-    db                => 'GO',
-    program           => 'goa_import',
-    production_lookup => 1,
-    linked_tables     => ['object_xref'],
+        # Analysis information
+        logic_name         => 'goa_import',
+        db                 => 'GO',
+        program            => 'goa_import',
+        production_lookup  => 1,
+        linked_tables      => [ 'object_xref' ],
 
-    # Datachecks
-    history_file   => undef,
-    config_file    => undef,
-    old_server_uri => undef,
-    advisory_dc_output => $self->o('pipeline_dir') . '/advisory_dc_output',
+        # Datachecks
+        history_file       => undef,
+        config_file        => undef,
+        old_server_uri     => undef,
+        advisory_dc_output => $self->o('pipeline_dir') . '/advisory_dc_output',
 
-    #filewatcher
-    file_name => 'annotations_ensembl-{}.gpa',
-    directory => $self->o('gpad_directory') . '/' . $self->o('gpad_dirname'),
-    watch_until => 48,
-    wait => 0,     
+        #filewatcher
+        file_name          => 'annotations_ensembl-{}.gpa',
+        directory          => $self->o('gpad_directory') . '/' . $self->o('gpad_dirname'),
+        watch_until        => 48,
+        wait               => 0,
 
-  };
+    };
 }
 
 sub pipeline_create_commands {
-  my ($self) = @_;
+    my ($self) = @_;
 
-  return [
-    @{$self->SUPER::pipeline_create_commands},
-    'mkdir -p '.$self->o('pipeline_dir'),
-  ];
+    return [
+        @{$self->SUPER::pipeline_create_commands},
+        'mkdir -p ' . $self->o('pipeline_dir'),
+    ];
 }
 
 # Ensures output parameters gets propagated implicitly
 sub hive_meta_table {
-  my ($self) = @_;
+    my ($self) = @_;
 
-  return {
-    %{$self->SUPER::hive_meta_table},
-    'hive_use_param_stack'  => 1,
-  };
+    return {
+        %{$self->SUPER::hive_meta_table},
+        'hive_use_param_stack' => 1,
+    };
 }
 
 sub pipeline_analyses {
-  my ($self) = @_;
+    my ($self) = @_;
 
-  return [
-    {
-        -logic_name      => 'FileWatcher',
-        -module          => 'ensembl.production.hive.FileWatcher',
-        -max_retry_count => 0,
-        -language        => 'python3',
-        -parameters      => {
-                              directory => $self->o('directory'),
-                              file_name => $self->o('file_name') ,
-			      species => $self->o('species'),
-                              watch_until => $self->o('watch_until'),
-                              wait => $self->o('wait'),
-                            },
-        -flow_into        => { 1 => ['AdvisoryDCReportInit'] },
-        -input_ids         => [ {} ],
-    },
-    {
-      -logic_name        => 'AdvisoryDCReportInit',
-      -module           => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
-      -flow_into        => {
-              '1->A' => ['DbFactory'],
-              'A->1' => ['DataCheckResults'],
-      }
-    },	  
-    {
-       -logic_name       => 'DataCheckResults',
-       -module           => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
-       -flow_into        => {
-               '1' => ['ConvertTapToJson'],
-       },
-    },
-    {
-      -logic_name       => 'ConvertTapToJson',
-      -module           => 'Bio::EnsEMBL::DataCheck::Pipeline::ConvertTapToJson',
-      -analysis_capacity => 10,
-      -max_retry_count   => 0,
-      -parameters        => {
-        tap => $self->o('advisory_dc_output'),
-        output_dir => $self->o('advisory_dc_output'),
-      },	
-      -flow_into => ['AdvisoryDataCheckReport'],
-    },
-    {
-      -logic_name        => 'AdvisoryDataCheckReport',
-      -module            => 'Bio::EnsEMBL::DataCheck::Pipeline::DataCheckMailSummary',
-      -rc_name           => 'default',
-      -parameters =>{
-         pipeline_name => $self->o('pipeline_name'),
-         email => $self->o('email'),
-	 output_dir => $self->o('advisory_dc_output'),
-      }
-    },
-    {
-      -logic_name        => 'DbFactory',
-      -module            => 'Bio::EnsEMBL::Production::Pipeline::Common::DbFactory',
-      -max_retry_count   => 1,
-      -parameters        => {
-                              species         => $self->o('species'),
-                              antispecies     => $self->o('antispecies'),
-                              division        => $self->o('division'),
-                              run_all         => $self->o('run_all'),
-                              meta_filters    => $self->o('meta_filters'),
-                              chromosome_flow => 0,
-                              regulation_flow => 0,
-                              variation_flow  => 0,
-                            },
-      -flow_into         => {
-                              '2->A' => ['BackupTables'],
-                              'A->2' => ['LoadAndDatacheck'],
-                            }
-    },
-    {
-      -logic_name        => 'BackupTables',
-      -module            => 'Bio::EnsEMBL::Production::Pipeline::Common::DatabaseDumper',
-      -max_retry_count   => 1,
-      -analysis_capacity => 20,
-      -parameters        => {
-                              table_list  => [
-                                'analysis',
-                                'analysis_description',
-                                'dependent_xref',
-                                'object_xref',
-                                'ontology_xref',
-                              ],
-                              output_file => catdir($self->o('pipeline_dir'), '#dbname#', 'pre_pipeline_bkp.sql.gz'),
-                            },
-      -flow_into         => {
-                              '1->A' => ['AnalysisSetup'],
-                              'A->1' => ['RemoveOrphans'],
-                            }
-    },
-    {
-      -logic_name        => 'AnalysisSetup',
-      -module            => 'Bio::EnsEMBL::Production::Pipeline::Common::AnalysisSetup',
-      -max_retry_count   => 0,
-      -analysis_capacity => 20,
-      -parameters        => {
-                              db_backup_required => 0,
-                              delete_existing    => $self->o('delete_existing'),
-                              production_lookup  => $self->o('production_lookup'),
-                              logic_name         => $self->o('logic_name'),
-                              db                 => $self->o('db'),
-                              program            => $self->o('program'),
-                              linked_tables      => $self->o('linked_tables')
-                            }
-    },
-    {
-      -logic_name        => 'RemoveOrphans',
-      -module            => 'Bio::EnsEMBL::Production::Pipeline::Common::SqlCmd',
-      -max_retry_count   => 0,
-      -analysis_capacity => 20,
-      -parameters        => {
-                              sql => [
-                                'DELETE dx.* FROM '.
-                                  'dependent_xref dx LEFT OUTER JOIN '.
-                                  'object_xref ox USING (object_xref_id) '.
-                                  'WHERE ox.object_xref_id IS NULL',
-                                'DELETE onx.* FROM '.
-                                  'ontology_xref onx LEFT OUTER JOIN '.
-                                  'object_xref ox USING (object_xref_id) '.
-                                  'WHERE ox.object_xref_id IS NULL',
-                              ]
-                            },
-    },
-    {
-       -logic_name       => 'LoadAndDatacheck',
-       -module           => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
-       -flow_into        => {
-                              '1->A' => ['SpeciesFactory'],
-                              'A->1' => ['RunXrefDatacheck'],
-                            },
-    },
-    {
-      -logic_name        => 'SpeciesFactory',
-      -module            => 'Bio::EnsEMBL::Production::Pipeline::Common::DbAwareSpeciesFactory',
-      -max_retry_count   => 1,
-      -parameters        => {
-                              chromosome_flow    => 0,
-                              otherfeatures_flow => 0,
-                              regulation_flow    => 0,
-                              variation_flow     => 0,
-                            },
-      -flow_into         => {
-                              '2' => ['FindFile'],
-                            }
-    },
-    {
-      -logic_name        => 'FindFile',
-      -module            => 'Bio::EnsEMBL::Production::Pipeline::GPAD::FindFile',
-      -analysis_capacity => 30,
-      -parameters        => {
-                              gpad_directory => $self->o('gpad_directory'),
-                              gpad_dirname   => $self->o('gpad_dirname'),
-                            },
-      -flow_into         => {
-                              '2' => ['LoadFile'],
-                            },
-      -rc_name           => 'dm',
-    },
-    {
-      -logic_name        => 'LoadFile',
-      -module            => 'Bio::EnsEMBL::Production::Pipeline::GPAD::LoadFile',
-      -analysis_capacity => 20,
-      -parameters        => {
-                              logic_name => $self->o('logic_name')
-                            },
-      -rc_name           => 'dm',
-    },
-    {
-       -logic_name       => 'RunXrefDatacheck',
-       -module           => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
-       -flow_into        => {
-                              '1->A' => ['RunXrefCriticalDatacheck'],
-                              'A->1' => ['RunXrefAdvisoryDatacheck']
-                            },
-    },
-    {
-      -logic_name        => 'RunXrefCriticalDatacheck',
-      -module            => 'Bio::EnsEMBL::DataCheck::Pipeline::RunDataChecks',
-      -max_retry_count   => 1,
-      -analysis_capacity => 10,
-      -parameters        => {
-                              datacheck_names  => ['ForeignKeys'],
-                              datacheck_groups => ['xref'],
-                              datacheck_types  => ['critical'],
-                              registry_file    => $self->o('registry'),
-                              config_file      => $self->o('config_file'),
-                              history_file     => $self->o('history_file'),
-                              old_server_uri   => $self->o('old_server_uri'),
-                              failures_fatal   => 1,
-                            },
-    },
-    {
-      -logic_name        => 'RunXrefAdvisoryDatacheck',
-      -module            => 'Bio::EnsEMBL::DataCheck::Pipeline::RunDataChecks',
-      -max_retry_count   => 1,
-      -analysis_capacity => 10,
-      -batch_size        => 10,
-      -parameters        => {
-                              datacheck_groups => ['xref_go_projection'],
-                              datacheck_types  => ['advisory'],
-                              registry_file    => $self->o('registry'),
-                              config_file      => $self->o('config_file'),
-                              history_file     => $self->o('history_file'),
-                              old_server_uri   => $self->o('old_server_uri'),
-			      output_dir       => $self->o('advisory_dc_output'),
-                              failures_fatal   => 0,
-                            },
-    },
-  ];
+    return [
+        {
+            -logic_name      => 'FileWatcher',
+            -module          => 'ensembl.production.hive.FileWatcher',
+            -max_retry_count => 0,
+            -language        => 'python3',
+            -parameters      => {
+                directory   => $self->o('directory'),
+                file_name   => $self->o('file_name'),
+                species     => $self->o('species'),
+                watch_until => $self->o('watch_until'),
+                wait        => $self->o('wait'),
+            },
+            -flow_into       => { 1 => [ 'AdvisoryDCReportInit' ] },
+            -input_ids       => [ {} ],
+            -rc_name         => 'dm'
+        },
+        {
+            -logic_name => 'AdvisoryDCReportInit',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+            -flow_into  => {
+                '1->A' => [ 'DbFactory' ],
+                'A->1' => [ 'DataCheckResults' ],
+            }
+        },
+        {
+            -logic_name => 'DataCheckResults',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+            -flow_into  => {
+                '1' => [ 'ConvertTapToJson' ],
+            },
+        },
+        {
+            -logic_name        => 'ConvertTapToJson',
+            -module            => 'Bio::EnsEMBL::DataCheck::Pipeline::ConvertTapToJson',
+            -analysis_capacity => 10,
+            -max_retry_count   => 0,
+            -parameters        => {
+                tap        => $self->o('advisory_dc_output'),
+                output_dir => $self->o('advisory_dc_output'),
+            },
+            -flow_into         => [ 'AdvisoryDataCheckReport' ],
+        },
+        {
+            -logic_name => 'AdvisoryDataCheckReport',
+            -module     => 'Bio::EnsEMBL::DataCheck::Pipeline::DataCheckMailSummary',
+            -rc_name    => 'default',
+            -parameters => {
+                pipeline_name => $self->o('pipeline_name'),
+                email         => $self->o('email'),
+                output_dir    => $self->o('advisory_dc_output'),
+            }
+        },
+        {
+            -logic_name      => 'DbFactory',
+            -module          => 'Bio::EnsEMBL::Production::Pipeline::Common::DbFactory',
+            -max_retry_count => 1,
+            -parameters      => {
+                species         => $self->o('species'),
+                antispecies     => $self->o('antispecies'),
+                division        => $self->o('division'),
+                run_all         => $self->o('run_all'),
+                meta_filters    => $self->o('meta_filters'),
+                chromosome_flow => 0,
+                regulation_flow => 0,
+                variation_flow  => 0,
+            },
+            -flow_into       => {
+                '2->A' => [ 'BackupTables' ],
+                'A->2' => [ 'LoadAndDatacheck' ],
+            }
+        },
+        {
+            -logic_name        => 'BackupTables',
+            -module            => 'Bio::EnsEMBL::Production::Pipeline::Common::DatabaseDumper',
+            -max_retry_count   => 1,
+            -analysis_capacity => 20,
+            -parameters        => {
+                table_list  => [
+                    'analysis',
+                    'analysis_description',
+                    'dependent_xref',
+                    'object_xref',
+                    'ontology_xref',
+                ],
+                output_file => catdir($self->o('pipeline_dir'), '#dbname#', 'pre_pipeline_bkp.sql.gz'),
+            },
+            -flow_into         => {
+                '1->A' => [ 'AnalysisSetup' ],
+                'A->1' => [ 'RemoveOrphans' ],
+            }
+        },
+        {
+            -logic_name        => 'AnalysisSetup',
+            -module            => 'Bio::EnsEMBL::Production::Pipeline::Common::AnalysisSetup',
+            -max_retry_count   => 0,
+            -analysis_capacity => 20,
+            -parameters        => {
+                db_backup_required => 0,
+                delete_existing    => $self->o('delete_existing'),
+                production_lookup  => $self->o('production_lookup'),
+                logic_name         => $self->o('logic_name'),
+                db                 => $self->o('db'),
+                program            => $self->o('program'),
+                linked_tables      => $self->o('linked_tables')
+            }
+        },
+        {
+            -logic_name        => 'RemoveOrphans',
+            -module            => 'Bio::EnsEMBL::Production::Pipeline::Common::SqlCmd',
+            -max_retry_count   => 0,
+            -analysis_capacity => 20,
+            -parameters        => {
+                sql => [
+                    'DELETE dx.* FROM ' .
+                        'dependent_xref dx LEFT OUTER JOIN ' .
+                        'object_xref ox USING (object_xref_id) ' .
+                        'WHERE ox.object_xref_id IS NULL',
+                    'DELETE onx.* FROM ' .
+                        'ontology_xref onx LEFT OUTER JOIN ' .
+                        'object_xref ox USING (object_xref_id) ' .
+                        'WHERE ox.object_xref_id IS NULL',
+                ]
+            },
+        },
+        {
+            -logic_name => 'LoadAndDatacheck',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+            -flow_into  => {
+                '1->A' => [ 'SpeciesFactory' ],
+                'A->1' => [ 'RunXrefDatacheck' ],
+            },
+        },
+        {
+            -logic_name      => 'SpeciesFactory',
+            -module          => 'Bio::EnsEMBL::Production::Pipeline::Common::DbAwareSpeciesFactory',
+            -max_retry_count => 1,
+            -parameters      => {
+                chromosome_flow    => 0,
+                otherfeatures_flow => 0,
+                regulation_flow    => 0,
+                variation_flow     => 0,
+            },
+            -flow_into       => {
+                '2' => [ 'FindFile' ],
+            }
+        },
+        {
+            -logic_name        => 'FindFile',
+            -module            => 'Bio::EnsEMBL::Production::Pipeline::GPAD::FindFile',
+            -analysis_capacity => 30,
+            -parameters        => {
+                gpad_directory => $self->o('gpad_directory'),
+                gpad_dirname   => $self->o('gpad_dirname'),
+            },
+            -flow_into         => {
+                '2' => [ 'LoadFile' ],
+            },
+            -rc_name           => 'default',
+        },
+        {
+            -logic_name        => 'LoadFile',
+            -module            => 'Bio::EnsEMBL::Production::Pipeline::GPAD::LoadFile',
+            -analysis_capacity => 20,
+            -parameters        => {
+                logic_name => $self->o('logic_name')
+            },
+            -rc_name           => 'default',
+        },
+        {
+            -logic_name => 'RunXrefDatacheck',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+            -flow_into  => {
+                '1->A' => [ 'RunXrefCriticalDatacheck' ],
+                'A->1' => [ 'RunXrefAdvisoryDatacheck' ]
+            },
+        },
+        {
+            -logic_name        => 'RunXrefCriticalDatacheck',
+            -module            => 'Bio::EnsEMBL::DataCheck::Pipeline::RunDataChecks',
+            -max_retry_count   => 1,
+            -analysis_capacity => 10,
+            -parameters        => {
+                datacheck_names  => [ 'ForeignKeys' ],
+                datacheck_groups => [ 'xref' ],
+                datacheck_types  => [ 'critical' ],
+                registry_file    => $self->o('registry'),
+                config_file      => $self->o('config_file'),
+                history_file     => $self->o('history_file'),
+                old_server_uri   => $self->o('old_server_uri'),
+                failures_fatal   => 1,
+            },
+        },
+        {
+            -logic_name        => 'RunXrefAdvisoryDatacheck',
+            -module            => 'Bio::EnsEMBL::DataCheck::Pipeline::RunDataChecks',
+            -max_retry_count   => 1,
+            -analysis_capacity => 10,
+            -batch_size        => 10,
+            -parameters        => {
+                datacheck_groups => [ 'xref_go_projection' ],
+                datacheck_types  => [ 'advisory' ],
+                registry_file    => $self->o('registry'),
+                config_file      => $self->o('config_file'),
+                history_file     => $self->o('history_file'),
+                old_server_uri   => $self->o('old_server_uri'),
+                output_dir       => $self->o('advisory_dc_output'),
+                failures_fatal   => 0,
+            },
+        },
+    ];
 }
 
 1;


### PR DESCRIPTION
Remove `dm` queue for loading (file are supposed to be synced to /nfs before proceeding. See SOP)

## Description

Dm queues are to be used for GOA dumps files until we add the required steps in pipeline

## Use case

Path to dump doesn't exists when ran from a standard production node. 
For GOA load part, since we are supposed to move files onto our nfs before run, (because of the limitation to 10 jobs per user on dm), no need to force the load from dm.

## Benefits

Files are dumped in the right place. 

## Possible Drawbacks

Nonw

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
