### PR TITLE
EP-7663: Fix GeneNameDescProjection_plants_conf

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GeneNameDescProjection_plants_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GeneNameDescProjection_plants_conf.pm
@@ -36,14 +36,6 @@ use strict;
 use warnings;
 use base ('Bio::EnsEMBL::Production::Pipeline::PipeConfig::GeneNameDescProjection_conf');
 
-sub pipeline_wide_parameters {
-    my ($self) = @_;
-    return {
-        %{$self->SUPER::pipeline_wide_parameters},
-        'exclude_species' => $self->o('antispecies')
-    };
-}
-
 
 sub default_options {
     my ($self) = @_;
@@ -54,7 +46,7 @@ sub default_options {
         compara_division => 'plants',
 
         gene_name_source => [ 'TAIR_SYMBOL', 'UniProtKB/Swiss-Prot', 'Uniprot_gn' ],
-        antispecies      => [ 'ciona_savignyi', 'homo_sapiens', 'caenorhabditis_elegans', 'drosophila_melanogaster', 'saccharomyces_cerevisiae' ],
+        exclude_species  => [ 'ciona_savignyi', 'homo_sapiens', 'caenorhabditis_elegans', 'drosophila_melanogaster', 'saccharomyces_cerevisiae' ],
         gd_config        => [
             {
                 source      => 'arabidopsis_thaliana',

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GeneNameDescProjection_plants_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GeneNameDescProjection_plants_conf.pm
@@ -46,7 +46,8 @@ sub default_options {
         compara_division => 'plants',
 
         gene_name_source => [ 'TAIR_SYMBOL', 'UniProtKB/Swiss-Prot', 'Uniprot_gn' ],
-        exclude_species  => [ 'ciona_savignyi', 'homo_sapiens', 'caenorhabditis_elegans', 'drosophila_melanogaster', 'saccharomyces_cerevisiae' ],
+        antispecies      => [ 'ciona_savignyi', 'homo_sapiens', 'caenorhabditis_elegans', 'drosophila_melanogaster', 'saccharomyces_cerevisiae' ],
+        exclude_species  => $self->o('antispecies'),  # Used by Bio::EnsEMBL::Compara::RunnableDB::GenomeDBFactory
         gd_config        => [
             {
                 source      => 'arabidopsis_thaliana',


### PR DESCRIPTION
Fix `GeneNameDescProjection_plants_conf`, set `exclude_species` in `default_options` instead of `pipeline_wide_parameters`.

Additional species can be excluded when istanciating the pipeline by specifying `-antispecies` param for `init_pipeline.pm`.

Note that `exclude_species` is used by `Bio::EnsEMBL::Compara::RunnableDB::GenomeDBFactory` only.