### PR TITLE
Fix backwards compatibility issues and general bugs

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/XrefDownload_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/XrefDownload_conf.pm
@@ -68,7 +68,9 @@ sub pipeline_analyses {
         source_dir    => $self->o('source_dir'),
         source_url    => $self->o('source_url'),
         reuse_db      => $self->o('reuse_db'),
-        skip_download => $self->o('skip_download')
+        skip_download => $self->o('skip_download'),
+        skip_preparse => $self->o('skip_preparse')
+
       },
       -flow_into  => {
         '2->A' => 'download_source',
@@ -200,8 +202,10 @@ sub pipeline_analyses {
       -parameters => {
         email   => $self->o('email'),
         subject => 'Xref Download finished',
-	base_path => $self->o('base_path'),
-        clean_files => $self->o('clean_files')
+        base_path => $self->o('base_path'),
+        clean_files => $self->o('clean_files'),
+        source_xref => $self->o('source_xref'),
+        skip_preparse => $self->o('skip_preparse')
       },
       -wait_for => 'pre_parse_source_tertiary',
       -rc_name    => 'small'

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/XrefProcess_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/XrefProcess_conf.pm
@@ -364,4 +364,13 @@ sub pipeline_wide_parameters {
   };
 }
 
+sub pipeline_create_commands {
+  my ($self) = @_;
+
+  return [
+    @{$self->SUPER::pipeline_create_commands},
+    $self->db_cmd('CREATE TABLE updated_species (species_name varchar(255) NOT NULL)')
+  ];
+}
+
 1;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/ParseSource.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/ParseSource.pm
@@ -34,14 +34,19 @@ sub run {
   my $file_name    = $self->param_required('file_name');
   my $source_id    = $self->param_required('source');
   my $xref_url     = $self->param_required('xref_url');
-  my $source_xref  = $self->param_required('source_xref');
+  my $source_xref  = $self->param('source_xref');
   my $db           = $self->param('db');
   my $release_file = $self->param('release_file');
 
   $self->dbc()->disconnect_if_idle() if defined $self->dbc();
 
   my ($user, $pass, $host, $port, $dbname) = $self->parse_url($xref_url);
-  my ($source_user, $source_pass, $source_host, $source_port, $source_dbname) = $self->parse_url($source_xref);
+  
+  my ($source_user, $source_pass, $source_host, $source_port, $source_dbname, $source_dbi);
+  if ($source_xref) {
+    ($source_user, $source_pass, $source_host, $source_port, $source_dbname) = $self->parse_url($source_xref);
+    $source_dbi = $self->get_dbi($source_host, $source_port, $source_user, $source_pass, $source_dbname);
+  }
 
   my $xref_dbc = XrefParser::Database->new({
             host    => $host,
@@ -52,7 +57,6 @@ sub run {
   $xref_dbc->disconnect_if_idle();
 
   my $dbi = $self->get_dbi($host, $port, $user, $pass, $dbname);
-  my $source_dbi = $self->get_dbi($source_host, $source_port, $source_user, $source_pass, $source_dbname) if defined $source_dbname;
 
   my @files;
   push @files, $file_name;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/ScheduleDownload.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/ScheduleDownload.pm
@@ -30,6 +30,11 @@ sub run {
   my $source_dir       = $self->param_required('source_dir');
   my $skip_download    = $self->param_required('skip_download');
 
+  my $skip_preparse = 1;
+  if ($self->param_exists('skip_preparse')) {
+    $skip_preparse = $self->param('skip_preparse');
+  }
+
   my $db_url = $self->param_required('source_url');
 
   $self->create_db($source_dir, $db_url, $self->param_required('reuse_db'));
@@ -45,6 +50,12 @@ sub run {
     my $db = $source->{'db'};
     my $version_file = $source->{'release'};
     my $preparse = $source->{'preparse'};
+
+    if ($preparse && $skip_preparse) {
+      $parser = $source->{'old_parser'};
+      $preparse = 0;
+    }
+
     $dataflow_params = {
       parser       => $parser,
       name         => $name,

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/SchedulePreParse.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/SchedulePreParse.pm
@@ -32,10 +32,10 @@ sub run {
   my $skip_preparse    = $self->param('skip_preparse');
 
   my ($user, $pass, $host, $port) = $self->parse_url($source_url);
-  my ($xref_user, $xref_pass, $xref_host, $xref_port, $xref_dbname) = $self->parse_url($source_xref);
   my $dataflow_params;
 
   unless ($skip_preparse) {
+    my ($xref_user, $xref_pass, $xref_host, $xref_port, $xref_dbname) = $self->parse_url($source_xref);
 
     # Create central Xref database
     my $xref_dbc = XrefParser::Database->new({

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/ScheduleSource.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/ScheduleSource.pm
@@ -63,7 +63,14 @@ sub run {
             port    => $port,
             user    => $user,
             pass    => $pass });
-  $dbc->create($sql_dir, 1, 1, $xref_source_dbi) if $order_priority == 1; 
+  if ($order_priority == 1) {
+    $dbc->create($sql_dir, 1, 1, $xref_source_dbi);
+
+    if ($self->param_exists('pipeline_part')) {
+      my $species_sth = $self->dbc->prepare("INSERT INTO updated_species (species_name) VALUES (?)");
+      $species_sth->execute($species);
+    }
+  }
   my $xref_db_url = sprintf("mysql://%s:%s@%s:%s/%s", $user, $pass, $host, $port, $dbname);
   my $xref_dbi = $dbc->dbi();
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_all_sources.json
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_all_sources.json
@@ -111,6 +111,7 @@
     {
       "name" : "RefSeq_dna",
       "parser" : "RefSeqDatabaseParser",
+      "old_parser" : "RefSeqGPFFParser",
       "file" : "ftp://ftp.ncbi.nlm.nih.gov/refseq/release/complete/complete*rna.gbff.gz",
       "method" : "--bestn 5",
       "query_cutoff" : 90,
@@ -122,6 +123,7 @@
     {
       "name" : "RefSeq_peptide",
       "parser" : "RefSeqDatabaseParser",
+      "old_parser" : "RefSeqGPFFParser",
       "file" : "ftp://ftp.ncbi.nlm.nih.gov/refseq/release/complete/complete.nonredundant*protein.gpff.gz",
       "method" : "--bestn 1",
       "query_cutoff" : 100,
@@ -154,6 +156,7 @@
     {
       "name" : "Uniprot/SWISSPROT",
       "parser" : "UniProtDatabaseParser",
+      "old_parser" : "UniProtParser",
       "file" : "http://ftp.ebi.ac.uk/pub/databases/uniprot/knowledgebase/uniprot_sprot.dat.gz",
       "method" : "--bestn 1",
       "query_cutoff" : 100,
@@ -165,6 +168,7 @@
     {
       "name" : "Uniprot/SPTREMBL",
       "parser" : "UniProtDatabaseParser",
+      "old_parser" : "UniProtParser",
       "file" : "ftp://ftp.ebi.ac.uk/pub/databases/uniprot/knowledgebase/uniprot_trembl.dat.gz",
       "method" : "--bestn 1",
       "query_cutoff" : 100,

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_sources.json
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_sources.json
@@ -111,6 +111,7 @@
     {
       "name" : "RefSeq_dna",
       "parser" : "RefSeqDatabaseParser",
+      "old_parser" : "RefSeqGPFFParser",
       "file" : "ftp://ftp.ncbi.nlm.nih.gov/refseq/release/vertebrate_mammalian/vertebrate_*rna.gbff.gz",
       "method" : "--bestn 5",
       "query_cutoff" : 90,
@@ -122,6 +123,7 @@
     {
       "name" : "RefSeq_dna",
       "parser" : "RefSeqDatabaseParser",
+      "old_parser" : "RefSeqGPFFParser",
       "file" : "ftp://ftp.ncbi.nlm.nih.gov/refseq/release/vertebrate_other/vertebrate*rna.gbff.gz",
       "method" : "--bestn 5",
       "query_cutoff" : 90,
@@ -133,6 +135,7 @@
     {
       "name" : "RefSeq_peptide",
       "parser" : "RefSeqDatabaseParser",
+      "old_parser" : "RefSeqGPFFParser",
       "file" : "ftp://ftp.ncbi.nlm.nih.gov/refseq/release/vertebrate_mammalian/vertebrate*protein.gpff.gz",
       "method" : "--bestn 1",
       "query_cutoff" : 100,
@@ -144,6 +147,7 @@
     {
       "name" : "RefSeq_peptide",
       "parser" : "RefSeqDatabaseParser",
+      "old_parser" : "RefSeqGPFFParser",
       "file" : "ftp://ftp.ncbi.nlm.nih.gov/refseq/release/vertebrate_other/vertebrate*protein.gpff.gz",
       "method" : "--bestn 1",
       "query_cutoff" : 100,
@@ -176,6 +180,7 @@
     {
       "name" : "Uniprot/SWISSPROT",
       "parser" : "UniProtDatabaseParser",
+      "old_parser" : "UniProtParser",
       "file" : "http://ftp.ebi.ac.uk/pub/databases/uniprot/knowledgebase/uniprot_sprot.dat.gz",
       "method" : "--bestn 1",
       "query_cutoff" : 100,
@@ -187,6 +192,7 @@
     {
       "name" : "Uniprot/SPTREMBL",
       "parser" : "UniProtDatabaseParser",
+      "old_parser" : "UniProtParser",
       "file" : "ftp://ftp.ebi.ac.uk/pub/databases/uniprot/knowledgebase/uniprot_trembl.dat.gz",
       "method" : "--bestn 1",
       "query_cutoff" : 100,


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Making the xref runnables backwards compatible, to allow users to run the old Xref_update_conf pipeline without errors. This PR also includes some fixes to the new pipeline.

## Use case

Main changes:
- Setting source_xref and skip_preparse usage to optional in several runnables to allow running the old pipeline or the new one but without pre-parsing
- Fixing bug in the new email notification runnable (use of xref_url)
- Adding extra information to the new email notification (list species updated)
- Adding an old_parser option to the RefSeq and UniProt sources to allow the use of the old parsers if pre-parsing is off or if running the old pipeline (sister PR in the ensembl repo)

## Benefits

Can run old pipeline without errors.

## Possible Drawbacks


## Testing

Ran the old pipeline (Xref_update_conf) with the 107 code and it ran without errors.

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
