### PR TITLE
No need to use a 1gb worker to follow DBcopy jobs

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DbCopy_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DbCopy_conf.pm
@@ -342,6 +342,7 @@ sub pipeline_analyses {
                                 "src_incl_db": "#src_incl_db#"
                               }/,
                             },
+       -rc_name           => '500M'
     },
     {
       -logic_name        => 'RenameDatabase_1',

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/OLSLoad_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/OLSLoad_conf.pm
@@ -339,6 +339,7 @@ sub pipeline_analyses {
                 'payload'  => $self->o('copy_service_mart_payload'),
                 'method'   => 'post',
             },
+            -rc_name     => "500M"
         },
     ];
 }


### PR DESCRIPTION
Following advises from sysinf

## Description
Message from sysinf: 
db_copy_egphx_b_106-Hive-default-2_1
The memory requested is 1 GB and max used is 400 MBytes.

## Use case

Better codon nodes resources management.

## Benefits

Reduce amount of tasks to default queue

## Possible Drawbacks

None

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
