### PR TITLE
New xref pipeline backwards compatibility

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/SchedulePreParse.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/SchedulePreParse.pm
@@ -44,7 +44,7 @@ sub run {
               port    => $xref_port,
               user    => $xref_user,
               pass    => $xref_pass });
-    $xref_dbc->create($sql_dir, 1, 1);
+    $xref_dbc->create($sql_dir, 1, 1, 1);
   
     # Retrieve list of sources to pre-parse from versioning database
     my ($source_user, $source_pass, $source_host, $source_port, $source_db) = $self->parse_url($source_url);

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/ScheduleSource.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/ScheduleSource.pm
@@ -46,6 +46,8 @@ sub run {
   my $host             = $self->param('xref_host');
   my $port             = $self->param('xref_port');
 
+  my $preparse = 0;
+
   if ($db_url) {
     ($user, $pass, $host, $port) = $self->parse_url($db_url);
   }
@@ -53,6 +55,7 @@ sub run {
   if ($source_xref) {
     ($xref_source_user, $xref_source_pass, $xref_source_host, $xref_source_port, $xref_source_db) = $self->parse_url($source_xref);
     $xref_source_dbi = $self->get_dbi($xref_source_host, $xref_source_port, $xref_source_user, $xref_source_pass, $xref_source_db);
+    $preparse = 1;
   }
 
   # Create Xref database
@@ -64,7 +67,7 @@ sub run {
             user    => $user,
             pass    => $pass });
   if ($order_priority == 1) {
-    $dbc->create($sql_dir, 1, 1, $xref_source_dbi);
+    $dbc->create($sql_dir, 1, 1, $preparse, $xref_source_dbi);
 
     if ($self->param_exists('pipeline_part')) {
       my $species_sth = $self->dbc->prepare("INSERT INTO updated_species (species_name) VALUES (?)");

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_all_sources.json
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_all_sources.json
@@ -210,7 +210,7 @@
     {
       "name" : "ZFIN_desc",
       "parser" : "ZFINDescParser",
-      "file" : "http://zfin.org/pub/transfer/MEOW/zfin_genes.txt",
+      "file" : "ftp://zfin.org/pub/transfer/MEOW/zfin_genes.txt",
       "priority" : 1
     },
     {

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_sources.json
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_sources.json
@@ -234,7 +234,7 @@
     {
       "name" : "ZFIN_desc",
       "parser" : "ZFINDescParser",
-      "file" : "http://zfin.org/pub/transfer/MEOW/zfin_genes.txt",
+      "file" : "ftp://zfin.org/pub/transfer/MEOW/zfin_genes.txt",
       "priority" : 1
     },
     {


### PR DESCRIPTION
## Description

Final backwards compatibility changes added to the xref pipeline.

## Use case

These changes allow users to run the old xref pipeline without any concerns, and it allows the run of the new pipeline without the use of pre-parsing. This PR also contains a fix to the ZFIN_desc download URL, reverting it back to ftp as the https one doesn't work).
This PR is related to [#612](https://github.com/Ensembl/ensembl/pull/612) opened in the ensembl repo.

## Benefits

Xref pipeline backwards compatibility.

## Possible Drawbacks

None

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

N/A
