### PR TITLE
fix for empty Genome xml file in search dumps

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Search/EBeyeGenomeWrapper.pm
+++ b/modules/Bio/EnsEMBL/Production/Search/EBeyeGenomeWrapper.pm
@@ -59,7 +59,9 @@ sub wrap_genomes {
 
   my $genome_file_out = File::Spec->catfile($out_path, 'Genome_Ensembl' . $division . '.xml');
 
-  my @genome_xml_files = File::Find::Rule->file->name("*_genome.xml")->in($out_path);
+  my @species_sub_dir = File::Find::Rule->directory->in( $out_path );
+
+  my @genome_xml_files = File::Find::Rule->file->name("*_genome.xml")->in(@species_sub_dir);
 
   open my $fh, '>', $genome_file_out or croak "Could not open $genome_file_out for writing";
 


### PR DESCRIPTION
module File::Find::Rule->file()->name("*_genome.xml") unable to find the genome xml files present in species sub directories recursively.
 Fix: method File::Find::Rule->directory  finds all the species directories in the search dump folder and this list of  species directory is given as input to method File::Find::Rule->file() to find all the genome xml file present in search dumps for given division. 