### PR TITLE
Bugfix/search default eg version

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Search/GenomeFetcher.pm
+++ b/modules/Bio/EnsEMBL/Production/Search/GenomeFetcher.pm
@@ -88,12 +88,10 @@ sub new {
                 }
 		if ( defined $eg ) {
 			# switch adaptor to use Ensembl Genomes if -EG supplied
-			$logger->debug("Using EG release");
-                        if(defined $eg_version){
-			  $self->{info_adaptor}->set_ensembl_genomes_release($eg_version);
-                        }else{
-			  $self->{info_adaptor}->set_ensembl_genomes_release();
-                        }
+			# try to get ENV var EG_VERSION if not defined.
+			my $version =  defined($eg_version) ? $eg_version : $ENV{'EG_VERSION'} || "";
+  		  	$logger->debug("Using EG release:".$version );
+			$self->{info_adaptor}->set_ensembl_genomes_release($version);
 		}
 
              
@@ -120,6 +118,7 @@ sub fetch_metadata {
 	my $division = $meta->get_division();
   my $org;
   foreach my $genome (@{$orgs}){
+	$logger->info("Org: ". $genome. " / division ". $division);
     $org = $genome if ($genome->division() eq $division);
   }
 	return $org;

--- a/modules/Bio/EnsEMBL/Production/Search/GenomeFetcher.pm
+++ b/modules/Bio/EnsEMBL/Production/Search/GenomeFetcher.pm
@@ -83,18 +83,15 @@ sub new {
 	}
 	if ( defined $metadata_dba ) {
 		$self->{info_adaptor} = $metadata_dba->get_GenomeInfoAdaptor();
-                if( defined $ens_version){
-                  $self->{info_adaptor}->set_ensembl_release($ens_version);
-                }
+		my $version = defined($ens_version) ? $ens_version : $ENV{'ENS_VERSION'} || "";
+		$self->{info_adaptor}->set_ensembl_release($version);
 		if ( defined $eg ) {
 			# switch adaptor to use Ensembl Genomes if -EG supplied
 			# try to get ENV var EG_VERSION if not defined.
-			my $version =  defined($eg_version) ? $eg_version : $ENV{'EG_VERSION'} || "";
+			$version =  defined($eg_version) ? $eg_version : $ENV{'EG_VERSION'} || "";
   		  	$logger->debug("Using EG release:".$version );
 			$self->{info_adaptor}->set_ensembl_genomes_release($version);
 		}
-
-             
 	}
 	return $self;
 } ## end sub new


### PR DESCRIPTION
## Description

Somehow sometime, for some species, `$eg_version` is not set. try to use env var from user to force a value. 
Same consideration taken for ENS_VERSION

## Use case

Search dumps non vertebrates.

## Benefits

Always get a version (both ENS and EG)

## Possible Drawbacks

If run with different values than initial ENV vars, might turn to fetch other dbs version.

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
