### PR TITLE
Add transcript tags to GFF3 files

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_GFF3.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_GFF3.pm
@@ -265,6 +265,15 @@ sub Bio::EnsEMBL::Transcript::summary_as_hash {
   my @tags;
   push(@tags, 'basic') if $self->gencode_basic();
   push(@tags, 'Ensembl_canonical') if $self->is_canonical();
+  
+  # A transcript can have different types of MANE-related attributes (MANE_Select, MANE_Plus_Clinical)
+  # We depend on the Bio::EnsEMBL::MANE object to get the specific type
+  my $mane = $self->mane_transcript();
+  if ($mane) {
+    my $mane_type = $mane->type();
+    push(@tags, $mane_type) if ($mane_type);
+  }
+
   $summary{'tag'} = \@tags if @tags;
 
   # Check for seq-edits

--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_GFF3.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_GFF3.pm
@@ -261,7 +261,11 @@ sub Bio::EnsEMBL::Transcript::summary_as_hash {
   $summary{'havana_version'}           = $havana_transcript->version() if $havana_transcript;
   $summary{'ccdsid'}                   = $self->ccds->display_id if $self->ccds;
   $summary{'transcript_support_level'} = $self->tsl if $self->tsl;
-  $summary{'tag'}                      = 'basic' if $self->gencode_basic();
+
+  my @tags;
+  push(@tags, 'basic') if $self->gencode_basic();
+  push(@tags, 'Ensembl_canonical') if $self->is_canonical();
+  $summary{'tag'} = \@tags if @tags;
 
   # Check for seq-edits
   my $seq_edits = $self->get_all_SeqEdits();

--- a/modules/Bio/EnsEMBL/Production/Pipeline/GFF3/DumpFile.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/GFF3/DumpFile.pm
@@ -277,7 +277,11 @@ sub Bio::EnsEMBL::Transcript::summary_as_hash {
   $summary{'ccdsid'}                   = $self->ccds->display_id if $self->ccds;
   $summary{'transcript_id'}            = $id;
   $summary{'transcript_support_level'} = $self->tsl if $self->tsl;
-  $summary{'tag'}                      = 'basic' if $self->gencode_basic();
+
+  my @tags;
+  push(@tags, 'basic') if $self->gencode_basic();
+  push(@tags, 'Ensembl_canonical') if $self->is_canonical();
+  $summary{'tag'} = \@tags if @tags;
 
   # Add xrefs
   if ($add_xrefs) {

--- a/modules/Bio/EnsEMBL/Production/Pipeline/GFF3/DumpFile.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/GFF3/DumpFile.pm
@@ -281,6 +281,15 @@ sub Bio::EnsEMBL::Transcript::summary_as_hash {
   my @tags;
   push(@tags, 'basic') if $self->gencode_basic();
   push(@tags, 'Ensembl_canonical') if $self->is_canonical();
+
+  # A transcript can have different types of MANE-related attributes (MANE_Select, MANE_Plus_Clinical)
+  # We depend on the Bio::EnsEMBL::MANE object to get the specific type
+  my $mane = $self->mane_transcript();
+  if ($mane) {
+    my $mane_type = $mane->type();
+    push(@tags, $mane_type) if ($mane_type);
+  }
+
   $summary{'tag'} = \@tags if @tags;
 
   # Add xrefs


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Adding the canonical and MANE flags for transcripts and their underlying features in the GFF3 files.
JIRA Ticket (canonical): [ENSCORESW-3981](https://www.ebi.ac.uk/panda/jira/browse/ENSCORESW-3981)
JIRA Ticket (MANE): [ENSCORESW-3986](https://www.ebi.ac.uk/panda/jira/browse/ENSCORESW-3986)

Sister PR [#136](https://github.com/Ensembl/ensembl-io/pull/136) in ensembl-io for GTF changes.

## Use case

The canonical attribute was added to the transcript attributes and is now handled by the REST API and the perl core. This change is a continuation of that in including this attribute in the GFF3 file dumps.
In addition, the MANE attribute (with its different types: MANE_Select, MANE_Plus_Clinical) was added to transcripts and thus needed to be reflected in the GFF3 file dumps.

## Benefits

Consistency with perl and REST APIs.

## Possible Drawbacks

None

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
