### PR TITLE
Updated port number for new `gallus_gallus` reference species.

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_conf.pm
@@ -97,7 +97,7 @@ sub default_options {
             'homo_sapiens'                     => 30001,
             'mus_musculus'                     => 30081,
             'danio_rerio'                      => 30003,
-            'gallus_gallus'                    => 30010,
+            'gallus_gallus'                    => 30005,
             'bos_taurus'                       => 30017,
             'oryctolagus_cuniculus'            => 30025,
             'oryzias_latipes'                  => 30026,


### PR DESCRIPTION
## Description

With gallus_gallus renaming/new reference/change in production name, the new assembly hasn't been caught by handover warning, so the port hasn't been updated for this new assembly.  Here I force the new port to be use for the `gallus_gallus` species production name. 

## Use case

Dump core for BLAT indexes.

## Benefits

Not use the same port compared to previous assembly (GRCg6a).
Port matches the one set by webteam for 107 release. 

## Possible Drawbacks

None

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
