### PR TITLE
update regulation_ftp_symlinks script to add more species

### DIFF
--- a/scripts/py/regulation_ftp_symlinks.py
+++ b/scripts/py/regulation_ftp_symlinks.py
@@ -22,14 +22,20 @@ Script to create specific symlinks for GENE-SWITCH project under the public misc
 
 import argparse
 import os.path
-import pymysql
 import re
-import sys
 
-MISC_SPECIES = ["sus_scrofa"] #New species should be added here
-META_KEY_SPECIES_NAME = "species.production_name"
-META_KEY_RELEASE_VERSION = "schema_version"
-META_KEY_ASSEMBLY_NAME = 'assembly.name'
+# ***** New (species, assemblies) should be added here *****
+
+# MISC_SPECIES_PEAKS = [(<species_name>, <assembly_name>), (...)]
+MISC_SPECIES_PEAKS = [("sus_scrofa", "Sscrofa11.1"), ("gallus_gallus", "GRCg7b"), ("gallus_gallus", "GRCg6a")]
+
+# MISC_SPECIES_SIGNAL = [(<source_species_name>, <source_assembly_name>,
+#                           <target_species_name>, <target_assembly_name>), (...)]
+MISC_SPECIES_SIGNAL = [("sus_scrofa", "Sscrofa11.1", "sus_scrofa", "Sscrofa11.1"),
+                       ("gallus_gallus", "bGalGal1.mat.broiler.GRCg7b", "gallus_gallus", "GRCg7b"),
+                       ("gallus_gallus_gca000002315v5", "GRCg6a", "gallus_gallus", "GRCg6a")]
+
+# Paths
 PUBLIC_PUB_PATH = "PUBLIC/pub"
 PUBLIC_DATA_FILES_PATH = "data_files"
 MISC_GENE_SWITCH_PATH = "misc/gene-switch/regulation"
@@ -39,65 +45,29 @@ def parse_arguments():
     """
     All Arguments are required.
     --ftp_path: Path to the root FTP directory.
-    --db_host: Url to the server where the db is hosted.
-    --db_name: Name of the funcgen Database.
-    --user: Database user with read permissions.
-    --port: Database server port.
+    --release_version: Release version
     """
-
     parser = argparse.ArgumentParser(description='Arguments')
     required_args = parser.add_argument_group('Required arguments')
     required_args.add_argument('-f', '--ftp_path', metavar='FTP path', type=str, help='FTP root path ...',
                                required=True)
-    required_args.add_argument('-d', '--db_host', metavar='DB host', type=str, help='Database host ...',
-                               required=True)
-    required_args.add_argument('-n', '--db_name', metavar='DB name', type=str, help='Database name ...',
-                               required=True)
-    required_args.add_argument('-u', '--user', metavar='DB user', type=str, help='Database user ...',
-                               required=True)
-    required_args.add_argument('-p', '--port', metavar='Port', type=int, help='Database port ...',
-                               required=True)
+    required_args.add_argument('-r', '--release_version', metavar='Release version', type=int,
+                               help='Release version ...', required=True)
 
     return parser.parse_args()
 
 
-def check_paths(arguments):
-    if not os.path.isdir(arguments.ftp_path):
+def check_ftp_path(ftp_path):
+    if not os.path.isdir(ftp_path):
         raise ValueError("Fatal Error: FTP path Not Found")
 
     return
 
 
-def db_connection(db_name, host, user, port):
-    try:
-        connection = pymysql.connect(host=host, user=user, db=db_name, port=port)
-
-        return connection
-
-    except Exception as e:
-        raise ValueError("Can't connect to the Core database: {}".format(e))
-
-
-def get_meta_data(cursor, keys, data):
-    try:
-        param_holders = ', '.join(("%s",) * len(keys))
-        query = "select meta_key, meta_value from meta where meta_key in (%s);" % param_holders
-        cursor.execute(query, keys)
-        meta = cursor.fetchall()
-
-        for row in meta:
-            data[row[0]] = row[1]
-
-        return data
-
-    except Exception as e:
-        raise ValueError("Exception: {}".format(e))
-
-
-def get_highest_release_directory(base_path):
+def get_highest_release_directory(base_path, current_release):
     try:
         release_dirs = next(os.walk(base_path))[1]
-        release_dirs = [int(i) for i in release_dirs]
+        release_dirs = [int(i) for i in release_dirs if int(i) <= current_release]
 
         return max(release_dirs)
 
@@ -105,14 +75,14 @@ def get_highest_release_directory(base_path):
         raise ValueError("Exception: {}".format(e))
 
 
-def get_highest_ensembl_release_directory(base_path):
+def get_highest_ensembl_release_directory(base_path, current_release):
     try:
         dirs = next(os.walk(base_path))[1]
         release_dirs = [i for i in dirs if i.startswith('release-')]
         highest_relese_number = 0
         for rel_dir in release_dirs:
             release_number = int(re.findall(r'\d+', rel_dir)[0])
-            if release_number > highest_relese_number:
+            if (release_number > highest_relese_number) and (release_number <= int(current_release)):
                 highest_relese_number = release_number
 
         return highest_relese_number
@@ -121,14 +91,15 @@ def get_highest_ensembl_release_directory(base_path):
         raise ValueError("Exception: {}".format(e))
 
 
-def misc_signal_symlinks(species, ftp_path, assembly, public_path, data_files_path, gene_switch_path):
+def misc_signal_symlinks(species, ftp_path, assembly, public_path, data_files_path, gene_switch_path,
+                         target_species, target_assembly, release_version):
     try:
         symlink_paths = {}
-        #signal directory
         base_path = os.path.join(ftp_path, public_path, data_files_path, species, assembly, "funcgen")
-        highest_release = get_highest_release_directory(base_path)
+        highest_release = get_highest_release_directory(base_path, release_version)
         src_signal_path = os.path.join(base_path, str(highest_release), "signal")
-        misc_signal_path = os.path.join(ftp_path, public_path, gene_switch_path, species, assembly, "signal")
+        misc_signal_path = os.path.join(ftp_path, public_path, gene_switch_path, target_species, target_assembly,
+                                        "signal")
 
         symlink_paths['source'] = src_signal_path
         symlink_paths['target'] = misc_signal_path
@@ -144,8 +115,8 @@ def misc_peaks_symlinks(species, ftp_path, assembly, public_path, gene_switch_pa
         symlink_paths = {}
         # peaks
         base_path = os.path.join(ftp_path, public_path)
-        highest_release_dir_number = get_highest_ensembl_release_directory(base_path)
-        if str(highest_release_dir_number) == release_version:
+        highest_release_dir_number = get_highest_ensembl_release_directory(base_path, release_version)
+        if highest_release_dir_number == release_version:
             release_dir = "release-" + str(highest_release_dir_number)
             src_peaks_path = os.path.join(base_path, release_dir, "regulation", species, assembly, "peaks")
             misc_peaks_path = os.path.join(ftp_path, public_path, gene_switch_path, species, assembly, "peaks")
@@ -165,22 +136,21 @@ def misc_peaks_symlinks(species, ftp_path, assembly, public_path, gene_switch_pa
 def create_symlinks(symlinks):
     try:
         for symlink_data in symlinks:
-            # create target path if does not exists
             target_splitted_path = symlink_data['target'].split('/')
             target_splitted_path.pop()
             separator = '/'
             target_parent_path = separator.join(target_splitted_path)
 
-            #remove symlink if already exists
+            # remove symlink if already exists
             if os.path.exists(symlink_data['target']):
                 if os.path.islink(symlink_data['target']):
                     os.unlink(symlink_data['target'])
 
-            #create path if doesn't exists
+            # create path if doesn't exists
             if not os.path.exists(target_parent_path):
                 os.makedirs(target_parent_path)
 
-            #create symlink
+            # create symlink
             os.symlink(src=symlink_data['source'], dst=symlink_data['target'], target_is_directory=True)
 
         return
@@ -190,50 +160,41 @@ def create_symlinks(symlinks):
 
 
 if __name__ == '__main__':
-    #check_arguments and db connectons
+    # check_arguments and paths
     args = parse_arguments()
-    check_paths(args)
-    funcgen_db = db_connection(args.db_name,args.db_host, args.user, args.port)
-    core_db_name = args.db_name.replace("funcgen", "core")
-    core_db = db_connection(core_db_name,args.db_host, args.user, args.port)
-    funcgen_cursor = funcgen_db.cursor()
-    core_cursor = core_db.cursor()
+    check_ftp_path(args.ftp_path)
 
-    #get meta_data values from funggen and core dbs
-    meta_data = get_meta_data(funcgen_cursor, [META_KEY_SPECIES_NAME, META_KEY_RELEASE_VERSION], {})
-    meta_data = get_meta_data(core_cursor, [META_KEY_ASSEMBLY_NAME], meta_data)
-
-    #Only species included in MISC_SPECIES list will be processed.
-    if not meta_data[META_KEY_SPECIES_NAME].lower() in MISC_SPECIES:
-        sys.exit(1)
-
-    #create symlinks
     symlinks_to_create = []
-    misc_signal = misc_signal_symlinks(species=meta_data[META_KEY_SPECIES_NAME], ftp_path=args.ftp_path,
-                                       assembly=meta_data[META_KEY_ASSEMBLY_NAME], public_path=PUBLIC_PUB_PATH,
-                                       data_files_path=PUBLIC_DATA_FILES_PATH, gene_switch_path=MISC_GENE_SWITCH_PATH)
+    for species_assembly in MISC_SPECIES_SIGNAL:
+        species_name = species_assembly[0]
+        assembly_name = species_assembly[1]
+        t_species_name = species_assembly[2]
+        t_assembly_name = species_assembly[3]
 
-    if misc_signal:
-        symlinks_to_create.append(misc_signal)
+        misc_signal = misc_signal_symlinks(species=species_name, ftp_path=args.ftp_path,
+                                           assembly=assembly_name, public_path=PUBLIC_PUB_PATH,
+                                           data_files_path=PUBLIC_DATA_FILES_PATH,
+                                           gene_switch_path=MISC_GENE_SWITCH_PATH, target_species=t_species_name,
+                                           target_assembly=t_assembly_name, release_version=args.release_version)
 
-    misc_peaks = misc_peaks_symlinks(species=meta_data[META_KEY_SPECIES_NAME], ftp_path=args.ftp_path,
-                                     assembly=meta_data[META_KEY_ASSEMBLY_NAME],
-                                     public_path=PUBLIC_PUB_PATH,
-                                     gene_switch_path=MISC_GENE_SWITCH_PATH,
-                                     release_version=meta_data[META_KEY_RELEASE_VERSION])
+        if misc_signal:
+            symlinks_to_create.append(misc_signal)
+            create_symlinks(symlinks_to_create)
 
-    if misc_peaks:
-        symlinks_to_create.append(misc_peaks)
+    symlinks_to_create = []
+    for species_assembly in MISC_SPECIES_PEAKS:
 
-    create_symlinks(symlinks_to_create)
+        species_name = species_assembly[0]
+        assembly_name = species_assembly[1]
 
-    funcgen_cursor.close()
-    funcgen_db.close()
-    core_cursor.close()
-    core_db.close()
+        misc_peaks = misc_peaks_symlinks(species=species_name, ftp_path=args.ftp_path,
+                                         assembly=assembly_name,
+                                         public_path=PUBLIC_PUB_PATH,
+                                         gene_switch_path=MISC_GENE_SWITCH_PATH,
+                                         release_version=args.release_version)
+
+        if misc_peaks:
+            symlinks_to_create.append(misc_peaks)
+            create_symlinks(symlinks_to_create)
 
     print("Symlinks successfully created!")
-
-
-
-


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

New species have been added to the scrip to create the symlinks under the misc directory in the FTP.
Parameters to connect to DBs have been removed.

## Use case

New species need to be also included in the script (gallus_gallus)

## Benefits

Will create the symlinks automatically for sus_scrofa and gallus_gallus (2 assmeblies)

## Possible Drawbacks

Symlinks maybe are not created if paths not match with the FTP site.

## Testing

Tests were performed locally

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
