### PR TITLE
Fixes for non-GIFTS species

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/AlphaFold/HiveLoadAlphaFoldDBProteinFeatures.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/AlphaFold/HiveLoadAlphaFoldDBProteinFeatures.pm
@@ -83,7 +83,6 @@ sub param_defaults {
       cs_version => undef,
       species => undef,
       rest_server => undef,
-      debug => undef,
     }
 }
 
@@ -112,10 +111,10 @@ sub fetch_input {
 
   $self->hrdb_set_con($core_dba,"core");
 
-  info(sprintf("Cleaning up old protein features and analysis for species %s\n", $self->{'species'})) if defined($self->{'debug'});
+  info(sprintf("Cleaning up old protein features and analysis for species %s\n", $self->{'species'}));
   $self->cleanup_protein_features('alphafold_import');
 
-  info(sprintf("Initiating MakeAlphaFoldDBProteinFeatures and creating the analysis object for species %s\n", $self->{'species'})) if defined($self->{'debug'});
+  info(sprintf("Initiating MakeAlphaFoldDBProteinFeatures and creating the analysis object for species %s\n", $self->{'species'}));
   my $runnable = Bio::EnsEMBL::Production::Pipeline::AlphaFold::MakeAlphaFoldDBProteinFeatures->new(
     -analysis => new Bio::EnsEMBL::Analysis(-logic_name => 'alphafold_import',
                                             -db => 'alphafold',
@@ -211,7 +210,7 @@ sub cleanup_protein_features() {
 
   if (defined($analysis)) {
       my $analysis_id = $analysis->dbID();
-      info(sprintf("Found alphafold_import analysis (ID: $analysis_id) for species %s. Deleting it ...\n", $self->{'species'})) if defined($self->{'debug'});
+      info(sprintf("Found alphafold_import analysis (ID: $analysis_id) for species %s. Deleting it ...\n", $self->{'species'}));
 
       my $pfa = $core_dba->get_ProteinFeatureAdaptor();
       $pfa->remove_by_analysis_id($analysis_id);

--- a/modules/Bio/EnsEMBL/Production/Pipeline/AlphaFold/HiveLoadAlphaFoldDBProteinFeatures.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/AlphaFold/HiveLoadAlphaFoldDBProteinFeatures.pm
@@ -58,6 +58,7 @@ use 5.014002;
 use Bio::EnsEMBL::Analysis::Tools::Utilities;
 use parent ('Bio::EnsEMBL::Analysis::Hive::RunnableDB::HiveBaseRunnableDB');
 use Bio::EnsEMBL::Production::Pipeline::AlphaFold::MakeAlphaFoldDBProteinFeatures;
+use Bio::EnsEMBL::Utils::Exception qw(throw info);
 
 use Net::FTP;
 use Bio::EnsEMBL::DBSQL::DBAdaptor;
@@ -111,10 +112,10 @@ sub fetch_input {
 
   $self->hrdb_set_con($core_dba,"core");
 
-  print "Cleaning up old protein features and analysis\n" if defined($self->param('debug'));
+  info(sprintf("Cleaning up old protein features and analysis for species %s\n", $self->{'species'})) if defined($self->{'debug'});
   $self->cleanup_protein_features('alphafold_import');
 
-  print "Initiating MakeAlphaFoldDBProteinFeatures and creating the analysis object\n" if defined($self->param('debug'));
+  info(sprintf("Initiating MakeAlphaFoldDBProteinFeatures and creating the analysis object for species %s\n", $self->{'species'})) if defined($self->{'debug'});
   my $runnable = Bio::EnsEMBL::Production::Pipeline::AlphaFold::MakeAlphaFoldDBProteinFeatures->new(
     -analysis => new Bio::EnsEMBL::Analysis(-logic_name => 'alphafold_import',
                                             -db => 'alphafold',
@@ -210,7 +211,7 @@ sub cleanup_protein_features() {
 
   if (defined($analysis)) {
       my $analysis_id = $analysis->dbID();
-      print "Found alphafold_import analysis (ID: $analysis_id). Deleting it ...\n" if defined($self->param('debug'));
+      info(sprintf("Found alphafold_import analysis (ID: $analysis_id) for species %s. Deleting it ...\n", $self->{'species'})) if defined($self->{'debug'});
 
       my $pfa = $core_dba->get_ProteinFeatureAdaptor();
       $pfa->remove_by_analysis_id($analysis_id);

--- a/modules/Bio/EnsEMBL/Production/Pipeline/AlphaFold/MakeAlphaFoldDBProteinFeatures.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/AlphaFold/MakeAlphaFoldDBProteinFeatures.pm
@@ -70,7 +70,6 @@ sub new {
 
     $self->{'pdb_info'} = undef;
     $self->{'perfect_matches'} = undef;
-    $self->{'debug'} = undef;
 
     return $self;
 }
@@ -94,15 +93,15 @@ sub new {
 sub run {
     my ($self) = @_;
 
-    info(sprintf("Parsing the afdb_file for species %s\n", $self->{'species'})) if defined($self->{'debug'});
+    info(sprintf("Parsing the afdb_file for species %s\n", $self->{'species'}));
     $self->{'afdb_info'} = $self->parse_afdb_file();
     unless (ref($self->{'afdb_info'}) eq 'ARRAY') {
         die "Missing info from AFDB file. Path: " . $self->{'alpha_path'} . ". Species: " . $self->{'species'} . "\n";
     }
 
-    info(sprintf("Calling GIFTS endpoint for species %s\n", $self->{'species'})) if defined($self->{'debug'});
+    info(sprintf("Calling GIFTS endpoint for species %s\n", $self->{'species'}));
     $self->{'perfect_matches'} = eval{fetch_latest_uniprot_enst_perfect_matches($self->{'rest_server'}, $self->{'cs_version'})};
-    info(sprintf("Done with GIFTS for species %s\n", $self->{'species'})) if defined($self->{'debug'});
+    info(sprintf("Done with GIFTS for species %s\n", $self->{'species'}));
 
     unless (scalar(keys %{$self->{'perfect_matches'}}) > 0) {
         info(sprintf("No data found for species %s in GIFTS DB using endpoint %s and assembly %s. Message:\n%s", $self->{'species'}, $self->{'rest_server'}, $self->{'cs_version'}, $@));
@@ -113,7 +112,7 @@ sub run {
         die(sprintf("No matches for species %s found in core DB %s\n", $self->{'species'}, $self->{'core_dba'}->dbc->dbname()));
     }
 
-    print "Making protein features ...\n" if defined($self->{'debug'});
+    info(sprintf("Making protein features for species %s\n", $self->{'species'}));
     $self->make_protein_features();
 
     return 1;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/AlphaFold/MakeAlphaFoldDBProteinFeatures.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/AlphaFold/MakeAlphaFoldDBProteinFeatures.pm
@@ -105,7 +105,7 @@ sub run {
     print "... done with GIFTS\n" if defined($self->{'debug'});
 
     unless (scalar(keys %{$self->{'perfect_matches'}}) > 0) {
-        print "No data found for species ".$self->{'species'}."in GIFTS DB for assembly ".$self->{'cs_version'}.$/;
+        print "No data found for species ".$self->{'species'}." in GIFTS DB for assembly ".$self->{'cs_version'}.$/ if defined($self->{'debug'});
 
         info(sprintf("No data found for species %s in GIFTS DB using endpoint %s and assembly %s. Message:\n%s", $self->{'species'}, $self->{'rest_server'}, $self->{'cs_version'}, $@));
         $self->{'perfect_matches'} = $self->fetch_uniprot_ensembl_matches();

--- a/modules/Bio/EnsEMBL/Production/Pipeline/AlphaFold/MakeAlphaFoldDBProteinFeatures.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/AlphaFold/MakeAlphaFoldDBProteinFeatures.pm
@@ -94,19 +94,17 @@ sub new {
 sub run {
     my ($self) = @_;
 
-    print "Parsing the afdb_file ...\n" if defined($self->{'debug'});
+    info(sprintf("Parsing the afdb_file for species %s\n", $self->{'species'})) if defined($self->{'debug'});
     $self->{'afdb_info'} = $self->parse_afdb_file();
     unless (ref($self->{'afdb_info'}) eq 'ARRAY') {
         die "Missing info from AFDB file. Path: " . $self->{'alpha_path'} . ". Species: " . $self->{'species'} . "\n";
     }
 
-    print "Calling GIFTS endpoint ...\n" if defined($self->{'debug'});
+    info(sprintf("Calling GIFTS endpoint for species %s\n", $self->{'species'})) if defined($self->{'debug'});
     $self->{'perfect_matches'} = eval{fetch_latest_uniprot_enst_perfect_matches($self->{'rest_server'}, $self->{'cs_version'})};
-    print "... done with GIFTS\n" if defined($self->{'debug'});
+    info(sprintf("Done with GIFTS for species %s\n", $self->{'species'})) if defined($self->{'debug'});
 
     unless (scalar(keys %{$self->{'perfect_matches'}}) > 0) {
-        print "No data found for species ".$self->{'species'}." in GIFTS DB for assembly ".$self->{'cs_version'}.$/ if defined($self->{'debug'});
-
         info(sprintf("No data found for species %s in GIFTS DB using endpoint %s and assembly %s. Message:\n%s", $self->{'species'}, $self->{'rest_server'}, $self->{'cs_version'}, $@));
         $self->{'perfect_matches'} = $self->fetch_uniprot_ensembl_matches();
     }

--- a/modules/Bio/EnsEMBL/Production/Pipeline/AlphaFold/MakeAlphaFoldDBProteinFeatures.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/AlphaFold/MakeAlphaFoldDBProteinFeatures.pm
@@ -70,6 +70,7 @@ sub new {
 
     $self->{'pdb_info'} = undef;
     $self->{'perfect_matches'} = undef;
+    $self->{'debug'} = undef;
 
     return $self;
 }
@@ -93,19 +94,28 @@ sub new {
 sub run {
     my ($self) = @_;
 
+    print "Parsing the afdb_file ...\n" if defined($self->{'debug'});
     $self->{'afdb_info'} = $self->parse_afdb_file();
     unless (ref($self->{'afdb_info'}) eq 'ARRAY') {
         die "Missing info from AFDB file. Path: " . $self->{'alpha_path'} . ". Species: " . $self->{'species'} . "\n";
     }
 
+    print "Calling GIFTS endpoint ...\n" if defined($self->{'debug'});
     $self->{'perfect_matches'} = eval{fetch_latest_uniprot_enst_perfect_matches($self->{'rest_server'}, $self->{'cs_version'})};
-    unless ($self->{'perfect_matches'}) {
+    print "... done with GIFTS\n" if defined($self->{'debug'});
+
+    unless (scalar(keys %{$self->{'perfect_matches'}}) > 0) {
+        print "No data found for species ".$self->{'species'}."in GIFTS DB for assembly ".$self->{'cs_version'}.$/;
+
         info(sprintf("No data found for species %s in GIFTS DB using endpoint %s and assembly %s. Message:\n%s", $self->{'species'}, $self->{'rest_server'}, $self->{'cs_version'}, $@));
         $self->{'perfect_matches'} = $self->fetch_uniprot_ensembl_matches();
     }
-    unless ($self->{'perfect_matches'}) {
-        die "No matches for species %s found in core DB %s\n", $self->{'species'}, $self->{'core_dba'}->dbc->dbname();
+
+    unless (scalar(keys %{$self->{'perfect_matches'}}) > 0) {
+        die(sprintf("No matches for species %s found in core DB %s\n", $self->{'species'}, $self->{'core_dba'}->dbc->dbname()));
     }
+
+    print "Making protein features ...\n" if defined($self->{'debug'});
     $self->make_protein_features();
 
     return 1;
@@ -212,34 +222,34 @@ sub make_protein_features() {
 
     if (defined($self->{'perfect_matches'}{$afdb_uniprot})) {
       my @ensts = @{$self->{'perfect_matches'}{$afdb_uniprot}};
-      if (scalar(@ensts) > 0) {
-        foreach my $enst (@ensts) {
+      #if (scalar(@ensts) > 0) {
+      foreach my $enst (@ensts) {
 
-          my %pf_translation;
-          my $t = $ta->fetch_by_stable_id($enst);
+        my %pf_translation;
+        my $t = $ta->fetch_by_stable_id($enst);
 
-          if ($t and $t->translation and $t->translation->length >= $$afdb_line{SP_END}) {
-            my $translation = $t->translation();
-            my $translation_sid = $translation->stable_id();
+        if ($t and $t->translation and $t->translation->length >= $$afdb_line{SP_END}) {
+          my $translation = $t->translation();
+          my $translation_sid = $translation->stable_id();
 
-            $$afdb_line{'SIFTS_RELEASE_DATE'} //= '';
+          $$afdb_line{'SIFTS_RELEASE_DATE'} //= '';
 
-            my $pf = Bio::EnsEMBL::ProteinFeature->new(
-                    -start    => $$afdb_line{'SP_BEG'},
-                    -end      => $$afdb_line{'SP_END'},
-                    -hseqname => $$afdb_line{'AFDB'}.".".$$afdb_line{'CHAIN'},
-                    -hstart   => $$afdb_line{'RES_BEG'},
-                    -hend     => $$afdb_line{'RES_END'},
-                    -analysis => $analysis,
-                    -hdescription => "Via SIFTS (".$$afdb_line{'SIFTS_RELEASE_DATE'}.
-                                     ") UniProt protein ".$$afdb_line{'SP_PRIMARY'}.
-                                     " isoform exact match to Ensembl protein $translation_sid"
-                 );
-              $pf_translation{$translation->dbID()} = $pf;
-              push(@pfs,\%pf_translation);
-          } # if t
-        } # foreach my enst
-      } # if scalar
+          my $pf = Bio::EnsEMBL::ProteinFeature->new(
+                  -start    => $$afdb_line{'SP_BEG'},
+                  -end      => $$afdb_line{'SP_END'},
+                  -hseqname => $$afdb_line{'AFDB'}.".".$$afdb_line{'CHAIN'},
+                  -hstart   => $$afdb_line{'RES_BEG'},
+                  -hend     => $$afdb_line{'RES_END'},
+                  -analysis => $analysis,
+                  -hdescription => "Via SIFTS (".$$afdb_line{'SIFTS_RELEASE_DATE'}.
+                                   ") UniProt protein ".$$afdb_line{'SP_PRIMARY'}.
+                                   " isoform exact match to Ensembl protein $translation_sid"
+               );
+            $pf_translation{$translation->dbID()} = $pf;
+            push(@pfs,\%pf_translation);
+        } # if t
+      } # foreach my enst
+      #} # if scalar
     } # if ensts
   } # foreach my afdb_line
 

--- a/scripts/py/alphafoldUpdate.py
+++ b/scripts/py/alphafoldUpdate.py
@@ -77,10 +77,12 @@ def get_alphamapping(work_dir: str) -> List[str]:
     alpha_mappings = []
     files = glob.glob(work_dir + '/*.pdb.gz')
     for f in files:
+        f_name = os.path.basename(f)[:-len('.gz')]
         with gzip.open(f, 'rt') as gfh:
             for line in gfh:
                 if ALPHA_MAP_RE.match(line):
-                    alpha_mappings.append(line)
+                    my_line = f"{f_name}:{line}"
+                    alpha_mappings.append(my_line)
     return alpha_mappings
 
 


### PR DESCRIPTION
## Description

Changes for fixing:
- duplicated `protein_feature` records in core DBs
- missing new `protein_feature` records for non-GIFTS species
- ".A" hit names for `protein_feature` 

## Use case

Create AlphaFold protein features for additional species, which are not necessarily represented in GIFTS DB.

## Benefits

Fixing bugs and mitigating current pipeline design issues.

## Possible Drawbacks

For non-GIFTS species, the Uniprot entry is retrieved from Xref data. These Xref are required to be of `info_type` DEPENDENT, but that is not necessarily the case for some non-vertebrates species.
In these latter cases, the AlphaFold data cannot be mapped, `protein_feature` are not created, and data checks will fail.

These drawbacks will be addressed in `release/109`.

## Testing

The changes were manually successfully tested. No automatic testing procedure was developed.

Dependencies
------------

No new deps.
