### PR TITLE
Resolved inconsitency in queue for WaitForFiles - shouldn't be `dm` b…

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GPAD_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/GPAD_conf.pm
@@ -104,7 +104,7 @@ sub pipeline_analyses {
             },
             -flow_into       => { 1 => [ 'AdvisoryDCReportInit' ] },
             -input_ids       => [ {} ],
-            -rc_name         => 'dm'
+            -rc_name         => 'default'
         },
         {
             -logic_name => 'AdvisoryDCReportInit',


### PR DESCRIPTION
…ecause of parallel job number limitation and subsequent analysis expect files in `/nfs/production` anyway.

## Description

GPAD SOP is to rsync file from dm queue to standard nfs not to be limited by dm queue jobs limitation.
The Wait analysis is still checking for files updates in `dm` though. which will trigger issue when automated

## Use case

GPAD load automation

## Benefits

No discrepencies

## Possible Drawbacks

None. 

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
