### PR TITLE
Bugfixe and log warning if Transcript is not found in related DB

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/GPAD/LoadFile.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/GPAD/LoadFile.pm
@@ -259,8 +259,12 @@ sub run {
             else {
                 $translation = $tl_adaptor->fetch_by_stable_id($tgt_protein);
                 $transcript = $translation->transcript;
-                $translation_hash{$tgt_protein} = $translation;
-                $transcript_hash{$tgt_protein} = $transcript;
+                if (defined $transcript) {
+                    $transcript_hash{$tgt_protein} = $transcript;
+                    $translation_hash{$tgt_protein} = $translation;
+                } else {
+                    $self->log()->warn("Transcript not found for protein $tgt_protein");
+                }
             }
 
             if (defined $translation) {
@@ -299,9 +303,13 @@ sub run {
                     # Protein xref is attached to translation
                     # But GO term should be attached to transcript
                     foreach my $translation (@$translations) {
-                        $self->log()->debug("Attaching via translation to transcript " . $translation->transcript()->dbID());
-                        $dbe_adaptor->store($go_xref, $translation->transcript->dbID, 'Transcript', 1, $master_xref);
-                        $species_added_via_xref{$tgt_species}++;
+                        if (defined $translation->transcript) {
+                            $self->log()->debug("Attaching via translation to transcript " . $translation->transcript()->dbID());
+                            $dbe_adaptor->store($go_xref, $translation->transcript->dbID, 'Transcript', 1, $master_xref);
+                            $species_added_via_xref{$tgt_species}++;
+                        } else {
+                            $self->log()->warn("Transcript not found for $translation");
+                        }
                     }
                 }
                 elsif ($is_transcript) {


### PR DESCRIPTION
## Description

Bug for old annotation when transcripts have been modified in related databases. 

## Use case

GPAD loading from unsynced files.

## Benefits

Ignore the errors and continue the file processing with data that can be imported

## Possible Drawbacks

Less annotations

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
