### PR TITLE
AlphaFold pipeline: integrate map file creation

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -14,4 +14,4 @@ requires 'File::Slurp';
 requires 'Log::Log4perl';
 requires 'XML::Simple';
 requires 'Time::Duration';
-
+requires 'Gzip::Faster';

--- a/modules/Bio/EnsEMBL/Production/Pipeline/AlphaFold/CreateAlphaFoldMapping.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/AlphaFold/CreateAlphaFoldMapping.pm
@@ -1,0 +1,187 @@
+=head1 LICENSE
+
+ Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+ Copyright [2016-2022] EMBL-European Bioinformatics Institute
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+=head1 CONTACT
+
+  Please email comments or questions to the public Ensembl
+  developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
+
+  Questions may also be sent to the Ensembl help desk at
+  <http://www.ensembl.org/Help/Contact>.
+
+=cut
+
+=head1 NAME
+
+Bio::EnsEMBL::Production::Pipeline::AlphaFold::CreateAlphaFoldMapping
+
+=head1 SYNOPSIS
+
+This module prepares the mapping files for the AlphaFold data.
+
+=head1 DESCRIPTION
+
+- finds species from metadata file
+- finds associated .tar files with protein predictions
+- extracts protein info from contained PDB files
+
+=cut
+
+package Bio::EnsEMBL::Production::Pipeline::AlphaFold::CreateAlphaFoldMapping;
+
+use warnings;
+use strict;
+
+use parent 'Bio::EnsEMBL::Production::Pipeline::Common::Base';
+
+use Bio::EnsEMBL::Utils::Exception qw(throw info);
+
+use open qw( :std :encoding(UTF-8) );
+
+use JSON;
+use Archive::Tar;
+use Gzip::Faster;
+use File::Path 'make_path';
+
+sub fetch_input {
+    my $self = shift;
+    $self->param_required('species');
+    $self->param_required('cs_version');
+    $self->param_required('core_dbhost');
+    $self->param_required('core_dbport');
+    $self->param_required('core_dbname');
+    $self->param_required('core_dbuser');
+    $self->param_required('core_dbpass');
+    $self->param_required('alphafold_data_dir');
+    $self->param_required('alphafold_mapfile_dir');
+    return 1;
+}
+
+sub run {
+    my ($self) = @_;
+
+    my $species = $self->param_required('species');
+    my $alpha_path = $self->param_required('alphafold_data_dir');
+    my $outpath = $self->param_required('alphafold_mapfile_dir');
+
+    my $metafile = $alpha_path . '/download_metadata.json';
+    my $datapath = $alpha_path . '/latest/';
+
+    throw ("Metadata file not found at alphafold_data_dir/download_metadata.json ($metafile) on host " . `hostname`) unless -f $metafile;
+    throw "Path for AlphaFold data not found at alphafold_data_dir/latest ($datapath)" unless -d $datapath;
+
+    if (! -d $outpath) {
+        make_path($outpath) or throw "Error creating alphafold_mapfile_dir ($outpath)";
+    }
+
+    my $metadata;
+    {
+        open my $fh, '<', $metafile or throw "Error opening metadata file '$metafile': $!";
+        local $/ = undef;
+        $metadata = <$fh>;
+        close $fh;
+    }
+
+    my $meta_array = decode_json($metadata);
+
+    my $done;
+    my $outfile;
+
+    foreach my $entry (@$meta_array) {
+        my $filename = $entry->{species};
+        next unless $filename;
+        $filename = lc($filename);
+        $filename =~ s/ /_/g;
+        next unless $filename eq $species;
+
+        my $archive_path = $datapath . $entry->{archive_name};
+
+        next unless (-f $archive_path);
+
+        $outfile = $outpath . "/" . $filename . ".map";
+        open my $fh, '>', $outfile or throw "Error opening output file '$outfile': $!";
+
+        print $fh extract($archive_path);
+        close $fh;
+        $done = 1;
+        last;
+    }
+    if ($done) {
+        my $dataflow_params = {
+            species     => $species,
+            cs_version  => $self->param('cs_version'),
+            core_dbhost => $self->param('core_dbhost'),
+            core_dbport => $self->param('core_dbport'),
+            core_dbname => $self->param('core_dbname'),
+            core_dbuser => $self->param('core_dbuser'),
+            core_dbpass => $self->param('core_dbpass'),
+            alphafold_mapfile => $outfile,
+        };
+        $self->dataflow_output_id($dataflow_params, 2);
+    } else {
+        info ("No AlphaFold data found for species $species.");
+        # There is no dataflow if there is no data
+    }
+
+    return 1;
+}
+
+sub extract {
+    my $tarfile = shift;
+    my $tar  = Archive::Tar->new;
+    $tar->read($tarfile);
+    my @items = $tar->get_files;
+    my @afdb_info;
+
+    foreach my $file (@items) {
+        next unless $file->name =~ /\.pdb\.gz$/;
+
+        my $pdbgz = $file->get_content_by_ref;
+        my $unz = gunzip( $$pdbgz );
+
+        open my $pdbdata, '<', \$unz;
+
+        while (my $line = <$pdbdata>) {
+            if ($line =~ /^DBREF/) {
+                my $clean_afdb = $file->name;
+                $clean_afdb =~ s/-model_.*$//;
+                my (undef, undef, $chain, $res_beg, $res_end, undef,
+                    $sp_primary, undef, $sp_beg, $sp_end) = split(/\s+/, $line);
+
+                push(@afdb_info,{'AFDB' => $clean_afdb,
+                    'CHAIN' => $chain,
+                    'SP_PRIMARY' => $sp_primary,
+                    'RES_BEG' => $res_beg,
+                    'RES_END' => $res_end,
+                    'SP_BEG' => $sp_beg,
+                    'SP_END' => $sp_end,
+                    'SIFTS_RELEASE_DATE' => undef
+                }) unless ($sp_beg > $sp_end);
+                # Skips the entry if the start of the protein is greater than the end as we cannot display it correctly.
+
+                last;
+            }
+        }
+        close $pdbdata;
+    }
+    return encode_json(\@afdb_info);
+}
+
+# Dataflow (dataflow_output_id() happens in "sub run"
+# sub write_output {}
+
+1;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/AlphaFold/MakeAlphaFoldDBProteinFeatures.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/AlphaFold/MakeAlphaFoldDBProteinFeatures.pm
@@ -34,7 +34,10 @@ Bio::EnsEMBL::Production::Pipeline::AlphaFold::MakeAlphaFoldDBProteinFeatures -
 
 =head1 DESCRIPTION
 
-This module makes protein features based on the AFDB-UniProt mappings found in the EMBL-EBI AFDB SIFTS data and the UniProt-ENSP mappings found in the GIFTS database in order to make the link between AFDB and ENSP having a AFDB entry as a protein feature for a given ENSP protein.
+This module makes protein features based on the AFDB-UniProt mappings found in
+the EMBL-EBI AFDB SIFTS data and the UniProt-ENSP mappings found in the GIFTS
+database in order to make the link between AFDB and ENSP having a AFDB entry as
+a protein feature for a given ENSP protein.
 
 =head1 APPENDIX
 
@@ -48,13 +51,14 @@ package Bio::EnsEMBL::Production::Pipeline::AlphaFold::MakeAlphaFoldDBProteinFea
 use warnings;
 use strict;
 
-# Bio::DB::HTS::Faidx used in Bio::EnsEMBL::GIFTS::DB needs Perl 5.14.2
-use 5.014002;
 use parent ('Bio::EnsEMBL::Analysis::Runnable');
 use Bio::EnsEMBL::Utils::Argument qw(rearrange);
 use Bio::EnsEMBL::Utils::Exception qw(throw info);
 use Bio::EnsEMBL::GIFTS::DB qw(fetch_latest_uniprot_enst_perfect_matches);
 use Bio::EnsEMBL::ProteinFeature;
+use JSON;
+
+use open qw( :std :encoding(UTF-8) );
 
 sub new {
     my ($class,@args) = @_;
@@ -92,6 +96,8 @@ sub new {
 
 sub run {
     my ($self) = @_;
+
+    Bio::EnsEMBL::Utils::Exception::verbose('ALL');
 
     info(sprintf("Parsing the afdb_file for species %s\n", $self->{'species'}));
     $self->{'afdb_info'} = $self->parse_afdb_file();
@@ -162,33 +168,19 @@ sub fetch_uniprot_ensembl_matches {
 
 =cut
 
-sub parse_afdb_file() {
+sub parse_afdb_file {
   my $self = shift;
 
-  open(my $afdb_fh,'<',$self->{'alpha_path'}) || throw('Cannot open: '.$self->{'alpha_path'});
-  my @afdb_info = ();
-  my $sifts_release_date;
-
-  while (my $line = <$afdb_fh>) {
-
-    # parse a AFDB-UniProt line
-    my ($afdb,undef,$chain,$res_beg,$res_end,undef,$sp_primary,undef,$sp_beg,$sp_end) = split(/\s+/,$line);
-    #my $clean_afdb = $afdb =~ /(AF-\w-\w)-model_\w.pdb:DBREF/g;
-    my ($clean_afdb) = $afdb =~ /(AF-\w+-\w+)-model_\w+.pdb:DBREF/;
-
-    push(@afdb_info,{'AFDB' => $clean_afdb,
-                    'CHAIN' => $chain,
-                    'SP_PRIMARY' => $sp_primary,
-                    'RES_BEG' => $res_beg,
-                    'RES_END' => $res_end,
-                    'SP_BEG' => $sp_beg,
-                    'SP_END' => $sp_end,
-                    'SIFTS_RELEASE_DATE' => $sifts_release_date
-                   }) unless ($sp_beg > $sp_end);
-    # ignore complex AFDB-UniProt mappings that allow SP_BEG > SP_END
+  my $alpha_data;
+  {
+      open(my $fh, '<', $self->{'alpha_path'}) || throw('Cannot open: '.$self->{'alpha_path'});
+      local $/ = undef;
+      $alpha_data = <$fh>;
+      close $fh;
   }
-  close($afdb_fh) || throw('Cannot close '.$self->{'alpha_path'});
-  return \@afdb_info;
+  my $afdb_info = decode_json($alpha_data);
+
+  return $afdb_info;
 }
 
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Common/MetadataCSVersion.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Common/MetadataCSVersion.pm
@@ -43,7 +43,6 @@ sub run {
         'core_dbpass' => $core_dbc->pass,
         'cs_version'  => $cs_version,
         'species'     => $species,
-        'alpha_path'  => File::Spec->catfile($self->param('base_path'), $self->param('species'), 'alpha_mappings.txt')
     },
         2
     );


### PR DESCRIPTION
## Description
The AlphaFold pipeline currently uses mapping files to associate proteins in a species with the prediction data. This commit changes the pipeline to create these mapping files in a first step.
The pipeline uses scratch_large_dir, which is created at the beginning and deleted when the pipelines has finished.
Includes a dependency on Gzip::Faster. It is 8 - 10x faster than the default IO::Compress::Gzip.

## Use case

No more preparing the map files.

## Benefits

Pipeline is easier to run, less room for errors.

## Testing

Pipeline tested manually. Code has no impact on other pipelines.

Dependencies
------------
New dependency on Gzip::Faster