### PR TITLE
AlphaFold pipeline: integrate map file creation

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -14,4 +14,4 @@ requires 'File::Slurp';
 requires 'Log::Log4perl';
 requires 'XML::Simple';
 requires 'Time::Duration';
-
+requires 'Gzip::Faster';

--- a/modules/Bio/EnsEMBL/Production/Pipeline/AlphaFold/CreateAlphaFoldMapping.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/AlphaFold/CreateAlphaFoldMapping.pm
@@ -1,0 +1,187 @@
+=head1 LICENSE
+
+ Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+ Copyright [2016-2022] EMBL-European Bioinformatics Institute
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+=head1 CONTACT
+
+  Please email comments or questions to the public Ensembl
+  developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
+
+  Questions may also be sent to the Ensembl help desk at
+  <http://www.ensembl.org/Help/Contact>.
+
+=cut
+
+=head1 NAME
+
+Bio::EnsEMBL::Production::Pipeline::AlphaFold::CreateAlphaFoldMapping
+
+=head1 SYNOPSIS
+
+This module prepares the mapping files for the AlphaFold data.
+
+=head1 DESCRIPTION
+
+- finds species from metadata file
+- finds associated .tar files with protein predictions
+- extracts protein info from contained PDB files
+
+=cut
+
+package Bio::EnsEMBL::Production::Pipeline::AlphaFold::CreateAlphaFoldMapping;
+
+use warnings;
+use strict;
+
+use parent 'Bio::EnsEMBL::Production::Pipeline::Common::Base';
+
+use Bio::EnsEMBL::Utils::Exception qw(throw info);
+
+use open qw( :std :encoding(UTF-8) );
+
+use JSON;
+use Archive::Tar;
+use Gzip::Faster;
+use File::Path 'make_path';
+
+sub fetch_input {
+    my $self = shift;
+    $self->param_required('species');
+    $self->param_required('cs_version');
+    $self->param_required('core_dbhost');
+    $self->param_required('core_dbport');
+    $self->param_required('core_dbname');
+    $self->param_required('core_dbuser');
+    $self->param_required('core_dbpass');
+    $self->param_required('alphafold_data_dir');
+    $self->param_required('alphafold_mapfile_dir');
+    return 1;
+}
+
+sub run {
+    my ($self) = @_;
+
+    my $species = $self->param_required('species');
+    my $alpha_path = $self->param_required('alphafold_data_dir');
+    my $outpath = $self->param_required('alphafold_mapfile_dir');
+
+    my $metafile = $alpha_path . '/download_metadata.json';
+    my $datapath = $alpha_path . '/latest/';
+
+    throw ("Metadata file not found at alphafold_data_dir/download_metadata.json ($metafile) on host " . `hostname`) unless -f $metafile;
+    throw "Path for AlphaFold data not found at alphafold_data_dir/latest ($datapath)" unless -d $datapath;
+
+    if (! -d $outpath) {
+        make_path($outpath) or throw "Error creating alphafold_mapfile_dir ($outpath)";
+    }
+
+    my $metadata;
+    {
+        open my $fh, '<', $metafile or throw "Error opening metadata file '$metafile': $!";
+        local $/ = undef;
+        $metadata = <$fh>;
+        close $fh;
+    }
+
+    my $meta_array = decode_json($metadata);
+
+    my $done;
+    my $outfile;
+
+    foreach my $entry (@$meta_array) {
+        my $filename = $entry->{species};
+        next unless $filename;
+        $filename = lc($filename);
+        $filename =~ s/ /_/g;
+        next unless $filename eq $species;
+
+        my $archive_path = $datapath . $entry->{archive_name};
+
+        next unless (-f $archive_path);
+
+        $outfile = $outpath . "/" . $filename . ".map";
+        open my $fh, '>', $outfile or throw "Error opening output file '$outfile': $!";
+
+        print $fh extract($archive_path);
+        close $fh;
+        $done = 1;
+        last;
+    }
+    if ($done) {
+        my $dataflow_params = {
+            species     => $species,
+            cs_version  => $self->param('cs_version'),
+            core_dbhost => $self->param('core_dbhost'),
+            core_dbport => $self->param('core_dbport'),
+            core_dbname => $self->param('core_dbname'),
+            core_dbuser => $self->param('core_dbuser'),
+            core_dbpass => $self->param('core_dbpass'),
+            alphafold_mapfile => $outfile,
+        };
+        $self->dataflow_output_id($dataflow_params, 2);
+    } else {
+        info ("No AlphaFold data found for species $species.");
+        # There is no dataflow if there is no data
+    }
+
+    return 1;
+}
+
+sub extract {
+    my $tarfile = shift;
+    my $tar  = Archive::Tar->new;
+    $tar->read($tarfile);
+    my @items = $tar->get_files;
+    my @afdb_info;
+
+    foreach my $file (@items) {
+        next unless $file->name =~ /\.pdb\.gz$/;
+
+        my $pdbgz = $file->get_content_by_ref;
+        my $unz = gunzip( $$pdbgz );
+
+        open my $pdbdata, '<', \$unz;
+
+        while (my $line = <$pdbdata>) {
+            if ($line =~ /^DBREF/) {
+                my $clean_afdb = $file->name;
+                $clean_afdb =~ s/-model_.*$//;
+                my (undef, undef, $chain, $res_beg, $res_end, undef,
+                    $sp_primary, undef, $sp_beg, $sp_end) = split(/\s+/, $line);
+
+                push(@afdb_info,{'AFDB' => $clean_afdb,
+                    'CHAIN' => $chain,
+                    'SP_PRIMARY' => $sp_primary,
+                    'RES_BEG' => $res_beg,
+                    'RES_END' => $res_end,
+                    'SP_BEG' => $sp_beg,
+                    'SP_END' => $sp_end,
+                    'SIFTS_RELEASE_DATE' => undef
+                }) unless ($sp_beg > $sp_end);
+                # Skips the entry if the start of the protein is greater than the end as we cannot display it correctly.
+
+                last;
+            }
+        }
+        close $pdbdata;
+    }
+    return encode_json(\@afdb_info);
+}
+
+# Dataflow (dataflow_output_id() happens in "sub run"
+# sub write_output {}
+
+1;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/AlphaFold/HiveLoadAlphaFoldDBProteinFeatures.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/AlphaFold/HiveLoadAlphaFoldDBProteinFeatures.pm
@@ -19,7 +19,11 @@ HiveLoadAlphaFoldDBProteinFeatures.pm
 
 =head1 DESCRIPTION
 
-This module inserts protein features into an Ensembl core database based on the AlphaFoldDB-UniProt mappings found in the EMBL-EBI AlphaFoldDB SIFTS data and the UniProt-ENSP mappings found in the GIFTS database in order to make the link between AlphaFoldDB and ENSP having a AlphaFoldDB entry as a protein feature for a given ENSP protein.
+This module inserts protein features into an Ensembl core database based on the
+AlphaFoldDB-UniProt mappings found in the EMBL-EBI AlphaFoldDB SIFTS data and
+the UniProt-ENSP mappings found in the GIFTS database in order to make the link
+between AlphaFoldDB and ENSP having a AlphaFoldDB entry as a protein feature for
+a given ENSP protein.
 
 It also populates the "pdb_ens" table in the GIFTS database with similar data.
 
@@ -45,7 +49,14 @@ It also populates the "pdb_ens" table in the GIFTS database with similar data.
 
 =head1 EXAMPLE USAGE
 
-standaloneJob.pl Bio::EnsEMBL::Production::Pipeline::AlphaFold::HiveLoadAlphaFoldDBProteinFeatures -alpha_path /hps/nobackup/flicek/ensembl/mr6/AlphaFoldDB/homo_sapiens/alpha_mappings.txt -core_dbhost genebuild3 -core_dbport 4500 -core_dbname carlos_homo_sapiens_core_89_test -core_dbuser *** -core_dbpass *** -cs_version GRCh38 -species homo_sapiens -rest_server https://www.ebi.ac.uk/gifts/api/
+standaloneJob.pl Bio::EnsEMBL::Production::Pipeline::AlphaFold::HiveLoadAlphaFoldDBProteinFeatures
+  -core_dbhost dev_host
+  -core_dbport 3xxx
+  -core_dbname homo_sapiens_core_test
+  -core_dbuser user
+  -core_dbpass pass
+  -cs_version GRCh38
+  -species homo_sapiens
 
 =cut
 
@@ -54,7 +65,6 @@ package Bio::EnsEMBL::Production::Pipeline::AlphaFold::HiveLoadAlphaFoldDBProtei
 use strict;
 use warnings;
 
-use 5.014002;
 use Bio::EnsEMBL::Analysis::Tools::Utilities;
 use parent ('Bio::EnsEMBL::Analysis::Hive::RunnableDB::HiveBaseRunnableDB');
 use Bio::EnsEMBL::Production::Pipeline::AlphaFold::MakeAlphaFoldDBProteinFeatures;
@@ -88,7 +98,7 @@ sub param_defaults {
 sub fetch_input {
   my $self = shift;
 
-  $self->param_required('alpha_path');
+  $self->param_required('alphafold_mapfile');
   $self->param_required('core_dbhost');
   $self->param_required('core_dbport');
   $self->param_required('core_dbname');
@@ -114,12 +124,12 @@ sub fetch_input {
     -analysis => new Bio::EnsEMBL::Analysis(-logic_name => 'alphafold_import',
                                             -db => 'alphafold',
                                             #-db_version => , it will be populated in the MakePDBProteinFeatures module when parsing the file
-                                            -db_file => $self->param('alpha_path'),
+                                            -db_file => $self->param('alphafold_mapfile'),
                                             -display_label => 'AlphaFoldDB import',
                                             -displayable => '1',
                                             -description => 'Protein features based on the AlphaFoldDB-UniProt mappings'),
     -core_dba => $self->hrdb_get_con("core"),
-    -alpha_path => $self->param('alpha_path'),
+    -alpha_path => $self->param('alphafold_mapfile'),
     -species => $self->param('species'),
     -cs_version => $self->param('cs_version'),
     -rest_server => $self->param('rest_server')

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Common/MetadataCSVersion.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Common/MetadataCSVersion.pm
@@ -43,7 +43,6 @@ sub run {
         'core_dbpass' => $core_dbc->pass,
         'cs_version'  => $cs_version,
         'species'     => $species,
-        'alpha_path'  => File::Spec->catfile($self->param('base_path'), $self->param('species'), 'alpha_mappings.txt')
     },
         2
     );

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/AlphaDBImport_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/AlphaDBImport_conf.pm
@@ -29,9 +29,9 @@ Bio::EnsEMBL:Production::Pipeline::PipeConfig::AlphaDBImport_conf:
 
 =head1 SYNOPSIS
 
+Creates links from a protein to the AlphaFold structure prediction in a Core database
 
 =head1 DESCRIPTION
-
 
 =cut
 
@@ -74,23 +74,12 @@ sub default_options {
     };
 }
 
-
-sub pipeline_wide_parameters {
-    my ($self) = @_;
-
-    return {
-        %{$self->SUPER::pipeline_wide_parameters},
-        rest_server => $self->o('rest_server'),
-        base_path   => $self->o('base_path')
-    }
-}
-
 sub pipeline_create_commands {
     my ($self) = @_;
+
     return [
         @{$self->SUPER::pipeline_create_commands},
-        'mkdir -p '.$self->o('pipeline_dir'),
-        'mkdir -p '.$self->o('scratch_large_dir')
+        'mkdir -p '.$self->o('scratch_large_dir'),
     ];
 }
 
@@ -99,40 +88,50 @@ sub pipeline_analyses {
 
     my @analyses = (
         {
-            -logic_name => 'load_params',
+            -logic_name => 'species_factory',
             -module     => 'Bio::EnsEMBL::Production::Pipeline::Common::SpeciesFactory',
             -input_ids  => [ {} ],
-            -flow_into  => {
-
-                '2' => [ 'metadata' ],
-            },
             -parameters => {
                 species     => $self->o('species'),
                 division    => $self->o('division'),
-                antispecies => [],
-
+                antispecies => $self->o('antispecies'),
+            },
+            -flow_into  => {
+                '2->A' => [ 'species_version' ],
+                'A->1' => [ 'cleanup' ]
             },
             -rc_name    => '4GB',
         },
         {
-            -logic_name => 'metadata',
+            -logic_name => 'species_version',
             -module     => 'Bio::EnsEMBL::Production::Pipeline::Common::MetadataCSVersion',
             -flow_into  => {
-                '2->A' => [ 'load_alphadb' ],
-                'A->1' => [ 'Datacheck' ]
+                '2' => [ 'alpha_map' ],
             },
+        },
+        {
+            -logic_name => 'alpha_map',
+            -module     => 'Bio::EnsEMBL::Production::Pipeline::AlphaFold::CreateAlphaFoldMapping',
+            -parameters => {
+                alphafold_data_dir => $self->o('alphafold_data_dir'),
+                alphafold_mapfile_dir => $self->o('scratch_large_dir'),
+            },
+            -flow_into  => {
+                '2->A' => [ 'load_alphadb' ],
+                'A->2' => [ 'datacheck' ]
+            },
+            -rc_name    => 'dm',
         },
         {
             -logic_name => 'load_alphadb',
             -module     => 'Bio::EnsEMBL::Production::Pipeline::AlphaFold::HiveLoadAlphaFoldDBProteinFeatures',
             -parameters => {
                 rest_server => $self->o('rest_server'),
-                output_path => $self->o('scratch_large_dir')
             },
             -rc_name    => '4GB',
         },
         {
-            -logic_name => 'Datacheck',
+            -logic_name => 'datacheck',
             -module     => 'Bio::EnsEMBL::DataCheck::Pipeline::RunDataChecks',
             -parameters => {
                 datacheck_names => [ 'CheckAlphafoldEntries' ],
@@ -148,8 +147,17 @@ sub pipeline_analyses {
             -max_retry_count   => 1,
             -analysis_capacity => 10,
             -parameters        => {
+                dbname        => $self->o('pipeline_db')->{'-dbname'},
                 email         => $self->o('email'),
                 pipeline_name => $self->o('pipeline_name'),
+            },
+        },
+        {
+            -logic_name        => 'cleanup',
+            -module            => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+            -max_retry_count   => 1,
+            -parameters        => {
+                cmd => 'rm -rf ' . $self->o('scratch_large_dir'),
             },
         },
     );


### PR DESCRIPTION
## Description
The AlphaFold pipeline currently uses mapping files to associate proteins in a species with the prediction data. This commit changes the pipeline to create these mapping files in a first step.
The pipeline uses scratch_large_dir, which is created at the beginning and deleted when the pipelines has finished.
Includes a dependency on Gzip::Faster. It is 8 - 10x faster than the default IO::Compress::Gzip.

## Use case

No more preparing the map files.

## Benefits

Pipeline is easier to run, less room for errors.

## Testing

Pipeline tested manually. Code has no impact on other pipelines.

Dependencies
------------
New dependency on Gzip::Faster