### PR TITLE
Init XrefAssociationAdaptor with GenomeDB adaptor DB

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/GeneTreeHighlight/HighlightGO.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/GeneTreeHighlight/HighlightGO.pm
@@ -107,7 +107,7 @@ sub run {
     my $dbc = $gdba->db()->dbc();
     my $go_parents = {};
 
-    my $xref_adaptor = Bio::EnsEMBL::Compara::DBSQL::XrefAssociationAdaptor->new($dbc);
+    my $xref_adaptor = Bio::EnsEMBL::Compara::DBSQL::XrefAssociationAdaptor->new($gdba->db());
     my @genome_dbs = grep {$_->name() ne 'ancestral_sequences'} @{$gdba->fetch_all()};
     @genome_dbs = grep {$_->name() eq $species} @genome_dbs if (defined $species);
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/GeneTreeHighlight/HighlightInterPro.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/GeneTreeHighlight/HighlightInterPro.pm
@@ -85,7 +85,7 @@ sub run {
     my $interpro_sql = $self->param_required('interpro_sql');
     my $dbc = $gdba->db()->dbc();
 
-    my $xref_adaptor = Bio::EnsEMBL::Compara::DBSQL::XrefAssociationAdaptor->new($dbc);
+    my $xref_adaptor = Bio::EnsEMBL::Compara::DBSQL::XrefAssociationAdaptor->new($gdba->db());
     my @genome_dbs = grep {$_->name() ne 'ancestral_sequences'} @{$gdba->fetch_all()};
     @genome_dbs = grep {$_->name() eq $species} @genome_dbs if (defined $species);
 


### PR DESCRIPTION
## Description

As a result of recent changes to the Ensembl Compara schema ([Compara PR #499](https://github.com/Ensembl/ensembl-compara/pull/499)), a `Compara::DBSQL::XrefAssociationAdaptor` method called in the gene-tree highlighting pipeline was executing very slowly due to an SQL query of a gene member by `stable_id`. The relevant SQL can be updated to address this issue, but the fix in `ensembl-compara` can be made simpler by updating `ensembl-production` to create `XrefAssociationAdaptor` using a `Compara::GenomeDBAdaptor->db()` object instead of `Compara::GenomeDBAdaptor->db()->dbc()`. This PR would implement that change in the `HighlightGO` and `HighlightInterPro` modules.

## Use case

In the `HighlightGO` and `HighlightInterPro` modules, the `XrefAssociationAdaptor` is initialised with the relevant `Compara::GenomeDBAdaptor->db()` object instead of the `Compara::GenomeDBAdaptor->db()->dbc()` currently used. This object would be used in the `XrefAssociationAdaptor` object to obtain the `genome_db_id` of the relevant core database, which is needed for an improved SQL query of the Compara gene member table.

## Benefits

With these changes in place, coupled with corresponding changes in Compara code, the gene-tree highlighting pipeline would run more quickly, and would be more robust in future to duplicate stable_ids.

## Possible Drawbacks

The solution implemented in this PR and the corresponding update in Compara reduces flexibility in creation of `XrefAssociationAdaptor` objects in order to `store_member_associations`.

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
