### PR TITLE
Fix issues with variation|geneset|homology subdirectories setup

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/DirectoryPaths.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/DirectoryPaths.pm
@@ -40,7 +40,7 @@ sub run {
   $self->param('species_name', $self->species_name($dba));
   $self->param('annotation_source', $self->annotation_source($dba));
   $self->param('assembly', $self->assembly($dba));
-  if ($data_category eq 'geneset') {
+  if ($data_category =~ /geneset|variation|homology/) {
     $self->param('geneset', $self->geneset($dba));
   }
 
@@ -68,8 +68,8 @@ sub write_output {
     ftp_dir         => $self->param('ftp_dir'),
     annotation_source => $self->param_required('annotation_source')
   );
-  if ($data_category eq 'geneset') {
-    $output{'geneset'} = $self->param_required('geneset');
+  if ($data_category =~ /geneset|variation|homology/) {
+    $output{'geneset'} = $self->param('geneset');
   }
 
   $self->dataflow_output_id(\%output, 3);
@@ -96,9 +96,9 @@ sub directories {
       $self->param_required("${data_category}_dirname"),
     );
   }
-  if ( grep( /^geneset|variation$/, @data_categories ) ) {
+  if ( $data_category =~ /geneset|variation|homology/ ) {
     # Variation and geneset dirs add a extra `YYYY_MM` subdir.
-    $subdirs = catdir ($subdirs, $self->param_required('geneset'))
+    $subdirs = catdir ($subdirs, $self->param('geneset'))
   }
   my $output_dir = catdir(
     $dump_dir,


### PR DESCRIPTION
- added in outputs
## Requirements

Wrong configuration manipulation for Variation/geneset directory path (able to add the YYYY_MM to the path)
Added as well for homology data category. 

## Description

FTP directory structure to include the Assembly date in the path for variation/homology/geneset paths in FTP. 

## Use case

RR FTP dumps new path layout

## Benefits

Include the right one for all use cases. 


## Possible Drawbacks

None. 

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
