### PR TITLE
Bugfix: replace release nuber in catalog before fetching

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/Base.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/Base.pm
@@ -120,8 +120,8 @@ sub download_file {
     }
 
     # Get list of files in catalog
-    my $list = get($catalog);
     $catalog =~ s/\*/$release_number/;
+    my $list = get($catalog);
     my %refseq_files = map {(split /\n/)} split /\t/, $list;
 
     while (my ($checksum, $file_name) = each %refseq_files) {


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Fixing bug with using the RefSeq catalog before replacing the release number.

## Use case

The RefSeq catalog URL contains a placeholder "*" in which the release number should be replaced to get the correct catalog. The code was trying to fetch this catalog before replacing the placeholder with the current release. This change fixes that.

## Benefits

Bugfix

## Possible Drawbacks

None

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
