### PR TITLE
Bugfix/rename dbs

### DIFF
--- a/scripts/get_new_db_name.pl
+++ b/scripts/get_new_db_name.pl
@@ -28,9 +28,13 @@ if($name =~ m/^(.*_[a-z]+_)([0-9]+)$/) {
     my $v1 = $2 + 1;
     my $v2 = $3 + 1;
     print "${1}${v1}_${v2}${4}\n";
+} elsif ($name =~  m/^(.*_compara_[a-z]+_)([0-9]+)_([0-9]+)$/) {
+    my $v1 = $2 + 1;
+    my $v2 = $3 + 1;
+    print "${1}${v1}_${v2}\n";
 } elsif($name =~ m/^(.*_[a-z]+_)([0-9]+)_([0-9]+)$/) {
     my $v1 = $2 + 1;
     print "${1}${v1}_${3}\n";
 } else {
-    print "$name\n";
+    print "4 $name\n";
 }

--- a/scripts/t/rename_db.t
+++ b/scripts/t/rename_db.t
@@ -26,9 +26,9 @@ diag("Testing DB renaming patterns ");
 
 subtest "Version upgrade", sub {
     my $file_dir = dirname(dirname(__FILE__));
-    my @in = ("ensembl_compara_109", "bacteria_109_collection_core_56_109_1", "homo_sapiens_core_109_38", "agrilus_planipennis_gca000109045v2_core_56_109_1");
+    my @in = ("ensembl_compara_109", "bacteria_109_collection_core_56_109_1", "homo_sapiens_core_109_38", "agrilus_planipennis_gca000109045v2_core_56_109_1", "ensembl_compara_protists_56_109");
     my @out = ();
-    my @expected = ("ensembl_compara_110", "bacteria_109_collection_core_57_110_1", "homo_sapiens_core_110_38", "agrilus_planipennis_gca000109045v2_core_57_110_1");
+    my @expected = ("ensembl_compara_110", "bacteria_109_collection_core_57_110_1", "homo_sapiens_core_110_38", "agrilus_planipennis_gca000109045v2_core_57_110_1", "ensembl_compara_protists_57_110");
     chdir($file_dir);
     my $script = File::Spec->catfile($file_dir, "get_new_db_name.pl");
     foreach (@in) {

--- a/scripts/t/rename_db.t
+++ b/scripts/t/rename_db.t
@@ -1,0 +1,42 @@
+# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Exception;
+use File::Spec;
+use File::Basename qw/dirname/;
+
+
+diag("Testing DB renaming patterns ");
+
+subtest "Version upgrade", sub {
+    my $file_dir = dirname(dirname(__FILE__));
+    my @in = ("ensembl_compara_109", "bacteria_109_collection_core_56_109_1", "homo_sapiens_core_109_38", "agrilus_planipennis_gca000109045v2_core_56_109_1");
+    my @out = ();
+    my @expected = ("ensembl_compara_110", "bacteria_109_collection_core_57_110_1", "homo_sapiens_core_110_38", "agrilus_planipennis_gca000109045v2_core_57_110_1");
+    chdir($file_dir);
+    my $script = File::Spec->catfile($file_dir, "get_new_db_name.pl");
+    foreach (@in) {
+        my $output = `$script $_`;
+        chomp($output);
+        push (@out, $output);
+    }
+    is_deeply(\@out, \@expected, "Same output as expected");
+};
+
+done_testing();

--- a/travisci/harness.sh
+++ b/travisci/harness.sh
@@ -12,6 +12,7 @@ if [ "$COVERALLS" = 'true' ]; then
   PERL5OPT='-MDevel::Cover=+ignore,bioperl,+ignore,ensembl-test' perl $PWD/ensembl-test/scripts/runtests.pl -verbose $PWD/modules/t $SKIP_TESTS
 else
   perl $PWD/ensembl-test/scripts/runtests.pl $PWD/modules/t $SKIP_TESTS
+  perl $PWD/ensembl-test/scripts/runtests.pl $PWD/scripts/t $SKIP_TESTS
 fi
 
 rt=$?


### PR DESCRIPTION
## Description

Rename db was not renaming the NV compara DB correctly (ensembl_compara_protists_56_109 renamed to ensembl_compara_protists_57_109). this is now fixed and added automated test for the future. 

## Use case

DBcopy pipeline used in production processes. 

## Benefits

All DB renamed and patched

## Possible Drawbacks

May be the test missed some extra cases. 

## Testing

- [x] Have you added/modified unit tests to test the changes?
- [x] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
