### PR TITLE
fix for warning msg in update_api_tarball 'tar: --exclude ‘*/.*’ has …

### DIFF
--- a/scripts/update_api_tarball.sh
+++ b/scripts/update_api_tarball.sh
@@ -51,7 +51,7 @@ for repo in $list; do
 done
 tarball=ensembl-api.tar.gz
 rm -f $tarball
-tar cvzf $tarball $list --exclude="*/.*" 
+tar cvzf $tarball --exclude="*/.*" $list
 tgt_tarball="$ftp_dir/$tarball"
 if ! cmp --silent $tarball $tgt_tarball; then
     echo "Updating $tgt_tarball"


### PR DESCRIPTION
…no effect'

**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description
tar: The following options were used after any non-optional arguments in archive create or update mode.  These options are positional and affect only arguments that follow them.  Please, rearrange them properly.
--
tar: --exclude ‘*/.*’ has no effect
tar: Exiting with failure status due to previous errors
Updating /nfs/ftp/ensemblftp//ensembl/PUBLIC/pub//ensembl-api.tar.gz

## Use case

fix for warning msg in update_api_tarball 'tar: --exclude ‘*/.*’ has no effect'

## Benefits

Avoid false error msg mail in cron execution

## Testing

Tested locally 
More info in jira: https://www.ebi.ac.uk/panda/jira/browse/ENSPROD-8562