### PR TITLE
Fixed find path for `vertebrates` division on FTP live dir.

### DIFF
--- a/scripts/assembly_converter/populate_assembly_converter_dir.sh
+++ b/scripts/assembly_converter/populate_assembly_converter_dir.sh
@@ -134,6 +134,8 @@ do
                         elif [[ "${assembly}" = 'NCBIM36' && "${dir}" = 'mus_musculus' ]]
                         then
                             file_path=`find ${src_ftp}/release-*/mus_musculus*/data/fasta/dna/ -type f -name "${dir^}.${assembly}.*.dna.seqlevel.fa.gz" | sort -r | head -n1`
+                        elif [[ $division == "vertebrates" ]]; then
+                            file_path=`find ${src_ftp}/release-*/fasta/${dir}/dna/ -type f -name "${dir^}.${assembly}.*.dna.toplevel.fa.gz" -o -name "${dir^}.${assembly}.dna.toplevel.fa.gz" | sort -r | head -n1`
                         else
                             file_path=`find ${src_ftp}/release-*/${division}/fasta/${dir}/dna/ -type f -name "${dir^}.${assembly}.*.dna.toplevel.fa.gz" -o -name "${dir^}.${assembly}.dna.toplevel.fa.gz" | sort -r | head -n1`
                         fi


### PR DESCRIPTION
## Description

Fixes wrong FTP target path for vertebrates ({division} sub directory doesn't exist for vertebrates)

## Use case

Assembly converter files generation for release.

## Benefits

No more file not found

## Possible Drawbacks

None 

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
