### PR TITLE
Keep specific caution comment in uniprot file

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/CleanupUniprot.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/CleanupUniprot.pm
@@ -112,7 +112,9 @@ sub run {
       while ($_ = $in_fh->getline()) {
         # Remove unused data
         $_ =~ s/\nR(N|P|X|A|T|R|L|C|G)\s{3}.*//g; # Remove references lines
+	$_ =~ s/\nCC(\s{3}.*)CAUTION: The sequence shown here is derived from an Ensembl(.*)/\nCT$1CAUTION: The sequence shown here is derived from an Ensembl$2/g; # Set specific caution comment to temporary
         $_ =~ s/\nCC\s{3}.*//g; # Remove comments
+        $_ =~ s/\nCT(\s{3}.*)CAUTION: The sequence shown here is derived from an Ensembl(.*)/\nCC$1CAUTION: The sequence shown here is derived from an Ensembl$2/g; # Set temp line back to comment
 	$_ =~ s/\nFT\s{3}.*//g; # Remove feature coordinates
         $_ =~ s/\nDR\s{3}($sources_to_remove);.*\n//g; # Remove sources skipped at processing
 


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Fixing a bug that was discovered in the Uniprot cleanup code

## Use case

When the cleanup code was first added, all comments (lines tarting with CC) were removed form the Uniprot files. However, it was recently noticed that the Uniprot parser file does check if a certain comment in available ([this line](https://github.com/Ensembl/ensembl-production/blob/main/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/Parser/UniProtDatabaseParser.pm#L114)). 
To handle that, the cleanup code was edited to keep this specific comment line if found.
This bug hasn't affected any releases since the Uniprot cleanup was introduced, since this caution comment line hasn't been present in any of the Uniprot files since then.

## Benefits

Fixing a bug that might affect future pipeline runs

## Possible Drawbacks

None

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
