### PR TITLE
Integrate GeneMemberHomologyStats into LoadFamily

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/LoadFamily_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/LoadFamily_conf.pm
@@ -22,6 +22,8 @@ package Bio::EnsEMBL::Production::Pipeline::PipeConfig::LoadFamily_conf;
 use strict;
 use warnings;
 
+use Bio::EnsEMBL::Compara::PipeConfig::Parts::GeneMemberHomologyStats;
+
 use base ('Bio::EnsEMBL::Production::Pipeline::PipeConfig::Base_conf');
 
 sub default_options {
@@ -59,8 +61,9 @@ sub pipeline_analyses {
                       logic_names  => $self->o('logic_names')                          
                      },
       -flow_into  => {
-                      2 => ['add_members'],
-                     },
+          '2->A'  => [ 'add_members' ],
+          'A->8'  => [ 'stats_families' ],
+      },
     },
     {
       -logic_name => 'add_members',
@@ -71,6 +74,7 @@ sub pipeline_analyses {
                      },
       -analysis_capacity => 20,
     },
+    @{ Bio::EnsEMBL::Compara::PipeConfig::Parts::GeneMemberHomologyStats::pipeline_analyses_fam_stats($self) },
   ];
 }
 


### PR DESCRIPTION
## Description

This PR integrates the Compara `GeneMemberHomologyStats` pipeline part into the Production `LoadFamily` pipeline.

## Use case

Currently two pipelines - `LoadFamily` and `EG::GeneMemberHomologyStats` - need to be run on each division for which InterPro Families are being generated. The integration of the latter pipeline into the former has the potential to streamline this process.

## Benefits

Instead of running two separate `LoadFamily` and `EG::GeneMemberHomologyStats` pipelines, it would be possible to run just one `LoadFamily` pipeline including the functionality of the integrated `GeneMemberHomologyStats` pipeline part.

## Possible Drawbacks

No drawbacks anticipated.
## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

No unit tests have been added or modified. However, a test pipeline has been initialised to confirm that the `GeneMemberHomologyStats` pipeline has been integrated correctly: `mysql://ensro@mysql-ens-compara-prod-9:4647/twalsh_dev_load_family_protists_example`

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.

With the changes in this PR, the `LoadFamily` pipeline would depend on the `Bio::EnsEMBL::Compara::PipeConfig::Parts::GeneMemberHomologyStats` pipeline part.
