### PR TITLE
Updated entries for obsolete TIGRfam being replaced by NCBIfam in int…

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProteinFeatures_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProteinFeatures_conf.pm
@@ -188,11 +188,11 @@ sub default_options {
         ipscan_lookup   => 1,
       },
       {
-        logic_name      => 'tigrfam',
-        db              => 'TIGRfam',
+        logic_name      => 'ncbifam',
+        db              => 'NCBIfam',
         program         => 'InterProScan',
-        ipscan_name     => 'TIGRFAM',
-        ipscan_xml      => 'TIGRFAM',
+        ipscan_name     => 'NCBIfam',
+        ipscan_xml      => 'NCBIfam',
         ipscan_lookup   => 1,
       },
       {


### PR DESCRIPTION
…eproscan.

## Description

Following retirement of TIGRFAM in favour of NCBIfam in latest version of interproscan, we need to update our pipeline to include those in replacement. 

## Use case

Protein Features run for 111 release. 
entry added to production DB 
![image](https://github.com/Ensembl/ensembl-production/assets/611039/b97ce674-5214-48f7-bce2-1b1f2e0b0f62)


## Benefits

We do import those. 

## Possible Drawbacks

Side effects potential on Xref. Notifice @ens-infraslackbot  about this. 
Accession will change from TIGRFAM accession (TIGR[0-9]+) to NCBIfam-specific model accessions (NF[0-9]+)

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
