### PR TITLE
Added a failure if gzip fails to complete properly

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Common/Gzip.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Common/Gzip.pm
@@ -17,7 +17,7 @@ limitations under the License.
 
 =head1 NAME
 
- Bio::EnsEMBL::Production::Pipeline::TSV::Gzip;
+ Bio::EnsEMBL::Production::Pipeline::Common::Gzip;
 
 =head1 DESCRIPTION
 
@@ -28,11 +28,11 @@ A simple script for gzipping files and catching errors
  ckong@ebi.ac.uk 
 
 =cut
-package Bio::EnsEMBL::Production::Pipeline::TSV::Gzip;;
+package Bio::EnsEMBL::Production::Pipeline::Common::Gzip;;
 
 use strict;
 use warnings;
-use base qw/Bio::EnsEMBL::Production::Pipeline::TSV::Base/;
+use base qw/Bio::EnsEMBL::Production::Pipeline::Common::Base/;
 use IO::Compress::Gzip qw(gzip $GzipError) ;
 
 sub fetch_input {

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Common/Gzip.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Common/Gzip.pm
@@ -42,20 +42,22 @@ return;
 
 sub run {
     my ($self) = @_;
-    my @compress = @{$self->param_required('compress')};
-
-    foreach my $file (@compress) {
-        my $output_file = $file.'.gz';
-        eval {
-            local $SIG{PIPE} = sub { die "gzip interrupted by SIGPIPE\n" };
-            gzip $file => $output_file
-                or die "gzip failed: $GzipError\n";
-            unlink $file;
-        };
-        if ($@) {
-            print "Error compressing '$file': $@\n";
-        } else {
-            print "Compressed '$file' to '$output_file' and removed the original file\n";
+    my @compress = @{$self->param('compress')};
+    if ($self->param_exists('compress')){
+        foreach my $file (@compress) {
+            my $output_file = $file . '.gz';
+            eval {
+                local $SIG{PIPE} = sub {die "gzip interrupted by SIGPIPE\n"};
+                gzip $file => $output_file
+                    or die "gzip failed: $GzipError\n";
+                unlink $file;
+            };
+            if ($@) {
+                print "Error compressing '$file': $@\n";
+            }
+            else {
+                print "Compressed '$file' to '$output_file' and removed the original file\n";
+            }
         }
     }
 return;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Common/Gzip.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Common/Gzip.pm
@@ -42,22 +42,19 @@ return;
 
 sub run {
     my ($self) = @_;
-    my @compress = @{$self->param('compress')};
-    if ($self->param_exists('compress')){
-        foreach my $file (@compress) {
-            my $output_file = $file . '.gz';
-            eval {
-                local $SIG{PIPE} = sub {die "gzip interrupted by SIGPIPE\n"};
-                gzip $file => $output_file
-                    or die "gzip failed: $GzipError\n";
-                unlink $file;
-            };
-            if ($@) {
-                print "Error compressing '$file': $@\n";
-            }
-            else {
-                print "Compressed '$file' to '$output_file' and removed the original file\n";
-            }
+    my @compress = @{$self->param_required('compress')};
+    foreach my $file (@compress) {
+        my $output_file = $file.'.gz';
+        eval {
+            local $SIG{PIPE} = sub { die "gzip interrupted by SIGPIPE\n" };
+            gzip $file => $output_file
+                or die "gzip failed: $GzipError\n";
+            unlink $file;
+        };
+        if ($@) {
+            print "Error compressing '$file': $@\n";
+        } else {
+            print "Compressed '$file' to '$output_file' and removed the original file\n";
         }
     }
 return;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Flatfile/DumpFile.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Flatfile/DumpFile.pm
@@ -149,7 +149,7 @@ sub run {
   }
   unless (@compress == 0) {
     $self->dataflow_output_id(
-        { "compress" => [ @compress ] }, 4);
+        { "compress" => \@compress  }, 4);
   }
   $self->_create_README();
   $self->core_dbc()->disconnect_if_idle();  

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Flatfile/DumpFile.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Flatfile/DumpFile.pm
@@ -147,7 +147,8 @@ sub run {
       return;
     });
   }
-  $self->param('compress', \@compress);
+  $self->dataflow_output_id(
+              { "compress" => @compress }, 1);
   $self->_create_README();
   $self->core_dbc()->disconnect_if_idle();  
   $self->hive_dbc()->disconnect_if_idle();  

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Flatfile/DumpFile.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Flatfile/DumpFile.pm
@@ -147,7 +147,7 @@ sub run {
       return;
     });
   }
-  unless (@compress == []) {
+  unless (@compress == 0) {
     $self->dataflow_output_id(
         { "compress" => [ @compress ] }, 1);
   }

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Flatfile/DumpFile.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Flatfile/DumpFile.pm
@@ -147,8 +147,10 @@ sub run {
       return;
     });
   }
-  $self->dataflow_output_id(
-              { "compress" => [@compress] }, 1);
+  unless (@compress == []) {
+    $self->dataflow_output_id(
+        { "compress" => [ @compress ] }, 1);
+  }
   $self->_create_README();
   $self->core_dbc()->disconnect_if_idle();  
   $self->hive_dbc()->disconnect_if_idle();  

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Flatfile/DumpFile.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Flatfile/DumpFile.pm
@@ -147,9 +147,10 @@ sub run {
       return;
     });
   }
+  unless (@compress == 0) {
     $self->dataflow_output_id(
-        { "compress" => [ @compress ] }, 1);
-
+        { "compress" => [ @compress ] }, 4);
+  }
   $self->_create_README();
   $self->core_dbc()->disconnect_if_idle();  
   $self->hive_dbc()->disconnect_if_idle();  

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Flatfile/DumpFile.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Flatfile/DumpFile.pm
@@ -147,10 +147,9 @@ sub run {
       return;
     });
   }
-  unless (@compress == 0) {
     $self->dataflow_output_id(
         { "compress" => [ @compress ] }, 1);
-  }
+
   $self->_create_README();
   $self->core_dbc()->disconnect_if_idle();  
   $self->hive_dbc()->disconnect_if_idle();  

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Flatfile/DumpFile.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Flatfile/DumpFile.pm
@@ -111,7 +111,8 @@ sub run {
     push(@chromosomes, $s) if $chr;
     push(@non_chromosomes, $s) if ! $chr;
   }
-  
+  my @compress = ();
+
   if(@non_chromosomes) {
     my $path = $self->_generate_file_name('nonchromosomal');
     $self->info('Dumping non-chromosomal data to %s', $path);
@@ -123,12 +124,11 @@ sub run {
       }
       return;
     });
-    $self->run_cmd("gzip -n $path");
+    push (@compress, $path);
   } else {
     $self->info('Did not find any non-chromosomal data');
   }
   
-  my @compress = ();
   foreach my $slice (@chromosomes) {
     $self->fine('Dumping chromosome %s', $slice->name());
     my $path = $self->_generate_file_name($slice->coord_system_name(), $slice->seq_region_name());
@@ -147,8 +147,8 @@ sub run {
       return;
     });
   }
-  
-  map { $self->run_cmd("gzip -n $_") } @compress;
+  $self->param('compress', \@compress);
+  $self->dataflow_output_id($self->param('compress'), 1);
 
   $self->_create_README();
   $self->core_dbc()->disconnect_if_idle();  

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Flatfile/DumpFile.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Flatfile/DumpFile.pm
@@ -148,8 +148,6 @@ sub run {
     });
   }
   $self->param('compress', \@compress);
-  $self->dataflow_output_id($self->param('compress'), 1);
-
   $self->_create_README();
   $self->core_dbc()->disconnect_if_idle();  
   $self->hive_dbc()->disconnect_if_idle();  

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Flatfile/DumpFile.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Flatfile/DumpFile.pm
@@ -148,7 +148,7 @@ sub run {
     });
   }
   $self->dataflow_output_id(
-              { "compress" => @compress }, 1);
+              { "compress" => [@compress] }, 1);
   $self->_create_README();
   $self->core_dbc()->disconnect_if_idle();  
   $self->hive_dbc()->disconnect_if_idle();  

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_conf.pm
@@ -594,7 +594,6 @@ sub pipeline_analyses {
             },
             -hive_capacity => 50,
             -rc_name       => '2GB',
-            -flow_into  => 'compress_file'
         },
 
         { -logic_name      => 'tsv_refseq',
@@ -605,7 +604,6 @@ sub pipeline_analyses {
             },
             -hive_capacity => 50,
             -rc_name       => '2GB',
-            -flow_into  => 'compress_file'
         },
 
         { -logic_name      => 'tsv_entrez',
@@ -616,7 +614,6 @@ sub pipeline_analyses {
             },
             -hive_capacity => 50,
             -rc_name       => '2GB',
-            -flow_into  => 'compress_file'
         },
 
 
@@ -624,15 +621,12 @@ sub pipeline_analyses {
             -module        => 'Bio::EnsEMBL::Production::Pipeline::TSV::DumpFileEna',
             -hive_capacity => 50,
             -rc_name       => '2GB',
-             -flow_into  => 'compress_file'
         },
 
         { -logic_name      => 'tsv_metadata',
             -module        => 'Bio::EnsEMBL::Production::Pipeline::TSV::DumpFileMetadata',
             -hive_capacity => 50,
             -rc_name       => '2GB',
-            -flow_into  => 'compress_file'
-
         },
         { -logic_name      => 'compress_file',
             -module        => 'Bio::EnsEMBL::Production::Pipeline::Common::Gzip',

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_conf.pm
@@ -635,7 +635,7 @@ sub pipeline_analyses {
 
         },
         { -logic_name      => 'compress_file',
-            -module        => 'Bio::EnsEMBL::Production::Pipeline::COMMON::Gzip',
+            -module        => 'Bio::EnsEMBL::Production::Pipeline::Common::Gzip',
             -hive_capacity => 50,
             -rc_name       => '4GB',
         },

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_conf.pm
@@ -364,7 +364,7 @@ sub pipeline_analyses {
             -hive_capacity => 50,
             -rc_name       => '4GB',
             -flow_into     => { '-1' => 'embl_32GB',
-                                 '1' => 'compress_file' },
+                                 '4' => 'compress_file' },
         },
 
         { -logic_name      => 'embl_32GB',
@@ -373,7 +373,7 @@ sub pipeline_analyses {
             -hive_capacity => 50,
             -rc_name       => '32GB',
             -flow_into     => { '-1' => 'embl_64GB',
-                                 '1' => 'compress_file' },
+                                 '4' => 'compress_file' },
 
         },
 
@@ -383,7 +383,7 @@ sub pipeline_analyses {
             -hive_capacity => 50,
             -rc_name       => '64GB',
             -flow_into     => { '-1' => 'embl_128GB',
-                                 '1' => 'compress_file' },
+                                 '4' => 'compress_file' },
         },
 
         { -logic_name      => 'embl_128GB',
@@ -391,7 +391,7 @@ sub pipeline_analyses {
             -parameters    => { type => 'embl', },
             -hive_capacity => 50,
             -rc_name       => '128GB',
-            -flow_into => { '1' => 'compress_file' },
+            -flow_into => { '4' => 'compress_file' },
         },
 
         ### GENBANK
@@ -401,7 +401,7 @@ sub pipeline_analyses {
             -hive_capacity => 50,
             -rc_name       => '4GB',
             -flow_into     => { -1 => 'genbank_32GB',
-                                '1' => 'compress_file' },
+                                '4' => 'compress_file' },
         },
 
         { -logic_name      => 'genbank_32GB',
@@ -410,7 +410,7 @@ sub pipeline_analyses {
             -hive_capacity => 50,
             -rc_name       => '32GB',
             -flow_into     => { -1 => 'genbank_64GB',
-                                 '1' => 'compress_file' },
+                                 '4' => 'compress_file' },
         },
 
         { -logic_name      => 'genbank_64GB',
@@ -419,7 +419,7 @@ sub pipeline_analyses {
             -hive_capacity => 50,
             -rc_name       => '64GB',
             -flow_into     => { -1 => 'genbank_128GB', 
-                                '1' => 'compress_file' },
+                                '4' => 'compress_file' },
         },
 
         { -logic_name      => 'genbank_128GB',
@@ -427,7 +427,7 @@ sub pipeline_analyses {
             -parameters    => { type => 'genbank', },
             -hive_capacity => 50,
             -rc_name       => '128GB',
-            -flow_into => { '1' => 'compress_file' },
+            -flow_into => { '4' => 'compress_file' },
         },
 
         ### FASTA (cdna, cds, dna, pep, ncrna)
@@ -594,7 +594,7 @@ sub pipeline_analyses {
             },
             -hive_capacity => 50,
             -rc_name       => '2GB',
-            -flow_into  => 'compress_file'
+            -flow_into  => { '4' => 'compress_file', },
         },
 
         { -logic_name      => 'tsv_refseq',
@@ -605,7 +605,7 @@ sub pipeline_analyses {
             },
             -hive_capacity => 50,
             -rc_name       => '2GB',
-            -flow_into  => 'compress_file'
+            -flow_into  => { '4' => 'compress_file', },
         },
 
         { -logic_name      => 'tsv_entrez',
@@ -616,7 +616,7 @@ sub pipeline_analyses {
             },
             -hive_capacity => 50,
             -rc_name       => '2GB',
-            -flow_into  => 'compress_file'
+            -flow_into  => { '4' => 'compress_file', },
         },
 
 
@@ -624,14 +624,14 @@ sub pipeline_analyses {
             -module        => 'Bio::EnsEMBL::Production::Pipeline::TSV::DumpFileEna',
             -hive_capacity => 50,
             -rc_name       => '2GB',
-             -flow_into  => 'compress_file'
+            -flow_into  => { '4' => 'compress_file', },
         },
 
         { -logic_name      => 'tsv_metadata',
             -module        => 'Bio::EnsEMBL::Production::Pipeline::TSV::DumpFileMetadata',
             -hive_capacity => 50,
             -rc_name       => '2GB',
-            -flow_into  => 'compress_file'
+            -flow_into  => { '4' => 'compress_file', },
 
         },
         { -logic_name      => 'compress_file',

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_conf.pm
@@ -594,6 +594,7 @@ sub pipeline_analyses {
             },
             -hive_capacity => 50,
             -rc_name       => '2GB',
+            -flow_into  => 'compress_file'
         },
 
         { -logic_name      => 'tsv_refseq',
@@ -604,6 +605,7 @@ sub pipeline_analyses {
             },
             -hive_capacity => 50,
             -rc_name       => '2GB',
+            -flow_into  => 'compress_file'
         },
 
         { -logic_name      => 'tsv_entrez',
@@ -614,6 +616,7 @@ sub pipeline_analyses {
             },
             -hive_capacity => 50,
             -rc_name       => '2GB',
+            -flow_into  => 'compress_file'
         },
 
 
@@ -621,12 +624,15 @@ sub pipeline_analyses {
             -module        => 'Bio::EnsEMBL::Production::Pipeline::TSV::DumpFileEna',
             -hive_capacity => 50,
             -rc_name       => '2GB',
+             -flow_into  => 'compress_file'
         },
 
         { -logic_name      => 'tsv_metadata',
             -module        => 'Bio::EnsEMBL::Production::Pipeline::TSV::DumpFileMetadata',
             -hive_capacity => 50,
             -rc_name       => '2GB',
+            -flow_into  => 'compress_file'
+
         },
         { -logic_name      => 'compress_file',
             -module        => 'Bio::EnsEMBL::Production::Pipeline::Common::Gzip',

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_conf.pm
@@ -363,7 +363,8 @@ sub pipeline_analyses {
             -parameters    => { type => 'embl', },
             -hive_capacity => 50,
             -rc_name       => '4GB',
-            -flow_into     => { '-1' => 'embl_32GB', },
+            -flow_into     => { '-1' => 'embl_32GB',
+                                 '1' => 'compress_file' },
         },
 
         { -logic_name      => 'embl_32GB',
@@ -371,7 +372,9 @@ sub pipeline_analyses {
             -parameters    => { type => 'embl', },
             -hive_capacity => 50,
             -rc_name       => '32GB',
-            -flow_into     => { '-1' => 'embl_64GB', },
+            -flow_into     => { '-1' => 'embl_64GB',
+                                 '1' => 'compress_file' },
+
         },
 
         { -logic_name      => 'embl_64GB',
@@ -379,7 +382,8 @@ sub pipeline_analyses {
             -parameters    => { type => 'embl', },
             -hive_capacity => 50,
             -rc_name       => '64GB',
-            -flow_into     => { '-1' => 'embl_128GB', },
+            -flow_into     => { '-1' => 'embl_128GB',
+                                 '1' => 'compress_file' },
         },
 
         { -logic_name      => 'embl_128GB',
@@ -387,6 +391,7 @@ sub pipeline_analyses {
             -parameters    => { type => 'embl', },
             -hive_capacity => 50,
             -rc_name       => '128GB',
+            -flow_into => { '1' => 'compress_file' },
         },
 
         ### GENBANK
@@ -395,7 +400,8 @@ sub pipeline_analyses {
             -parameters    => { type => 'genbank', },
             -hive_capacity => 50,
             -rc_name       => '4GB',
-            -flow_into     => { -1 => 'genbank_32GB', },
+            -flow_into     => { -1 => 'genbank_32GB',
+                                '1' => 'compress_file' },
         },
 
         { -logic_name      => 'genbank_32GB',
@@ -403,7 +409,8 @@ sub pipeline_analyses {
             -parameters    => { type => 'genbank', },
             -hive_capacity => 50,
             -rc_name       => '32GB',
-            -flow_into     => { -1 => 'genbank_64GB', },
+            -flow_into     => { -1 => 'genbank_64GB',
+                                 '1' => 'compress_file' },
         },
 
         { -logic_name      => 'genbank_64GB',
@@ -411,7 +418,8 @@ sub pipeline_analyses {
             -parameters    => { type => 'genbank', },
             -hive_capacity => 50,
             -rc_name       => '64GB',
-            -flow_into     => { -1 => 'genbank_128GB', },
+            -flow_into     => { -1 => 'genbank_128GB', 
+                                '1' => 'compress_file' },
         },
 
         { -logic_name      => 'genbank_128GB',
@@ -419,6 +427,7 @@ sub pipeline_analyses {
             -parameters    => { type => 'genbank', },
             -hive_capacity => 50,
             -rc_name       => '128GB',
+            -flow_into => { '1' => 'compress_file' },
         },
 
         ### FASTA (cdna, cds, dna, pep, ncrna)
@@ -585,7 +594,7 @@ sub pipeline_analyses {
             },
             -hive_capacity => 50,
             -rc_name       => '2GB',
-            -flow_into  => 'compress_tsv'
+            -flow_into  => 'compress_file'
         },
 
         { -logic_name      => 'tsv_refseq',
@@ -596,7 +605,7 @@ sub pipeline_analyses {
             },
             -hive_capacity => 50,
             -rc_name       => '2GB',
-            -flow_into  => 'compress_tsv'
+            -flow_into  => 'compress_file'
         },
 
         { -logic_name      => 'tsv_entrez',
@@ -607,7 +616,7 @@ sub pipeline_analyses {
             },
             -hive_capacity => 50,
             -rc_name       => '2GB',
-            -flow_into  => 'compress_tsv'
+            -flow_into  => 'compress_file'
         },
 
 
@@ -615,18 +624,18 @@ sub pipeline_analyses {
             -module        => 'Bio::EnsEMBL::Production::Pipeline::TSV::DumpFileEna',
             -hive_capacity => 50,
             -rc_name       => '2GB',
-             -flow_into  => 'compress_tsv'
+             -flow_into  => 'compress_file'
         },
 
         { -logic_name      => 'tsv_metadata',
             -module        => 'Bio::EnsEMBL::Production::Pipeline::TSV::DumpFileMetadata',
             -hive_capacity => 50,
             -rc_name       => '2GB',
-            -flow_into  => 'compress_tsv'
+            -flow_into  => 'compress_file'
 
         },
-        { -logic_name      => 'compress_tsv',
-            -module        => 'Bio::EnsEMBL::Production::Pipeline::TSV::Gzip',
+        { -logic_name      => 'compress_file',
+            -module        => 'Bio::EnsEMBL::Production::Pipeline::COMMON::Gzip',
             -hive_capacity => 50,
             -rc_name       => '4GB',
         },

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpCore_conf.pm
@@ -585,6 +585,7 @@ sub pipeline_analyses {
             },
             -hive_capacity => 50,
             -rc_name       => '2GB',
+            -flow_into  => 'compress_tsv'
         },
 
         { -logic_name      => 'tsv_refseq',
@@ -595,6 +596,7 @@ sub pipeline_analyses {
             },
             -hive_capacity => 50,
             -rc_name       => '2GB',
+            -flow_into  => 'compress_tsv'
         },
 
         { -logic_name      => 'tsv_entrez',
@@ -605,6 +607,7 @@ sub pipeline_analyses {
             },
             -hive_capacity => 50,
             -rc_name       => '2GB',
+            -flow_into  => 'compress_tsv'
         },
 
 
@@ -612,12 +615,20 @@ sub pipeline_analyses {
             -module        => 'Bio::EnsEMBL::Production::Pipeline::TSV::DumpFileEna',
             -hive_capacity => 50,
             -rc_name       => '2GB',
+             -flow_into  => 'compress_tsv'
         },
 
         { -logic_name      => 'tsv_metadata',
             -module        => 'Bio::EnsEMBL::Production::Pipeline::TSV::DumpFileMetadata',
             -hive_capacity => 50,
             -rc_name       => '2GB',
+            -flow_into  => 'compress_tsv'
+
+        },
+        { -logic_name      => 'compress_tsv',
+            -module        => 'Bio::EnsEMBL::Production::Pipeline::TSV::Gzip',
+            -hive_capacity => 50,
+            -rc_name       => '4GB',
         },
 
     ];

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FileDumpMySQL_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FileDumpMySQL_conf.pm
@@ -201,14 +201,13 @@ sub pipeline_analyses {
         },
         {
             -logic_name        => 'MySQL_Compress',
-            -module            => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+            -module            => 'Bio::EnsEMBL::Production::Pipeline::Common::Gzip',
             -max_retry_count   => 1,
             -analysis_capacity => 10,
             -batch_size        => 10,
             -parameters        => {
-                cmd => 'gzip -n -f "#output_filename#"',
+                compress => "#output_filename#",
             },
-            -rc_name           => '1GB',
         },
         {
             -logic_name        => 'Checksum',

--- a/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFile.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFile.pm
@@ -58,11 +58,11 @@ sub run {
     my @compress;
     $self->info( "Starting tsv dump for " . $self->param('species'));
     $self->_write_tsv();
+    $self->param('compress', @compress);
     $self->_create_README();
     $self->info( "Completed tsv dump for " . $self->param('species'));
     $self->dbc()->disconnect_if_idle();
-    $self->param('compress', @compress);
-    $self->dataflow_output_id($self->param('compress'), 1);
+    $self->dataflow_output_id($self->param('compress'), 1)
 return;
 }
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFile.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFile.pm
@@ -117,12 +117,6 @@ sub _write_tsv {
   }#slice 
   close $fh; 
   $self->core_dbc()->disconnect_if_idle();
-  $self->info( "Compressing tsv dump for " . $self->param('species'));
-  my $unzip_out_file = $out_file;
-  `gzip -n $unzip_out_file`;
-
-  if (-e $unzip_out_file) { `rm $unzip_out_file`; }
-
 return;
 }
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFile.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFile.pm
@@ -58,11 +58,11 @@ sub run {
     my @compress;
     $self->info( "Starting tsv dump for " . $self->param('species'));
     $self->_write_tsv();
-    $self->param('compress', @compress);
     $self->_create_README();
     $self->info( "Completed tsv dump for " . $self->param('species'));
     $self->dbc()->disconnect_if_idle();
-    $self->dataflow_output_id($self->param('compress'), 1)
+    $self->param('compress', @compress);
+    $self->dataflow_output_id($self->param('compress'), 1);
 return;
 }
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFile.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFile.pm
@@ -55,12 +55,14 @@ return;
 
 sub run {
     my ($self) = @_;
-
+    my @compress;
     $self->info( "Starting tsv dump for " . $self->param('species'));
     $self->_write_tsv();
+    $self->param('compress', @compress);
     $self->_create_README();
     $self->info( "Completed tsv dump for " . $self->param('species'));
     $self->dbc()->disconnect_if_idle();
+    $self->dataflow_output_id($self->param('compress'), 1)
 return;
 }
 
@@ -115,7 +117,8 @@ sub _write_tsv {
          }#transcript
       }#gene
   }#slice 
-  close $fh; 
+  close $fh;
+  push (@compress,$out_file);
   $self->core_dbc()->disconnect_if_idle();
 return;
 }

--- a/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFile.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFile.pm
@@ -55,14 +55,11 @@ return;
 
 sub run {
     my ($self) = @_;
-    my @compress;
     $self->info( "Starting tsv dump for " . $self->param('species'));
     $self->_write_tsv();
-    $self->param('compress', @compress);
     $self->_create_README();
     $self->info( "Completed tsv dump for " . $self->param('species'));
     $self->dbc()->disconnect_if_idle();
-    $self->dataflow_output_id($self->param('compress'), 1)
 return;
 }
 
@@ -118,7 +115,6 @@ sub _write_tsv {
       }#gene
   }#slice 
   close $fh;
-  push (@compress,$out_file);
   $self->core_dbc()->disconnect_if_idle();
 return;
 }

--- a/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileEna.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileEna.pm
@@ -54,7 +54,6 @@ sub run {
     $self->_create_README();
     $self->info( "Completed ENA tsv dump for " . $self->param('species'));
     $self->cleanup_DBAdaptor();
-    $self->dataflow_output_id($self->param('compress'), 1)
 return;
 }
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileEna.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileEna.pm
@@ -122,7 +122,7 @@ sub _write_tsv {
 
     if ($xrefs_exist == 1) {
         $self->dataflow_output_id(
-            { "compress" => [ $out_file ] }, 1);
+            { "compress" => [ $out_file ] }, 4);
     }else{
       unlink $out_file  or die "failed to delete $out_file!";
     }

--- a/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileEna.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileEna.pm
@@ -125,7 +125,6 @@ sub _write_tsv {
     }else {
       push(@compress, $out_file);
       $self->param('compress', @compress);
-      $self->dataflow_output_id($self->param('compress'), 1);
     }
 return;
 }

--- a/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileEna.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileEna.pm
@@ -63,7 +63,7 @@ return;
 #############
 sub _write_tsv {
     my ($self) = @_;
-
+    my @compress;
     my $out_file  = $self->_generate_file_name();
     my $header    = $self->_build_headers();   
 
@@ -124,7 +124,9 @@ sub _write_tsv {
     if ($xrefs_exist != 1) {
       unlink $out_file  or die "failed to delete $out_file!";
     }else {
-        push (@compress,$out_file);
+      push(@compress, $out_file);
+      $self->param('compress', @compress);
+      $self->dataflow_output_id($self->param('compress'), 1);
     }
 return;
 }

--- a/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileEna.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileEna.pm
@@ -47,13 +47,13 @@ sub param_defaults {
 
 sub run {
     my ($self) = @_;
-    my @compress;
+
     $self->info( "Starting ENA tsv dump for " . $self->param('species'));
     $self->_write_tsv();
-    $self->param('compress', @compress);
     $self->_create_README();
     $self->info( "Completed ENA tsv dump for " . $self->param('species'));
     $self->cleanup_DBAdaptor();
+
 return;
 }
 
@@ -62,9 +62,9 @@ return;
 #############
 sub _write_tsv {
     my ($self) = @_;
-    my @compress;
+
     my $out_file  = $self->_generate_file_name();
-    my $header    = $self->_build_headers();   
+    my $header    = $self->_build_headers();
 
     open my $fh, '>', $out_file or die "cannot open $out_file for writing!";
     print $fh join ("\t", @$header);
@@ -107,8 +107,8 @@ sub _write_tsv {
         if(!defined $row->[5]){
 	   $row->[5] = $self->_find_contig($ta, $contig_ids, $row->[3] );
         } elsif( !defined $row->[6] && defined $row->[4]){
-	   $row->[6] = $cds2acc->{$row->[4]}; 
- 	} 
+	   $row->[6] = $cds2acc->{$row->[4]};
+ 	}
 
 	if (defined $row->[5]) {
             $row->[5] =~ s/\.[0-9]+$//;
@@ -120,12 +120,13 @@ sub _write_tsv {
     }
     close $fh;
 
-    if ($xrefs_exist != 1) {
+    if ($xrefs_exist == 1) {
+        $self->dataflow_output_id(
+            { "compress" => [ $out_file ] }, 1);
+    }else{
       unlink $out_file  or die "failed to delete $out_file!";
-    }else {
-      push(@compress, $out_file);
-      $self->param('compress', @compress);
     }
+
 return;
 }
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileEna.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileEna.pm
@@ -47,13 +47,14 @@ sub param_defaults {
 
 sub run {
     my ($self) = @_;
-
+    my @compress;
     $self->info( "Starting ENA tsv dump for " . $self->param('species'));
     $self->_write_tsv();
+    $self->param('compress', @compress);
     $self->_create_README();
     $self->info( "Completed ENA tsv dump for " . $self->param('species'));
     $self->cleanup_DBAdaptor();
-
+    $self->dataflow_output_id($self->param('compress'), 1)
 return;
 }
 
@@ -122,8 +123,9 @@ sub _write_tsv {
 
     if ($xrefs_exist != 1) {
       unlink $out_file  or die "failed to delete $out_file!";
+    }else {
+        push (@compress,$out_file);
     }
-
 return;
 }
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileEna.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileEna.pm
@@ -120,12 +120,7 @@ sub _write_tsv {
     }
     close $fh;
 
-    if ($xrefs_exist == 1) {
-      $self->info( "Compressing ENA tsv dump for " . $self->param('species'));
-      my $unzip_out_file = $out_file;
-      `gzip -n $unzip_out_file`;
-    } else {
-      # If we have no xrefs, delete the file (which will just have a header).
+    if ($xrefs_exist != 1) {
       unlink $out_file  or die "failed to delete $out_file!";
     }
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileMetadata.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileMetadata.pm
@@ -70,18 +70,18 @@ return;
 
 sub run {
   my ($self) = @_;
+
   $self->_make_karyotype_file();
+
 return;
 }
 
 sub _make_karyotype_file {
-   my @compress;
-
     my ($self) = @_;
 
     my $sp = $self->param_required('species');
     my $sa = Bio::EnsEMBL::Registry->get_adaptor($sp, 'core', 'slice');
-   
+
     if(! $sa) {
         $self->info("Cannot continue as we cannot find a core:slice DBAdaptor for %s", $sp);
         return;
@@ -92,11 +92,8 @@ sub _make_karyotype_file {
     my $slices = $sa->fetch_all_karyotype();
     # If we don't have any slices (ie. chromosomes), don't make the file
     return unless(scalar(@$slices));
- 
+
     my $file = $self->_generate_file_name();
-      push(@compress, $file);
-      $self->param('compress', @compress);
-#      $self->dataflow_output_id($self->param('compress'), 1);
   
     work_with_file($file, 'w', sub {
       my ($fh) = @_;
@@ -106,7 +103,7 @@ sub _make_karyotype_file {
       }
    });
 
-
+      $self->dataflow_output_id({ "compress" => [$file] }, 1);
 return;
 }
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileMetadata.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileMetadata.pm
@@ -94,7 +94,7 @@ sub _make_karyotype_file {
     return unless(scalar(@$slices));
  
     my $file = $self->_generate_file_name();
-      push(@compress, $out_file);
+      push(@compress, $file);
       $self->param('compress', @compress);
       $self->dataflow_output_id($self->param('compress'), 1);
   

--- a/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileMetadata.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileMetadata.pm
@@ -96,7 +96,7 @@ sub _make_karyotype_file {
     my $file = $self->_generate_file_name();
       push(@compress, $file);
       $self->param('compress', @compress);
-      $self->dataflow_output_id($self->param('compress'), 1);
+#      $self->dataflow_output_id($self->param('compress'), 1);
   
     work_with_file($file, 'w', sub {
       my ($fh) = @_;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileMetadata.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileMetadata.pm
@@ -103,9 +103,6 @@ sub _make_karyotype_file {
       }
    });
 
-  $self->info( "Compressing tsv dump for " . $sp);
-  my $unzip_file = $file;
-  `gzip -n $unzip_file`;
 
 return;
 }

--- a/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileMetadata.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileMetadata.pm
@@ -70,9 +70,10 @@ return;
 
 sub run {
   my ($self) = @_;
-  
+  my @compress;
   $self->_make_karyotype_file();
-  
+  $self->param('compress', @compress);
+  $self->dataflow_output_id($self->param('compress'), 1);
 return;
 }
 
@@ -94,6 +95,7 @@ sub _make_karyotype_file {
     return unless(scalar(@$slices));
  
     my $file = $self->_generate_file_name();
+    push(@compress, $file);
   
     work_with_file($file, 'w', sub {
       my ($fh) = @_;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileMetadata.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileMetadata.pm
@@ -103,7 +103,7 @@ sub _make_karyotype_file {
       }
    });
 
-      $self->dataflow_output_id({ "compress" => [$file] }, 1);
+      $self->dataflow_output_id({ "compress" => [$file] }, 4);
 return;
 }
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileMetadata.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileMetadata.pm
@@ -70,14 +70,13 @@ return;
 
 sub run {
   my ($self) = @_;
-  my @compress;
   $self->_make_karyotype_file();
-  $self->param('compress', @compress);
-  $self->dataflow_output_id($self->param('compress'), 1);
 return;
 }
 
 sub _make_karyotype_file {
+   my @compress;
+
     my ($self) = @_;
 
     my $sp = $self->param_required('species');
@@ -95,7 +94,9 @@ sub _make_karyotype_file {
     return unless(scalar(@$slices));
  
     my $file = $self->_generate_file_name();
-    push(@compress, $file);
+      push(@compress, $out_file);
+      $self->param('compress', @compress);
+      $self->dataflow_output_id($self->param('compress'), 1);
   
     work_with_file($file, 'w', sub {
       my ($fh) = @_;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileXref.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileXref.pm
@@ -130,7 +130,7 @@ sub _write_tsv {
 
   if ($xrefs_exist == 1) {
       $self->dataflow_output_id(
-              { "compress" => [$out_file] }, 1);
+              { "compress" => [$out_file] }, 4);
   } else {
     # If we have no xrefs, delete the file (which will just have a header).
     unlink $out_file  or die "failed to delete $out_file!";

--- a/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileXref.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileXref.pm
@@ -46,25 +46,25 @@ sub param_defaults {
 
 sub fetch_input {
     my ($self) = @_;
-    my @compress;
     my $type = $self->param('type');
     my $external_db = $self->param('external_db');
     $self->param('type', $type);
     $self->param('external_db', $external_db);
     $self->param('dba', $self->get_DBAdaptor());
-    $self->param('compress', @compress);
-    $self->dataflow_output_id($self->param('compress'), 1);
+
 
 return;
 }
 
 sub run {
     my ($self) = @_;
-
+    my @compress;
     $self->info( "Starting tsv dump for " . $self->param('species'));
     $self->_write_tsv();
     $self->_create_README();
     $self->info( "Completed tsv dump for " . $self->param('species'));
+    $self->param('compress', @compress);
+    $self->dataflow_output_id($self->param('compress'), 1);
 
 return;
 }

--- a/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileXref.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileXref.pm
@@ -46,12 +46,14 @@ sub param_defaults {
 
 sub fetch_input {
     my ($self) = @_;
-
+    my @compress;
     my $type = $self->param('type');
     my $external_db = $self->param('external_db');
     $self->param('type', $type);
     $self->param('external_db', $external_db);
     $self->param('dba', $self->get_DBAdaptor());
+    $self->param('compress', @compress);
+    $self->dataflow_output_id($self->param('compress'), 1);
 
 return;
 }
@@ -127,6 +129,8 @@ sub _write_tsv {
 
   if ($xrefs_exist != 1) {
     unlink $out_file  or die "failed to delete $out_file!";
+  }else{
+      push(@compress, $out_file)
   }
 
 return;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileXref.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileXref.pm
@@ -46,35 +46,37 @@ sub param_defaults {
 
 sub fetch_input {
     my ($self) = @_;
+
     my $type = $self->param('type');
     my $external_db = $self->param('external_db');
     $self->param('type', $type);
     $self->param('external_db', $external_db);
     $self->param('dba', $self->get_DBAdaptor());
 
-
 return;
 }
 
 sub run {
     my ($self) = @_;
+
     $self->info( "Starting tsv dump for " . $self->param('species'));
     $self->_write_tsv();
     $self->_create_README();
     $self->info( "Completed tsv dump for " . $self->param('species'));
 
-
 return;
 }
+sub write {
 
+}
 #############
 ##SUBROUTINES
 #############
 sub _write_tsv {
     my ($self) = @_;
-    my @compress;
+
     my $out_file  = $self->_generate_file_name();
-    my $header    = $self->_build_headers();   
+    my $header    = $self->_build_headers();
 
     open my $fh, '>', $out_file or die "cannot open $out_file for writing!";
     print $fh join ("\t", @$header);
@@ -112,9 +114,9 @@ sub _write_tsv {
                    my $xref_db       = $dbentry->dbname();
                    my $xref_info_type= $dbentry->info_type();
 
-                   if ($dbentry->isa('Bio::EnsEMBL::IdentityXref')){ 
- 		      $src_identity  = $dbentry->ensembl_identity(); 
-                      $xref_identity = $dbentry->xref_identity(); 
+                   if ($dbentry->isa('Bio::EnsEMBL::IdentityXref')){
+ 		      $src_identity  = $dbentry->ensembl_identity();
+                      $xref_identity = $dbentry->xref_identity();
                    }
 		   $linkage_type = join(' ', @{$dbentry->get_all_linkage_types()})if($dbentry->isa('Bio::EnsEMBL::OntologyXref'));
                    print $fh "$g_id\t$tr_id\t$tl_id\t$xref_id\t$xref_db\t$xref_info_type\t$src_identity\t$xref_identity\t$linkage_type\n";
@@ -122,16 +124,17 @@ sub _write_tsv {
 	       }#dbentry
          }#transcript
       }#gene
-  }#slice 
-  close $fh; 
+  }#slice
+  close $fh;
 
-  if ($xrefs_exist != 1) {
+
+  if ($xrefs_exist == 1) {
+      $self->dataflow_output_id(
+              { "compress" => [$out_file] }, 1);
+  } else {
+    # If we have no xrefs, delete the file (which will just have a header).
     unlink $out_file  or die "failed to delete $out_file!";
-  }else{
-      push(@compress, $out_file);
-      $self->param('compress', @compress);
   }
-
 return;
 }
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileXref.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileXref.pm
@@ -130,7 +130,6 @@ sub _write_tsv {
   }else{
       push(@compress, $out_file);
       $self->param('compress', @compress);
-      $self->dataflow_output_id($self->param('compress'), 1);
   }
 
 return;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileXref.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileXref.pm
@@ -58,13 +58,11 @@ return;
 
 sub run {
     my ($self) = @_;
-    my @compress;
     $self->info( "Starting tsv dump for " . $self->param('species'));
     $self->_write_tsv();
     $self->_create_README();
     $self->info( "Completed tsv dump for " . $self->param('species'));
-    $self->param('compress', @compress);
-    $self->dataflow_output_id($self->param('compress'), 1);
+
 
 return;
 }
@@ -74,7 +72,7 @@ return;
 #############
 sub _write_tsv {
     my ($self) = @_;
-
+    my @compress;
     my $out_file  = $self->_generate_file_name();
     my $header    = $self->_build_headers();   
 
@@ -130,7 +128,9 @@ sub _write_tsv {
   if ($xrefs_exist != 1) {
     unlink $out_file  or die "failed to delete $out_file!";
   }else{
-      push(@compress, $out_file)
+      push(@compress, $out_file);
+      $self->param('compress', @compress);
+      $self->dataflow_output_id($self->param('compress'), 1);
   }
 
 return;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileXref.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/TSV/DumpFileXref.pm
@@ -125,14 +125,7 @@ sub _write_tsv {
   }#slice 
   close $fh; 
 
-  if ($xrefs_exist == 1) {
-    $self->info( "Compressing tsv dump for " . $self->param('species'));
-    my $unzip_out_file = $out_file;
-    `gzip -n $unzip_out_file`;
-
-    if (-e $unzip_out_file) { `rm $unzip_out_file`; }
-  } else {
-    # If we have no xrefs, delete the file (which will just have a header).
+  if ($xrefs_exist != 1) {
     unlink $out_file  or die "failed to delete $out_file!";
   }
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/TSV/Gzip.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/TSV/Gzip.pm
@@ -1,0 +1,51 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2023] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 NAME
+
+ Bio::EnsEMBL::Production::Pipeline::TSV::Gzip;
+
+=head1 DESCRIPTION
+
+A simple script for gzipping files and catching errors
+
+=head1 AUTHOR
+
+ ckong@ebi.ac.uk 
+
+=cut
+package Bio::EnsEMBL::Production::Pipeline::TSV::Gzip;;
+
+use strict;
+use warnings;
+use base qw/Bio::EnsEMBL::Production::Pipeline::TSV::Base/;
+
+sub fetch_input {
+    my ($self) = @_;
+return;
+}
+
+sub run {
+    my ($self) = @_;
+    my $out_file  = $self->_generate_file_name();
+    `gzip -n $out_file`;
+
+    if (-e $out_file) { die "Error: gzip failed" }
+return;
+}
+
+1;


### PR DESCRIPTION
## Description

Swapped direct calling of gzip with using the perl module.
Separated compression from SQL queries.

## Use case

Will be used in all mySQL dumps and all core dumps.

## Benefits

Escapes the compression bug and allows us to restart failed compressions without restarting the queries.

## Possible Drawbacks

The module gzip may be slower.

## Testing
Pipeline was tested with mysql dumps and core non_vert dumps. 

Tested using a single species. 

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

No new dependencies.