### PR TITLE
Generate checksums and insert into Perl refget

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/LoadRefget_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/LoadRefget_conf.pm
@@ -48,6 +48,7 @@ sub default_options {
         ## Checksum parameters
         'check_refget' => 1,
         'verify_checksums' => 1,
+        'sequence_type'  => [],
     };
 }
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/LoadRefget_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/LoadRefget_conf.pm
@@ -46,7 +46,7 @@ sub default_options {
         'division'    => [],
         'dbname'      => undef,
         ## Checksum parameters
-        'check_refget' => 1,
+        'check_refget' => 0,
         'verify_checksums' => 1,
         'sequence_type'  => [],
     };

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/LoadRefget_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/LoadRefget_conf.pm
@@ -1,0 +1,136 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2023] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::Production::Pipeline::PipeConfig::LoadRefget_conf;
+
+use strict;
+use warnings;
+
+use base ('Bio::EnsEMBL::Production::Pipeline::PipeConfig::Base_conf');
+
+use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
+use Bio::EnsEMBL::Hive::Version 2.5;
+use File::Spec;
+
+sub default_options {
+    my ($self) = @_;
+
+    return {
+        %{$self->SUPER::default_options()},
+
+        ## General parameters
+        'release'        => $self->o('ensembl_release'),
+        'pipeline_name'  => 'pipeline_refgetloader_' . $self->o('ensembl_release'),
+        'web_email'      => '',
+        'run_all'        => 0,
+        'email'          => 'ensembl-production@ebi.ac.uk',
+        ## 'job_factory' parameters
+        'species'     => [],
+        'antispecies' => [],
+        'division'    => [],
+        'dbname'      => undef,
+        ## Checksum parameters
+        'check_refget' => 1,
+        'verify_checksums' => 1,
+    };
+}
+
+sub pipeline_create_commands {
+    my ($self) = @_;
+
+    return [
+        @{$self->SUPER::pipeline_create_commands}
+    ];
+}
+
+# Ensures output parameters gets propagated implicitly
+sub hive_meta_table {
+    my ($self) = @_;
+
+    return {
+        %{$self->SUPER::hive_meta_table},
+        'hive_use_param_stack' => 1,
+    };
+}
+
+sub pipeline_wide_parameters {
+    my ($self) = @_;
+
+    return {
+        %{$self->SUPER::pipeline_wide_parameters},
+        'pipeline_name'  => $self->o('pipeline_name'),
+        'release'        => $self->o('release'),
+    };
+}
+
+sub pipeline_analyses {
+    my ($self) = @_;
+
+    return [
+        {
+            -logic_name    => 'init_checksum',
+            -module        => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+            -input_ids     => [{}],
+            -flow_into     => {'1->A' => 'species_factory', 'A->1' => 'email_report'}
+        },
+        {
+            -logic_name => 'species_factory',
+            -module     => 'Bio::EnsEMBL::Production::Pipeline::Common::SpeciesFactory',
+            -parameters => {
+                species     => $self->o('species'),
+                antispecies => $self->o('antispecies'),
+                division    => $self->o('division'),
+                dbname      => $self->o('dbname'),
+                run_all     => $self->o('run_all'),
+            },
+            -max_retry_count => 1,
+            -flow_into       => {'2->A' => 'load_refget', 'A->2' => 'run_datacheck'},
+        },
+        {
+            -logic_name         => 'load_refget',
+            -module             => 'Bio::EnsEMBL::Production::Pipeline::Refget::RefgetLoader',
+            -analysis_capacity  => 20,
+        },
+        {
+            -logic_name        => 'run_datacheck',
+            -module            => 'Bio::EnsEMBL::DataCheck::Pipeline::RunDataChecks',
+            -max_retry_count   => 1,
+            -analysis_capacity => 10,
+            -batch_size        => 10,
+            -parameters        => {
+                datacheck_names => ['SequenceChecksum'],
+                datacheck_types => ['critical'],
+                registry_file   => $self->o('registry'),
+                failures_fatal  => 1,
+            },
+        },
+        {
+            -logic_name => 'email_report',
+            -module     => 'Bio::EnsEMBL::Hive::RunnableDB::NotifyByEmail',
+            -parameters => {
+                'email'   => $self->o('email'),
+                'subject' => 'Pipeline ' . $self->o('pipeline_name') . ' completed!',
+                'text'    => 'Checksum value added to attrib tables'
+            },
+        },
+    ];
+}
+
+1;
+

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/LoadRefget_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/LoadRefget_conf.pm
@@ -49,6 +49,8 @@ sub default_options {
         'check_refget' => 0,
         'verify_checksums' => 1,
         'sequence_type'  => [],
+        'refget_dba_name' => 'multi',
+        'refget_dba_group' => 'refget',
     };
 }
 
@@ -77,9 +79,6 @@ sub pipeline_wide_parameters {
         %{$self->SUPER::pipeline_wide_parameters},
         'pipeline_name'  => $self->o('pipeline_name'),
         'release'        => $self->o('release'),
-        'check_refget' => $self->o('check_refget'),
-        'verify_checksums' => $self->o('verify_checksums'),
-        'sequence_type' => $self->o('sequence_type'),
     };
 }
 
@@ -88,7 +87,7 @@ sub pipeline_analyses {
 
     return [
         {
-            -logic_name    => 'init_checksum',
+            -logic_name    => 'init_refget_load',
             -module        => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
             -input_ids     => [{}],
             -flow_into     => {'1->A' => 'species_factory', 'A->1' => 'email_report'}
@@ -110,6 +109,11 @@ sub pipeline_analyses {
             -logic_name         => 'load_refget',
             -module             => 'Bio::EnsEMBL::Production::Pipeline::Refget::RefgetLoader',
             -analysis_capacity  => 20,
+            -parameters         => {
+                check_refget => $self->o('check_refget'),
+                verify_checksums => $self->o('verify_checksums'),
+                sequence_type => $self->o('sequence_type'),
+            },
         },
         {
             -logic_name        => 'run_datacheck',

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/LoadRefget_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/LoadRefget_conf.pm
@@ -77,6 +77,9 @@ sub pipeline_wide_parameters {
         %{$self->SUPER::pipeline_wide_parameters},
         'pipeline_name'  => $self->o('pipeline_name'),
         'release'        => $self->o('release'),
+        'check_refget' => $self->o('check_refget'),
+        'verify_checksums' => $self->o('verify_checksums'),
+        'sequence_type' => $self->o('sequence_type'),
     };
 }
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Refget/RefgetLoader.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Refget/RefgetLoader.pm
@@ -116,9 +116,9 @@ sub run {
     my $dba = $self->get_DBAdaptor($group);
     $self->throw("Cannot find adaptor for type $group") unless $dba;
     # Assumes refget is available from the multi name & refget type
+    my $refget_dba = Bio::EnsEMBL::Registry->get_DBAdaptor('multi', 'refget');
     my $refget_schema = Refget::Schema->connect(sub {
-        my $dba = Bio::EnsEMBL::Registry->get_DBAdaptor('multi', 'refget');
-        return $dba->dbc()->db_handle();
+        return $refget_dba->dbc()->db_handle();
     });
     #Setup refget objects
     $self->create_basic_refget_objects($dba, $refget_schema);
@@ -147,6 +147,10 @@ sub run {
             $self->generate_and_load_transcripts_and_proteins($slice, $checksum_lookup, $refget_schema);
         });
     }
+    
+    # cleanup
+    $dba->dbc->disconnect_if_idle();
+    $refget_dba->dbc->disconnect_if_idle();
 }
 
 ##### DBIX::Class/Ensembl object loading methods

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Refget/RefgetLoader.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Refget/RefgetLoader.pm
@@ -137,7 +137,7 @@ sub run {
     # Get the checksum lookups
     my $checksum_lookup = {};
     if($self->param('verify_checksums')) {
-        foreach my $type ($self->param('sequence_type')) {
+        foreach my $type (@{$self->param('sequence_type')}) {
             foreach my $checksum (qw/md5 sha512t24u/) {
                 $checksum_lookup->{$type}->{$checksum} = $self->_get_checksums_from_db($dba, $type, $checksum);
             }

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Refget/RefgetLoader.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Refget/RefgetLoader.pm
@@ -126,13 +126,24 @@ sub run {
     my $attribute_adaptor = $dba->get_AttributeAdaptor();
     my $sequence_adaptor = $dba->get_SequenceAdaptor();
     my @slices = reverse @{$slice_adaptor->fetch_all('toplevel', undef, 1, undef, undef)};
+
+    # Get the checksum lookups
+    my $checksum_lookup = {};
+    if($self->param('verify_checksums')) {
+        foreach my $type (qw/toplevel cdna cds pep/) {
+            foreach my $checksum (qw/md5 sha512t24u/) {
+                $lookup->{$type}->{$checksum} = $self->_get_checksums_from_db($dba, $type, $checksum);
+            }
+        }
+    }
+
     while(my $slice = shift @slices) {
         # Transaction block is left at just one per toplevel region. 
         # Sometimes it'll be fine and others it won't be
         # Rows only inserted into molecule if there's a new id+seq+release+type
         $refget_schema->txn_do(sub {
-            $self->generate_and_load_toplevel($slice, $attribute_adaptor, $sequence_adaptor, $refget_schema);
-            $self->generate_and_load_transcripts_and_proteins($slice, $attribute_adaptor, $refget_schema);
+            $self->generate_and_load_toplevel($slice, $checksum_lookup, $sequence_adaptor, $refget_schema);
+            $self->generate_and_load_transcripts_and_proteins($slice, $checksum_lookup, $refget_schema);
         });
     }
 }
@@ -180,24 +191,23 @@ sub create_basic_refget_objects {
 }
 
 sub generate_and_load_toplevel {
-    my ($self, $slice, $attribute_adaptor, $sequence_adaptor, $refget_schema) = @_;
-    
+    my ($self, $slice, $checksum_lookup, $sequence_adaptor, $refget_schema) = @_;
+
     # Generate the checksums from the sequence in the DB
     my $seq_ref = $sequence_adaptor->fetch_by_Slice_start_end_strand($slice, 1, undef, 1);
     my $slice_checksums = $self->_generate_checksums_from_seq_ref($seq_ref);
-    my $existing_slice_checksums = { md5 => '', sha512t24u => '' };
 
     # Verify means fetch the DB stored checksums and make sure there isn't any drift
     # Die if there is drift
     if($self->param('verify_checksums')) {
-        $existing_slice_checksums = $self->_get_slice_checksums($slice, $attribute_adaptor);
+        my $seq_region_id = $slice->get_seq_region_id();
         foreach my $checksum (qw/md5 sha512t24u/) {
-            if($slice_checksums->{$checksum} ne $existing_slice_checksums->{$checksum}) {
-                my $seq_region_id = $slice->get_seq_region_id();
+            my $existing_checksum = $checksum_lookup->{'toplevel'}->{$checksum}->{$seq_region_id};
+            if($slice_checksums->{$checksum} ne $existing_checksum) {
                 my $seq_region_name =  $slice->seq_region_name();
                 my $error_string = sprintf(
                     'The stored %s checksum (%s) for seq_region_name %s seq_region_id %d does not match the calculated checksum (%s)',
-                    $checksum, $existing_slice_checksums->{$checksum}, $seq_region_name, $seq_region_id, $slice_checksums->{$checksum}
+                    $checksum, $existing_checksum, $seq_region_name, $seq_region_id, $slice_checksums->{$checksum}
                 );
                 $self->throw($error_string);
             }
@@ -228,16 +238,17 @@ sub generate_and_load_toplevel {
 }
 
 sub generate_and_load_transcripts_and_proteins {
-    my ($self, $slice, $attribute_adaptor, $refget_schema) = @_;
+    my ($self, $slice, $checksum_lookup, $refget_schema) = @_;
     my $transcripts = $slice->get_all_Transcripts();
     my $is_circular = 0;
+    my $verify_checksums = $self->param('verify_checksums');
     while(my $transcript = shift @{$transcripts}) {
         my $cdna = $transcript->seq()->seq();
         my $cdna_seq_hash = $self->create_seq_hash(\$cdna);
         my $transcript_id = $transcript->stable_id_version();
 
-        if($self->param('verify_checksums')) {
-            my $cdna_checksums = $self->_get_cdna_checksums($transcript, $attribute_adaptor);
+        if($verify_checksums) {
+            my $cdna_checksums = $checksum_lookup->{cdna};
             $self->_verify_checksums_match($cdna_seq_hash, $cdna_checksums, 'cdna', $transcript->stable_id_version(), $transcript->dbID());
         }
 
@@ -249,8 +260,8 @@ sub generate_and_load_transcripts_and_proteins {
             my $cds = $transcript->translateable_seq();
             my $cds_seq_hash = $self->create_seq_hash(\$cds);
 
-            if($self->param('verify_checksums')) {
-                my $cds_checksums = $self->_get_cds_checksums($transcript, $attribute_adaptor);
+            if($verify_checksums) {
+                my $cds_checksums = $checksum_lookup->{cds};
                 $self->_verify_checksums_match($cds_seq_hash, $cds_checksums, 'cds', $transcript->stable_id_version(), $transcript->dbID());
             }
             $self->insert_molecule($refget_schema, \$cds, $cds_seq_hash, $transcript_id, 'cds');
@@ -259,8 +270,8 @@ sub generate_and_load_transcripts_and_proteins {
             my $protein = $translation->seq();
             my $protein_seq_hash = $self->create_seq_hash(\$protein);
             my $protein_id = $translation->stable_id_version();
-            if($self->param('verify_checksums')) {
-                my $protein_checksums = $self->_get_protein_checksums($translation, $attribute_adaptor);
+            if($verify_checksums) {
+                my $protein_checksums = $checksum_lookup->{pep};
                 $self->_verify_checksums_match($protein_seq_hash, $protein_checksums, 'pep', $protein_id, $translation->dbID());
             }
             $self->insert_molecule($refget_schema, \$protein, $protein_seq_hash, $protein_id, 'protein');
@@ -368,64 +379,77 @@ sub insert_raw_sequence {
     return $raw_seq;
 }
 
-##### Checksum attribute retrieval and checking
-
-sub _get_checksums_from_attributes {
-    my ($self, $attributes, $seq_type, $identifier, $db_id) = @_;
-    my $values = {};
-    my $key_names = $self->param('attrib_keys');
-    # Transform attributes for easier lookup rather than multiple DB trips
-    my %inverted_attributes = map { $_->code(), $_->value() } @{$attributes};
-    foreach my $checksum (qw/md5 sha512t24u/) {
-        my $code = $key_names->{$seq_type}->{$checksum};
-        my $value = $inverted_attributes{$code};
-        if(! $value) {
-            my $error = sprintf('Could not find a %s attribute (%s) in the database linked to id %s (db id %d) of type %s', 
-                $checksum, $code, $identifier, $db_id, $seq_type
-            );
-            $self->throw($error);
-        }
-        $values->{$checksum} = $value;
-    }
-    return $values;
-}
-
-sub _get_slice_checksums {
-    my ($self, $slice, $attribute_adaptor) = @_;
-    my $attributes = $attribute_adaptor->fetch_all_by_Slice($slice);
-    return $self->_get_checksums_from_attributes($attributes, 'toplevel', $slice->seq_region_name(), $slice->get_seq_region_id());
-}
-
-sub _get_cdna_checksums {
-    my ($self, $transcript, $attribute_adaptor) = @_;
-    my $attributes = $attribute_adaptor->fetch_all_by_Transcript($transcript);
-    return $self->_get_checksums_from_attributes($attributes, 'cdna', $transcript->stable_id_version(), $transcript->dbID());
-}
-
-sub _get_cds_checksums {
-    my ($self, $transcript, $attribute_adaptor) = @_;
-    my $attributes = $attribute_adaptor->fetch_all_by_Transcript($transcript);
-    return $self->_get_checksums_from_attributes($attributes, 'cds', $transcript->stable_id_version(), $transcript->dbID());
-}
-
-sub _get_protein_checksums {
-    my ($self, $translation, $attribute_adaptor) = @_;
-    my $attributes = $attribute_adaptor->fetch_all_by_Translation($translation);
-    return $self->_get_checksums_from_attributes($attributes, 'pep', $translation->stable_id_version(), $translation->dbID());
-}
+##### Batch checksum attribute retrieval and checking
 
 sub _verify_checksums_match {
     my ($self, $generated_checksums, $retreived_checksums, $type, $id, $db_id) = @_;
     foreach my $checksum (qw/md5 sha512t24u/) {
-        if($generated_checksums->{$checksum} ne $retreived_checksums->{$checksum}) {
+        my $calculated_checksum = $generated_checksums->{$checksum};
+        my $stored_checksum = $retreived_checksums->{$checksum}->{$db_id};
+        if( ne $stored_checksum) {
             my $error_string = sprintf(
                 'The stored %s %s checksum (%s) for ID %s dbID %d does not match the calculated checksum (%s)',
-                $type, $checksum, $retreived_checksums->{$checksum}, $id, $db_id, $generated_checksums->{$checksum}
+                $type, $checksum, $stored_checksum, $id, $db_id, $calculated_checksum
             );
             $self->throw($error_string);
         }
     }
     return 1;
+}
+
+sub _get_checksums_from_db {
+    my ($self, $dba, $type, $checksum) = @_;
+    my ($sql, $params) = $self->_get_attribute_sql_and_params($dba, $type, $checksum);
+    my $lookup = $dba->dbc()->sql_helper()->execute_into_hash(-SQL => $sql, -PARAMS => $params);
+    return $lookup;
+}
+
+sub _get_attribute_sql_and_params {
+    my ($self, $dba, $type, $checksum) = @_;
+    my $sql = q{};
+    if($type eq 'toplevel') {
+      $sql = << 'EOF';
+SELECT sr.seq_region_id, att.value
+FROM seq_region sr
+JOIN coord_system cs on cs.coord_system_id = sr.coord_system_id
+JOIN seq_region_attrib att ON sr.seq_region_id = att.seq_region_id
+JOIN attrib_type at on att.attrib_type_id = at.attrib_type_id
+WHERE cs.species_id =?
+AND at.code =?
+EOF
+    }
+    elsif ($type eq q{cdna} || $type eq q{cds}) {
+      $sql = << 'EOF';
+SELECT t.transcript_id, att.value
+FROM transcript t
+JOIN seq_region sr ON t.seq_region_id = sr.seq_region_id
+JOIN coord_system cs on cs.coord_system_id = sr.coord_system_id
+JOIN transcript_attrib att ON t.transcript_id = att.transcript_id
+JOIN attrib_type at on att.attrib_type_id = at.attrib_type_id
+WHERE cs.species_id =?
+AND at.code =?
+EOF
+    }
+    elsif ($type eq q{pep}) {
+      $sql = << 'EOF';
+SELECT tr.translation_id, att.value
+FROM transcript t
+JOIN seq_region sr ON t.seq_region_id = sr.seq_region_id
+JOIN coord_system cs on cs.coord_system_id = sr.coord_system_id
+JOIN translation tr ON t.transcript_id = tr.transcript_id
+JOIN translation_attrib att ON tr.translation_id = att.translation_id
+JOIN attrib_type at on att.attrib_type_id = at.attrib_type_id
+WHERE cs.species_id =?
+AND at.code =?
+EOF
+    }
+    else {
+        $self->throw("Given unknown sequence type '${type}'");
+    }
+
+    # Params set to the species id for the species and the attrib key for a checksum e.g. sha512t24u or md5
+    my $params = [$dba->species_id(), $self->param('attrib_keys')->{$type}->{$checksum}];
+    return ($sql, $params);
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Refget/RefgetLoader.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Refget/RefgetLoader.pm
@@ -267,7 +267,7 @@ sub generate_and_load_transcripts_and_proteins {
 
         # Skip if we were not to process this type
         my $transcript_id = $transcript->stable_id_version();
-        if(! $process_cdna) {
+        if($process_cdna) {
             my $cdna = $transcript->seq()->seq();
             my $cdna_seq_hash = $self->create_seq_hash(\$cdna);
 
@@ -283,7 +283,7 @@ sub generate_and_load_transcripts_and_proteins {
         if($translation) {
             # We only have a CDS when it is a translation. Perl API will return an empty string
             # if there is no translation associcated with a transcript record
-            if(! $process_cds) {
+            if($process_cds) {
                 my $cds = $transcript->translateable_seq();
                 my $cds_seq_hash = $self->create_seq_hash(\$cds);
 
@@ -295,7 +295,7 @@ sub generate_and_load_transcripts_and_proteins {
             }
 
             # Now process protein
-            if(! $process_pep) {
+            if($process_pep) {
                 my $protein = $translation->seq();
                 my $protein_seq_hash = $self->create_seq_hash(\$protein);
                 my $protein_id = $translation->stable_id_version();

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Refget/RefgetLoader.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Refget/RefgetLoader.pm
@@ -117,9 +117,13 @@ sub run {
     $self->throw("Cannot find adaptor for type $group") unless $dba;
     # Assumes refget is available from the multi name & refget type
     my $refget_dba = Bio::EnsEMBL::Registry->get_DBAdaptor('multi', 'refget');
+    my $extra_attributes = {};
+    if($refget_dba->dbc()->driver() eq 'mysql') {
+        $extra_attributes->{quote_char} = '`';
+    }
     my $refget_schema = Refget::Schema->connect(sub {
         return $refget_dba->dbc()->db_handle();
-    });
+    }, $extra_attributes);
     #Setup refget objects
     $self->create_basic_refget_objects($dba, $refget_schema);
 
@@ -147,7 +151,7 @@ sub run {
             $self->generate_and_load_transcripts_and_proteins($slice, $checksum_lookup, $refget_schema);
         });
     }
-    
+
     # cleanup
     $dba->dbc->disconnect_if_idle();
     $refget_dba->dbc->disconnect_if_idle();

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Refget/RefgetLoader.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Refget/RefgetLoader.pm
@@ -418,7 +418,7 @@ sub _verify_checksums_match {
     foreach my $checksum (qw/md5 sha512t24u/) {
         my $calculated_checksum = $generated_checksums->{$checksum};
         my $stored_checksum = $retreived_checksums->{$checksum}->{$db_id};
-        if( ne $stored_checksum) {
+        if($calculated_checksum ne $stored_checksum) {
             my $error_string = sprintf(
                 'The stored %s %s checksum (%s) for ID %s dbID %d does not match the calculated checksum (%s)',
                 $type, $checksum, $stored_checksum, $id, $db_id, $calculated_checksum

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Refget/RefgetLoader.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Refget/RefgetLoader.pm
@@ -1,0 +1,431 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2023] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+=pod
+
+
+=head1 CONTACT
+
+  Please email comments or questions to the public Ensembl
+  developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
+
+  Questions may also be sent to the Ensembl help desk at
+  <http://www.ensembl.org/Help/Contact>.
+
+=head1 NAME
+
+Bio::EnsEMBL::Production::Pipeline::Refget::RefgetLoader
+
+=head1 DESCRIPTION
+
+A module for loading sequences from a core-like database into the 
+Perl reference implementation of refget (https://github.com/andrewyatz/refget-server-perl). 
+
+The code will load all proteins, cds and cDNA, and can optionally load toplevel
+sequences if missing from ENA's refget instance (https://www.ebi.ac.uk/ena/cram/).
+
+Allowed parameters are:
+
+=over 8
+
+=item species - The species to fetch the genomic sequence
+
+=item release - A required parameter for the version of Ensembl we are dumping for
+
+=item db_types - Array reference of the database groups to use. Defaults to core
+
+=item check_refget - Ping a refget for MD5 existence before attempting to load a toplevel sequence. Defaults to true
+
+=item refget_ping_url - URL to ping when checking for pre-existing sequences. Defaults to ENA's implementation
+
+=item verify_checksums - If set to true this module will double check the recorded checksum. Defaults to true
+
+=item source - Annotation source. Defaults to Ensembl
+
+=back
+
+The database connection for DBIx::Class is assumed to be in the registry under the species name B<multi>
+and the group of B<refget>. DBIx::Class then can take the underlying DBI handle to connect. Adding
+a C<-DRIVER> attribute of type C<"Pg"> to a C<Bio::EnsEMBL::DBSQL::DBAdaptor> constructor will make
+the magic happen (assuming the underlying Refget is in PostgreSQL).
+
+=cut
+
+package Bio::EnsEMBL::Production::Pipeline::Refget::RefgetLoader;
+
+use strict;
+use warnings;
+
+use Bio::EnsEMBL::Registry;
+use Refget::Schema;
+use HTTP::Tiny;
+use Refget::Util qw/trunc512_digest ga4gh_to_trunc512 ga4gh_digest/;
+use Digest::MD5 qw/md5_hex/;
+use Mojo::URL;
+
+use base qw/Bio::EnsEMBL::Production::Pipeline::Common::Base/;
+
+sub param_defaults {
+    my ($self) = @_;
+    return {
+        check_refget => 1,
+        refget_ping_url => 'https://www.ebi.ac.uk/ena/cram',
+        verify_checksums => 1,
+        attrib_keys => {
+            toplevel => {
+                md5 => 'md5_toplevel',
+                sha512t24u => 'sha512t24u_toplevel',
+            },
+            cdna => {
+                md5 => 'md5_cdna',
+                sha512t24u => 'sha512t24u_cdna',
+            },
+            cds => {
+                md5 => 'md5_cds',
+                sha512t24u => 'sha512t24u_cds',
+            },
+            pep => {
+                md5 => 'md5_pep',
+                sha512t24u => 'sha512t24u_pep',
+            },
+        },
+        source => 'Ensembl',
+    };
+}
+
+sub run {
+    my ($self) = @_;
+    my $group = $self->param('group');
+    my $dba = $self->get_DBAdaptor($group);
+    $self->throw("Cannot find adaptor for type $group") unless $dba;
+    # Assumes refget is available from the multi name & refget type
+    my $refget_schema = Refget::Schema->connect(sub {
+        my $dba = Bio::EnsEMBL::Registry->get_DBAdaptor('multi', 'refget');
+        return $dba->dbc()->db_handle();
+    });
+    #Setup refget objects
+    $self->create_basic_refget_objects($dba, $refget_schema);
+
+    my $slice_adaptor = $dba->get_SliceAdaptor();
+    my $attribute_adaptor = $dba->get_AttributeAdaptor();
+    my $sequence_adaptor = $dba->get_SequenceAdaptor();
+    my @slices = reverse @{$slice_adaptor->fetch_all('toplevel', undef, 1, undef, undef)};
+    while(my $slice = shift @slices) {
+        # Transaction block is left at just one per toplevel region. 
+        # Sometimes it'll be fine and others it won't be
+        # Rows only inserted into molecule if there's a new id+seq+release+type
+        $refget_schema->txn_do(sub {
+            $self->generate_and_load_toplevel($slice, $attribute_adaptor, $sequence_adaptor, $refget_schema);
+            $self->generate_and_load_transcripts_and_proteins($slice, $attribute_adaptor, $refget_schema);
+        });
+    }
+}
+
+##### DBIX::Class/Ensembl object loading methods
+
+# Responsible for setting up the basic bits of information required to load a record
+# into a refget instance.
+sub create_basic_refget_objects {
+    my ($self, $dba, $refget_schema) = @_;
+    my $mc = $dba->get_MetaContainer();
+    my $csa = $dba->get_CoordSystemAdaptor();
+    my ($cs) = @{$csa->fetch_all()};
+
+    my $species_name = $mc->get_scientific_name();
+    my $species_assembly = $cs->version();
+    my $species_division = $mc->single_value_by_key('species.division');
+    my $species_release = $self->param('release');
+    my $source = $self->param('source');
+
+    # Done in a transaction but everything here is addative and doesn't create new records
+    # unless needed
+    $refget_schema->txn_do(sub {
+        my $species_obj = $refget_schema->resultset('Species')->create_entry($species_name, $species_assembly);
+        my $division_obj = $refget_schema->resultset('Division')->create_entry($species_division);
+        $self->param('species_obj', $species_obj);
+        $self->param('division_obj', $division_obj);
+        $self->param('release_obj', $refget_schema->resultset('Release')->create_entry($species_release, $division_obj, $species_obj));
+        my $mol_types = {};
+        foreach my $mol_type (qw/dna cds cdna protein/) {
+            my $mol_obj = $refget_schema->resultset('MolType')->find_entry($mol_type);
+            if(! $mol_obj) {
+                $self->throw("No mol object found for mol type '${mol_type}'. Is the DB pre-populated?");
+            }
+            $mol_types->{$mol_type} = $mol_obj;
+        }
+        $self->param('mol_type_objs', $mol_types);
+        my $source_obj = $refget_schema->resultset('Source')->find_entry($self->param('source'));
+        if(! $source_obj) {
+            $self->throw("No source object found for source '${source}'. Is the DB pre-populated?");
+        }
+        $self->param('source_obj', $source_obj);
+    });
+    return;
+}
+
+sub generate_and_load_toplevel {
+    my ($self, $slice, $attribute_adaptor, $sequence_adaptor, $refget_schema) = @_;
+    
+    # Generate the checksums from the sequence in the DB
+    my $seq_ref = $sequence_adaptor->fetch_by_Slice_start_end_strand($slice, 1, undef, 1);
+    my $slice_checksums = $self->_generate_checksums_from_seq_ref($seq_ref);
+    my $existing_slice_checksums = { md5 => '', sha512t24u => '' };
+
+    # Verify means fetch the DB stored checksums and make sure there isn't any drift
+    # Die if there is drift
+    if($self->param('verify_checksums')) {
+        $existing_slice_checksums = $self->_get_slice_checksums($slice, $attribute_adaptor);
+        foreach my $checksum (qw/md5 sha512t24u/) {
+            if($slice_checksums->{$checksum} ne $existing_slice_checksums->{$checksum}) {
+                my $seq_region_id = $slice->get_seq_region_id();
+                my $seq_region_name =  $slice->seq_region_name();
+                my $error_string = sprintf(
+                    'The stored %s checksum (%s) for seq_region_name %s seq_region_id %d does not match the calculated checksum (%s)',
+                    $checksum, $existing_slice_checksums->{$checksum}, $seq_region_name, $seq_region_id, $slice_checksums->{$checksum}
+                );
+                $self->throw($error_string);
+            }
+        }
+    }
+
+    # Check if it is in refget at ENA. Otherwise we need to load this
+    my $exists_in_refget = 0;
+    if($self->param('check_refget')) {
+        my $md5 = $slice_checksums->{md5};
+        $exists_in_refget = $self->sequence_exists($md5);
+    }
+
+    # Load if it wasn't found in refget
+    if(! $exists_in_refget) {
+        my $seq_hash = {
+            trunc512 => $slice_checksums->{trunc512},
+            md5 => $slice_checksums->{md5},
+            ga4gh => $slice_checksums->{ga4gh},
+            size => length(${$seq_ref}),
+            circular => 0,
+        };
+        my $id = $slice->seq_region_name();
+        $self->insert_molecule($refget_schema, $seq_ref, $seq_hash, $id, 'dna');
+    }
+
+    return;
+}
+
+sub generate_and_load_transcripts_and_proteins {
+    my ($self, $slice, $attribute_adaptor, $refget_schema) = @_;
+    my $transcripts = $slice->get_all_Transcripts();
+    my $is_circular = 0;
+    while(my $transcript = shift @{$transcripts}) {
+        my $cdna = $transcript->seq()->seq();
+        my $cdna_seq_hash = $self->create_seq_hash(\$cdna);
+        my $transcript_id = $transcript->stable_id_version();
+
+        if($self->param('verify_checksums')) {
+            my $cdna_checksums = $self->_get_cdna_checksums($transcript, $attribute_adaptor);
+            $self->_verify_checksums_match($cdna_seq_hash, $cdna_checksums, 'cdna', $transcript->stable_id_version(), $transcript->dbID());
+        }
+
+        $self->insert_molecule($refget_schema, \$cdna, $cdna_seq_hash, $transcript_id, 'cdna');
+        my $translation = $transcript->translation();
+        if($translation) {
+            # We only have a CDS when it is a translation. Perl API will return an empty string
+            # if there is no translation associcated with a transcript record
+            my $cds = $transcript->translateable_seq();
+            my $cds_seq_hash = $self->create_seq_hash(\$cds);
+
+            if($self->param('verify_checksums')) {
+                my $cds_checksums = $self->_get_cds_checksums($transcript, $attribute_adaptor);
+                $self->_verify_checksums_match($cds_seq_hash, $cds_checksums, 'cds', $transcript->stable_id_version(), $transcript->dbID());
+            }
+            $self->insert_molecule($refget_schema, \$cds, $cds_seq_hash, $transcript_id, 'cds');
+
+            # Now process protein
+            my $protein = $translation->seq();
+            my $protein_seq_hash = $self->create_seq_hash(\$protein);
+            my $protein_id = $translation->stable_id_version();
+            if($self->param('verify_checksums')) {
+                my $protein_checksums = $self->_get_protein_checksums($translation, $attribute_adaptor);
+                $self->_verify_checksums_match($protein_seq_hash, $protein_checksums, 'pep', $protein_id, $translation->dbID());
+            }
+            $self->insert_molecule($refget_schema, \$protein, $protein_seq_hash, $protein_id, 'protein');
+        }
+    }
+    return;
+}
+
+##### Hashes etc... generation
+
+sub create_seq_hash {
+    my ($self, $seq_ref, $is_circular) = @_;
+    my $checksums = $self->_generate_checksums_from_seq_ref($seq_ref);
+    my $length = length(${$seq_ref});
+    $is_circular = 0 unless defined $is_circular;
+    return {
+        md5 => $checksums->{md5}, 
+        trunc512 => $checksums->{trunc512},
+        ga4gh => $checksums->{ga4gh},
+        sha512t24u => $checksums->{sha512t24u},
+        size => $length, 
+        circular => $is_circular
+    };
+}
+
+sub _generate_checksums_from_seq_ref {
+    my ($self, $seq_ref) = @_;
+    my $md5 = md5_hex(${$seq_ref});
+    my $ga4gh = ga4gh_digest(${$seq_ref});
+    my $trunc512 = ga4gh_to_trunc512($ga4gh);
+    my $sha512t24u = $ga4gh;
+    $sha512t24u =~ s/^ga4gh:SQ.//g;
+    return {
+        md5 => $md5,
+        ga4gh => $ga4gh,
+        trunc512 => $trunc512,
+        sha512t24u => $sha512t24u
+    };
+}
+
+##### Sequence existence methods
+
+sub sequence_exists {
+    my ($self, $md5) = @_;
+    my $url = $self->param('refget_ping_url');
+    my $full_url = "${url}/sequence/${md5}/metadata";
+    my $headers = {};
+    # ENA server issue. Does not accept application/json but does return correct
+    # data if you omit this.
+    if($url !~ /www\.ebi\.ac\.uk\/ena\/cram/) {
+        $headers->{Accept} = 'application/json';
+    }
+    my $res = HTTP::Tiny->new()->get($full_url, { headers => $headers } );
+    return ($res->{success}) ? 1 : 0;
+}
+
+##### DBIX::Class methods
+
+sub insert_molecule {
+    my ($self, $refget_schema, $seq_ref, $seq_hash, $id, $mol_type) = @_;
+    my $molecule_type_obj = $self->param('mol_type_objs')->{$mol_type};
+    my $release_obj = $self->param('release_obj');
+    my $species_obj = $self->param('species_obj');
+    # This is an option to insert but we don't do it in refget main ...
+    # my $division_obj = $self->param('division_obj');
+    my $source_obj = $self->param('source_obj');
+    my ($seq_obj, $first_seen) = $self->insert_sequence($refget_schema, $seq_ref, $seq_hash);
+    my $molecule_obj = $seq_obj->find_or_create_related(
+        'molecules',
+        {
+            id => $id,
+            first_seen => $first_seen,
+            release => $release_obj,
+            mol_type => $molecule_type_obj,
+            source => $source_obj,
+        }
+    );
+    return $molecule_obj;
+}
+
+sub insert_sequence {
+    my ($self, $refget_schema, $seq_ref, $seq_hash) = @_;
+    my $rs = $refget_schema->resultset('Seq');
+    my $ga4gh_id = $seq_hash->{ga4gh};
+    my %seq_hash_clone = %{$seq_hash};
+    delete $seq_hash_clone{ga4gh};
+    delete $seq_hash_clone{sha512t24u};
+    # Logic taken from Refget::Schema::ResultSet::Seq so there is logic bleed here
+    # Could be moved up
+    my $seq_obj = $rs->find_or_new(\%seq_hash_clone, {key => 'seq_trunc512_uniq'});
+    my $first_seen = 0;
+    if(!$seq_obj->in_storage()) {
+        $first_seen = 1;
+        $seq_obj->insert();
+        $self->insert_raw_sequence($refget_schema, $seq_ref, $ga4gh_id);
+    }
+    return ($seq_obj, $first_seen);
+}
+
+sub insert_raw_sequence {
+    my ($self, $refget_schema, $seq_ref, $ga4gh_id) = @_;
+    my $hash = ga4gh_to_trunc512($ga4gh_id);
+    my $rs = $refget_schema->resultset('RawSeq');
+    my $raw_seq = $rs->find_or_create({ checksum => $hash, seq => ${$seq_ref} });
+    return $raw_seq;
+}
+
+##### Checksum attribute retrieval and checking
+
+sub _get_checksums_from_attributes {
+    my ($self, $attributes, $seq_type, $identifier, $db_id) = @_;
+    my $values = {};
+    my $key_names = $self->param('attrib_keys');
+    # Transform attributes for easier lookup rather than multiple DB trips
+    my %inverted_attributes = map { $_->code(), $_->value() } @{$attributes};
+    foreach my $checksum (qw/md5 sha512t24u/) {
+        my $code = $key_names->{$seq_type}->{$checksum};
+        my $value = $inverted_attributes{$code};
+        if(! $value) {
+            my $error = sprintf('Could not find a %s attribute (%s) in the database linked to id %s (db id %d) of type %s', 
+                $checksum, $code, $identifier, $db_id, $seq_type
+            );
+            $self->throw($error);
+        }
+        $values->{$checksum} = $value;
+    }
+    return $values;
+}
+
+sub _get_slice_checksums {
+    my ($self, $slice, $attribute_adaptor) = @_;
+    my $attributes = $attribute_adaptor->fetch_all_by_Slice($slice);
+    return $self->_get_checksums_from_attributes($attributes, 'toplevel', $slice->seq_region_name(), $slice->get_seq_region_id());
+}
+
+sub _get_cdna_checksums {
+    my ($self, $transcript, $attribute_adaptor) = @_;
+    my $attributes = $attribute_adaptor->fetch_all_by_Transcript($transcript);
+    return $self->_get_checksums_from_attributes($attributes, 'cdna', $transcript->stable_id_version(), $transcript->dbID());
+}
+
+sub _get_cds_checksums {
+    my ($self, $transcript, $attribute_adaptor) = @_;
+    my $attributes = $attribute_adaptor->fetch_all_by_Transcript($transcript);
+    return $self->_get_checksums_from_attributes($attributes, 'cds', $transcript->stable_id_version(), $transcript->dbID());
+}
+
+sub _get_protein_checksums {
+    my ($self, $translation, $attribute_adaptor) = @_;
+    my $attributes = $attribute_adaptor->fetch_all_by_Translation($translation);
+    return $self->_get_checksums_from_attributes($attributes, 'pep', $translation->stable_id_version(), $translation->dbID());
+}
+
+sub _verify_checksums_match {
+    my ($self, $generated_checksums, $retreived_checksums, $type, $id, $db_id) = @_;
+    foreach my $checksum (qw/md5 sha512t24u/) {
+        if($generated_checksums->{$checksum} ne $retreived_checksums->{$checksum}) {
+            my $error_string = sprintf(
+                'The stored %s %s checksum (%s) for ID %s dbID %d does not match the calculated checksum (%s)',
+                $type, $checksum, $retreived_checksums->{$checksum}, $id, $db_id, $generated_checksums->{$checksum}
+            );
+            $self->throw($error_string);
+        }
+    }
+    return 1;
+}
+
+1;

--- a/scripts/refget/check_sequence_refget.pl
+++ b/scripts/refget/check_sequence_refget.pl
@@ -1,0 +1,321 @@
+#!/usr/bin/env perl
+# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package Script;
+
+use strict;
+use warnings;
+use feature 'say';
+
+use Bio::EnsEMBL::Registry;
+use Bio::EnsEMBL::Utils::Exception qw/throw warning/;
+use HTTP::Tiny;
+use Text::CSV;
+use Getopt::Long qw/:config no_ignore_case auto_version bundling_override/;
+use Pod::Usage;
+use File::Spec;
+
+sub run {
+  my ($class) = @_;
+  my $self = bless({}, $class);
+  $self->args();
+  $self->setup();
+  $self->process();
+  return;
+}
+
+sub args {
+  my ($self) = @_;
+  my $opts = {
+    port => 3306,
+    refget => 'https://www.ebi.ac.uk/ena/cram',
+  };
+  GetOptions(
+    $opts, qw/
+      release|version=i
+      host|hostname|h=s
+      port|P=i
+      username|user|u=s
+      password|pass|p=s
+      species=s
+      group=s
+      refget=s
+      output_dir=s
+      verbose
+      help
+      man
+      /
+  ) or pod2usage(-verbose => 1, -exitval => 1);
+  pod2usage(-verbose => 1, -exitval => 0) if $opts->{help};
+  pod2usage(-verbose => 2, -exitval => 0) if $opts->{man};
+  $self->{opts} = $opts;
+  return;
+}
+
+sub opts {
+  my ($self) = @_;
+  return $self->{'opts'};
+}
+
+sub setup {
+  my ($self) = @_;
+  my $o = $self->opts();
+
+  if(!$o->{output_dir}) {
+    throw("No output location given. Exiting");
+  }
+  my $output_dir = $o->{output_dir};
+  if(! -d $output_dir) {
+    throw("Output directory '${output_dir}' does not exist. Exiting");
+  }
+
+  $self->v('Using the database server %s@%s:%d', map { $o->{$_} } qw/username host port/);
+
+  ##SETTING UP REGISTRY
+  my %args = (
+    -HOST => $o->{host}, -PORT => $o->{port},
+    -USER => $o->{username}
+  );
+  $args{-DB_VERSION} = $o->{release};
+  $args{-PASS} = $o->{password} if $o->{password};
+  # $args{-VERBOSE} = 1 if $o->{verbose};
+  my $loaded = Bio::EnsEMBL::Registry->load_registry_from_db(%args);
+  $self->v('Loaded %d DBAdaptor(s)', $loaded);
+
+  return;
+}
+
+sub process {
+  my ($self) = @_;
+  my $dbas = $self->_get_dbs();
+  while (my $dba = shift @{$dbas}) {
+    $self->_process_dba($dba);
+  }
+  return
+}
+
+sub _process_dba {
+  my ($self, $dba) = @_;
+  $self->v('Working with species %s and group %s', $dba->species(), $dba->group());
+  my $production_name = $dba->get_MetaContainer()->get_production_name();
+
+  #Setup files
+  my $output_file = "${production_name}.csv";
+  my $output = File::Spec->catfile($self->opts()->{output_dir}, $output_file);
+  open(my $fh, ">:encoding(utf8)", $output) or throw("${output}: $!");
+  my $csv = $self->csv();
+
+  my $checksums = $self->_get_checksums($dba);
+  my @slices = @{$dba->get_SliceAdaptor()->fetch_all('toplevel', undef, 1, undef, undef)};
+  while(my $slice = shift @slices) {
+    my $seq_region_id = $slice->get_seq_region_id();
+    my $region_name = $slice->seq_region_name();
+    my $length = $slice->length();
+    my $md5 = $checksums->{$seq_region_id};
+    my $exists = $self->sequence_exists($md5);
+    my $row = [$production_name, $seq_region_id, $md5, $region_name, $length, $exists];
+    $csv->say($fh, $row);
+  }
+  #Cleanup
+  $dba->dbc()->disconnect_if_idle();
+  close($fh) or throw("Cannot close ${output}: $!");
+  return;
+}
+
+sub sequence_exists {
+    my ($self, $md5) = @_;
+    my $url = $self->opts->{refget};
+    my $full_url = "${url}/sequence/${md5}/metadata";
+    my $headers = {};
+    # ENA server issue. Does not accept application/json but does return correct
+    # data if you omit this.
+    if($url !~ /www\.ebi\.ac\.uk\/ena\/cram/) {
+        $headers->{Accept} = 'application/json';
+    }
+    my $res = $self->http_tiny()->get($full_url, { headers => $headers } );
+    return ($res->{success}) ? 1 : 0;
+}
+
+sub http_tiny {
+  my ($self) = @_;
+  if(! exists $self->{http_tiny}) {
+    $self->{http_tiny} = HTTP::Tiny->new();
+  }
+  return $self->{http_tiny};
+}
+
+sub csv {
+  my ($self) = @_;
+  if(! exists $self->{csv}) {
+    $self->{csv} = Text::CSV->new ({ binary => 1, auto_diag => 1 });
+  }
+  return $self->{csv};
+}
+
+sub _get_checksums {
+  my ($self, $dba) = @_;
+  my $sql = << 'EOF';
+  SELECT sr.seq_region_id, att.value
+FROM seq_region sr
+JOIN coord_system cs on cs.coord_system_id = sr.coord_system_id
+JOIN seq_region_attrib att ON sr.seq_region_id = att.seq_region_id
+JOIN attrib_type at on att.attrib_type_id = at.attrib_type_id
+WHERE cs.species_id =?
+AND at.code =?
+EOF
+  my $params = [$dba->species_id(), 'md5_toplevel'];
+  my $lookup = $dba->dbc()->sql_helper()->execute_into_hash(-SQL => $sql, -PARAMS => $params);
+  return $lookup;
+}
+
+sub _get_dbs {
+  my ($self) = @_;
+  my $dbas;
+  my %args;
+  $args{-SPECIES} = $self->opts->{species} if $self->opts->{species};
+  $args{-GROUP} = $self->opts->{group} if $self->opts->{group};
+  if(%args) {
+    $dbas = Bio::EnsEMBL::Registry->get_all_DBAdaptors(%args);
+  }
+  else {
+     $dbas = Bio::EnsEMBL::Registry->get_all_DBAdaptors();
+  }
+  my @final_dbas;
+  while(my $dba = shift @{$dbas}) {
+    next if $dba->species() eq 'multi';
+    next if lc($dba->species()) =~ /ancestral sequences/;
+    next if $dba->dbc()->dbname() =~ /^.+_userdata$/xms;
+
+    my $type = $dba->get_MetaContainer()->single_value_by_key('schema_type');
+    $dba->dbc()->disconnect_if_idle();
+    next unless $type;
+    push(@final_dbas, $dba) if $type eq 'core';
+  }
+  $self->v('Found %d core like database(s)', scalar(@final_dbas));
+  return [sort { $a->species() cmp $b->species() } @final_dbas];
+}
+
+sub v {
+  my ($self, $msg, @params) = @_;
+  return unless $self->opts()->{verbose};
+  say sprintf($msg, @params);
+  return;
+}
+
+Script->run();
+
+1;
+__END__
+
+=pod
+
+=head1 NAME
+
+check_sequence_refget.pl
+
+=head1 SYNOPSIS
+
+  #BASIC
+  ./check_sequence_refget.pl -release VER -user USER -pass PASS -host HOST [-port PORT] \
+                      [-species SPECIES] [-group GROUP] \
+                      [-output_dir PATH] \
+                      [-verbose] \
+                      [-help | -man]
+
+  #EXAMPLE
+  ./check_sequence_refget.pl -release 110 -host ensembdb.ensembl.org -port 5306 -user anonymous -species homo_sapiens -group core
+
+  #Everything for a release
+  ./check_sequence_refget.pl -release 110 -host ensembdb.ensembl.org -port 5306 -user anonymous -group core
+
+=head1 DESCRIPTION
+
+A script which goes through a given genome and looks to see if its sequences are all to be found in the specified refget instance. It 
+does this by looking for the md5 checksum attribute C<md5_toplevel> (so a DB must have had checksums run against it) and
+queries refget for the sequence's existence. Will write data to the specified file. It is recommended to run this once. 
+Primary use is to record existence in ENA's refget instance
+
+=head1 OPTIONS
+
+=over 8
+
+=item B<--username | --user | -u>
+
+REQUIRED. Username of the connecting account
+
+=item B<--password | -pass | -p>
+
+REQUIRED. Password of the connecting user.
+
+=item B<--release | --version>
+
+REQUIRED. Indicates the release of Ensembl to process
+
+=item B<--host | --host | -h>
+
+REQUIRED. Host name of the database to connect to
+
+=item B<--port | -P>
+
+Optional integer of the database port. Defaults to 3306.
+
+=item B<--species>
+
+Specify the tests to run over a single species' set of core databases
+
+=item B<--group>
+
+Only run tests on a single type of database registry group
+
+=item B<--refget>
+
+Run tests against the given refget server. Defaults to C<https://www.ebi.ac.uk/ena/cram>.
+
+=item B<--output_dir>
+
+REQUIRED. Write information about the sequence's existence in ENA. Will write to a CSV file 
+with the columns C<production_name,seq_region_id,md5,region_name,length,exists> where exists is set to a 1 or 0. 
+Will create a file per species processed of the format C<production_name.csv>
+
+=item B<--verbose>
+
+Write messages about progress
+
+=item B<--help>
+
+Help message
+
+=item B<--man>
+
+Man page
+
+=back
+
+=head1 REQUIREMENTS
+
+=over 8
+
+=item Perl 5.10+
+
+=item Bio::EnsEMBL
+
+=item Text::CSV
+
+=item HTTP::Tiny
+
+=back
+
+=end

--- a/scripts/refget/check_sequence_refget.pl
+++ b/scripts/refget/check_sequence_refget.pl
@@ -54,6 +54,7 @@ sub args {
       group=s
       refget=s
       output_dir=s
+      check_refget
       verbose
       help
       man
@@ -137,6 +138,9 @@ sub _process_dba {
 
 sub sequence_exists {
     my ($self, $md5) = @_;
+    if(! $self->opts()->{check_refget}) {
+      return -1;
+    }
     my $url = $self->opts->{refget};
     my $full_url = "${url}/sequence/${md5}/metadata";
     my $headers = {};
@@ -232,6 +236,7 @@ check_sequence_refget.pl
   ./check_sequence_refget.pl -release VER -user USER -pass PASS -host HOST [-port PORT] \
                       [-species SPECIES] [-group GROUP] \
                       [-output_dir PATH] \
+                      [-check_refget] \
                       [-verbose] \
                       [-help | -man]
 
@@ -239,7 +244,7 @@ check_sequence_refget.pl
   ./check_sequence_refget.pl -release 110 -host ensembdb.ensembl.org -port 5306 -user anonymous -species homo_sapiens -group core
 
   #Everything for a release
-  ./check_sequence_refget.pl -release 110 -host ensembdb.ensembl.org -port 5306 -user anonymous -group core
+  ./check_sequence_refget.pl -release 110 -host ensembdb.ensembl.org -port 5306 -user anonymous -group core -check_refget
 
 =head1 DESCRIPTION
 
@@ -287,8 +292,12 @@ Run tests against the given refget server. Defaults to C<https://www.ebi.ac.uk/e
 =item B<--output_dir>
 
 REQUIRED. Write information about the sequence's existence in ENA. Will write to a CSV file 
-with the columns C<production_name,seq_region_id,md5,region_name,length,exists> where exists is set to a 1 or 0. 
-Will create a file per species processed of the format C<production_name.csv>
+with the columns C<production_name,seq_region_id,md5,region_name,length,exists> where exists is set to a 1 or 0 (or -1 
+if C<--check_refget> wasn't on). Will create a file per species processed of the format C<[production_name].csv>.
+
+=item B<--check_refget>
+
+Run the check against refget for every md5 checksum. If not set, then the output in the CSV will be B<-1>.
 
 =item B<--verbose>
 


### PR DESCRIPTION
## Description

New pipeline which

- Takes in a core database
- Generates the checksums
- Checks if there has been drift against previously stored checksums (can be turned off)
- Checks if toplevel seqs are in ENA refget (avoids storing if they are)
- Inserts into Perl Refget using its DBIX::Class
- Creates transactions around each slice
- Will only insert new molecule data for the same id,sequence,type when it's a new release

## Use case

We need sequences in refget for MVP and this loads them from a core database rather than a FASTA file.

## Benefits

We don't need to go through the FTP site and we get better coverage of the transcripts (already an issue)

## Possible Drawbacks

Might be slow.

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

I've run this locally and tested. Point me at the test suite and I'll do that too if needed.

Dependencies
------------

Deployments must have a copy of the Perl reference impl of Refget to run this code (due to DBIX::Class model dependency) available from https://github.com/andrewyatz/refget-server-perl plus the obvious dependencies e.g. DBIx::Class, DBD::Pg.
