### PR TITLE
Update ChecksumGenerator.pm

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Ga4ghChecksum/ChecksumGenerator.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Ga4ghChecksum/ChecksumGenerator.pm
@@ -340,8 +340,7 @@ sub delete_checksums {
                     inner join coord_system using (coord_system_id)
                     inner join meta using (species_id)
                     inner join attrib_type using (attrib_type_id)
-                    where meta_key = 'species.db_name'
-                        and meta_value = ?
+                    where coord_system.species_id = ?
                         and code = ?
             ";
         } elsif ($seq_type eq 'cdna' or $seq_type eq 'cds') {
@@ -353,8 +352,7 @@ sub delete_checksums {
                     inner join coord_system using (coord_system_id)
                     inner join meta using (species_id)
                     inner join attrib_type using (attrib_type_id)
-                    where meta_key = 'species.db_name'
-                        and meta_value = ?
+                    where coord_system.species_id = ?
                         and code = ?
             ";
         } elsif ($seq_type eq 'pep') {
@@ -367,8 +365,7 @@ sub delete_checksums {
                     inner join coord_system using (coord_system_id)
                     inner join meta using (species_id)
                     inner join attrib_type using (attrib_type_id)
-                    where meta_key = 'species.db_name'
-                        and meta_value = ?
+                    where coord_system.species_id = ?
                         and code = ?
             ";
         }
@@ -379,7 +376,7 @@ sub delete_checksums {
             my $at_code = $hash_type . "_" . $seq_type;
 
             my $sth = $dba->dbc->db_handle->prepare($sql);
-            my $records = $sth->execute($species, $at_code);
+            my $records = $sth->execute($dba->species_id(), $at_code);
             $self->warning("Deleted $records for species $species, type $at_code from table $attrib_table");
         }
     }


### PR DESCRIPTION
Existing delete SQL query considers meta_key `species.db_name`  which exits for collection db alone and fails to delete attributes for non-collection dbs.
