### PR TITLE
Removed RNASeq tests from FileDump for RR

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FileDumpCore_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FileDumpCore_conf.pm
@@ -40,9 +40,7 @@ sub default_options {
       'Geneset_GTF',
       'Xref_TSV',
     ],
-    rnaseq_types => [
-      'RNASeq_Exists',
-    ],
+    rnaseq_types => [],
 
     dump_metadata => 1,
 


### PR DESCRIPTION
## Description

Remove RNASeq_exists DC test from dump, now obsolete. 

## Use case

Stop spamming GB team with obsolete message for RR FTP dumps. 

## Benefits

No mails

## Possible Drawbacks

Actual missing files will be really missing.

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
