### PR TITLE
Add gencode primary tag to GFF3 files

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_GFF3.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_GFF3.pm
@@ -274,6 +274,9 @@ sub Bio::EnsEMBL::Transcript::summary_as_hash {
     push(@tags, $mane_type) if ($mane_type);
   }
 
+  my $gencode_primary = $self->get_all_Attributes('gencode_primary');
+  push(@tags, 'GENCODE Primary') if @{$gencode_primary};
+
   $summary{'tag'} = \@tags if @tags;
 
   # Check for seq-edits

--- a/modules/Bio/EnsEMBL/Production/Pipeline/GFF3/DumpFile.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/GFF3/DumpFile.pm
@@ -290,6 +290,9 @@ sub Bio::EnsEMBL::Transcript::summary_as_hash {
     push(@tags, $mane_type) if ($mane_type);
   }
 
+  my $gencode_primary = $self->get_all_Attributes('gencode_primary');
+  push(@tags, 'GENCODE Primary') if @{$gencode_primary};
+
   $summary{'tag'} = \@tags if @tags;
 
   # Add xrefs


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Adding the tag 'Gencode Primary' into dumped GFF3 files.

## Use case

A new transcript attribute, gencode primary, was added to transcripts (human). This attribute needs to be reflected in the GFF3 files dumped from the core db, in the form of the 'tag' field (like previously attributes gencode_basic, canonical, etc...). This change was added in the 2 pipelines that can dump GFF3 files.

## Benefits

Consistency between data in core db and GFF3 files.

## Possible Drawbacks

None

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
