### PR TITLE
Changed the path for `pipeline_dir` to match our hps simplified direc…

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FileDumpVEP_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FileDumpVEP_conf.pm
@@ -38,10 +38,11 @@ sub default_options {
     # (the vep conf overrides them with values we don't want)
     ensembl_release => Bio::EnsEMBL::ApiVersion::software_version(), 
     pipeline_name   => $self->default_pipeline_name().'_'.$self->o('rel_with_suffix'),
-
     # The sub_dir is there to allow for this pipeline to match
     # the current main site structure, but also give flexibility
     # for RR structure, if/when that becomes necessary.
+    tmp_base_dir => '/hps/nobackup/flicek/ensembl/production',
+    tmp_dir => catdir($self->o('tmp_base_dir'), $ENV{'USER'}, 'vepdump'),
     target_dir   => catdir($self->o('dump_dir'), $self->o('sub_dir')),
     pipeline_dir => catdir($self->o('vep_dir')),
 	};

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FileDumpVEP_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FileDumpVEP_conf.pm
@@ -43,7 +43,7 @@ sub default_options {
     # the current main site structure, but also give flexibility
     # for RR structure, if/when that becomes necessary.
     target_dir   => catdir($self->o('dump_dir'), $self->o('sub_dir')),
-    pipeline_dir => catdir($self->o('vep_dir'), $self->o('sub_dir')),
+    pipeline_dir => catdir($self->o('vep_dir')),
 	};
 }
 


### PR DESCRIPTION
…tory structure.

## Description

Pipeline dir was set with the extra from sub_dir, removed this part for the pipeline files to be generated under single 'vep_dir' group. which will append the division automatically
Related SOP updated https://www.ebi.ac.uk/seqdb/confluence/display/GTI/Data+dumping#Datadumping-VEPfiles 

## Use case

VEP dumps runs for 112 release. 

## Benefits

No more messy directory structure (the `pipeline_dir` is the `vep_dir`)

## Possible Drawbacks

None

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
