### PR TITLE
RefSeq peptide Cleanup Fix

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/CleanupRefseqPeptide.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/CleanupRefseqPeptide.pm
@@ -89,7 +89,7 @@ sub run {
       while (<$in_fh>) {
         if ($_ =~ /^REFERENCE/ || $_ =~ /^COMMENT/ || $_ =~ /^\s{5}Protein/) {
           $skip_data = 1;
-        } elsif ($_ =~ /^\s{5}source/ || $_ =~ /^\s{5}CDS/) {
+        } elsif ($_ =~ /^\s{5}source/ || $_ =~ /^\s{5}CDS/ || $_ =~ /^ORIGIN/) {
           $skip_data = 0;
         }
         if (!$skip_data) {print $out_fh $_;}


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Fix for the RefSeq peptide files cleanup.

## Use case

A bug was discovered in the process the cleans up the RefSeq peptide files (removes irrelevant data). The bug was leading to some incorrect xref information in the peptide files. This change fixes that.

## Benefits

Bug fix.

## Possible Drawbacks

Need to re-run the cleanup process for the currently running pipeline.

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
