### PR TITLE
Hotfix/xref tsv dump

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Xref_TSV.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Xref_TSV.pm
@@ -103,11 +103,18 @@ sub print_xrefs {
     my $external_db_list = join(", ", map { "'$_'" } @$external_dbs);
     $edb_filter = " AND e.db_name in ($external_db_list) ";
   }
-  $file->append("\n");
-  $self->print_xref_subset( $file, $self->go_xref_sql($edb_filter) );
-  $self->print_xref_subset( $file, $self->gene_xref_sql($edb_filter) );
-  $self->print_xref_subset( $file, $self->transcript_xref_sql($edb_filter) );
-  $self->print_xref_subset( $file, $self->translation_xref_sql($edb_filter) );
+
+  # The append method opens and closes the file every time it is called.
+  # We therefore get the filehandle - also needlessly locking the file -
+  # to avoid this unwanted behaviour
+
+  my $fh = $file->opena({ locked => 1 });
+  print $fh "\n";
+  $self->print_xref_subset( $fh, $self->go_xref_sql($edb_filter) );
+  $self->print_xref_subset( $fh, $self->gene_xref_sql($edb_filter) );
+  $self->print_xref_subset( $fh, $self->transcript_xref_sql($edb_filter) );
+  $self->print_xref_subset( $fh, $self->translation_xref_sql($edb_filter) );
+  close $fh or die("Error while closing the file: $@");
 }
 
 sub print_xref_subset {
@@ -118,10 +125,15 @@ sub print_xref_subset {
     -SQL => $sql
   );
 
-  foreach my $result (@$results) {
-    $file->append(join("\t", @$result));
-    $file->append("\n");
-  }
+    foreach my $result (@$results) {
+      eval {
+        print $file join("\t", @$result);
+        print $file "\n";
+      };
+      if($@) {
+         die("Could not print results to file: $@");
+      }
+    }
 }
 
 sub go_xref_sql {


### PR DESCRIPTION
## Description

This is a PR sister to #840 .

Changes are the same: `Xref_TSV.pm` as per writing TSV file to file system.

The `append` method of `Path::Tiny` assumes data are provided as a whole: it therefore opens, writes out and closes the file.
Used in a loop, this method opens and closes the underlying file every time. This is not desireable for many reasons.
Some exception checking are also added.

## Use case

The pipeline analysis "Xref_TSV" takes forever to run and may also fails - especially on SLURM.

## Benefits

Enhanced performance. Better use of the FS.

## Possible Drawbacks

None.

## Testing

Test suite runs fine

Dependencies
------------

None
