### PR TITLE
Fix for "scalar on reference"

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/AlphaFold/InsertProteinFeatures.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/AlphaFold/InsertProteinFeatures.pm
@@ -171,7 +171,7 @@ sub run {
             info("Found GIFTS file $file, species: $1, assembly: $2, release: $3");
             if ($2 eq $assembly) {
                 $mappings = read_gifts_data("$gifts_dir/$file");
-                info("Read data for GIFTS from file $gifts_dir/file, " . (scalar (keys ($mappings))) . " entries");
+                info("Read data for GIFTS from file $gifts_dir/file, " . (scalar (keys %$mappings)) . " entries");
                 last;
             }
         }


### PR DESCRIPTION
In the code, scalar was called on a hash reference. This is either not permitted or produces a warning, depending on the Perl version. Fixed.