### PR TITLE
Alphafold - Fixes for pipe config and cleanup

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/AlphaFold/InsertProteinFeatures.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/AlphaFold/InsertProteinFeatures.pm
@@ -97,6 +97,7 @@ sub fetch_input {
     $self->param_required('species');
     $self->param_required('db_dir');
     $self->param_required('species_list');
+    $self->param_required('gifts_pass');
 
     return 1;
 }


### PR DESCRIPTION
- The pipeline config did not pass the gifts_pass parameter to the runnable
- Added an early check for gifts_pass so it is required at pipeline creation
- cleanup was running too early. Changed the logic
