### PR TITLE
Xref Fix and Process Xref Slurm resources

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/XrefProcess_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/XrefProcess_conf.pm
@@ -76,7 +76,7 @@ sub pipeline_analyses {
       '1->A' => 'schedule_species',
       'A->1' => 'EmailAdvisoryXrefReport'
     },
-    -rc_name    => 'small',
+    -rc_name    => 'default',
   },
   {
     -logic_name => 'schedule_species',
@@ -93,7 +93,7 @@ sub pipeline_analyses {
       '2->A' => 'schedule_source',
       'A->2' => 'schedule_dependent_source'
     },
-    -rc_name    => 'small',
+    -rc_name    => 'default',
   },
   {
     -logic_name => 'schedule_source',
@@ -112,7 +112,7 @@ sub pipeline_analyses {
       xref_pass  => $self->o('xref_pass'),
     },
     -flow_into  => { '2' => 'parse_source' },
-    -rc_name    => 'small',
+    -rc_name    => '1GB_D',
     -analysis_capacity => 10,
   },
   {
@@ -133,7 +133,7 @@ sub pipeline_analyses {
       '2->A' => 'parse_source',
       'A->1' => 'schedule_tertiary_source',
     },
-    -rc_name    => 'small',
+    -rc_name    => '4GB_D',
   },
   {
     -logic_name => 'schedule_tertiary_source',
@@ -153,12 +153,12 @@ sub pipeline_analyses {
       '2->A' => 'parse_source',
       'A->1' => 'dump_ensembl',
     },
-    -rc_name    => 'small',
+    -rc_name    => 'default',
   },
   {
     -logic_name        => 'parse_source',
     -module            => 'Bio::EnsEMBL::Production::Pipeline::Xrefs::ParseSource',
-    -rc_name           => 'large',
+    -rc_name           => '16GB_D',
     -hive_capacity     => 300,
     -analysis_capacity => 50,
     -batch_size        => 30,
@@ -177,7 +177,7 @@ sub pipeline_analyses {
       '2->A' => 'dump_xref',
       'A->1' => 'schedule_mapping'
     },
-    -rc_name    => 'mem',
+    -rc_name    => '16GB_D',
   },
   {
     -logic_name => 'dump_xref',
@@ -188,7 +188,7 @@ sub pipeline_analyses {
       config_file => $self->o('config_file')
     },
     -flow_into  => { 2 => 'align_factory' },
-    -rc_name    => 'normal',
+    -rc_name    => '1GB',
   },
   {
     -logic_name => 'align_factory',
@@ -197,7 +197,7 @@ sub pipeline_analyses {
       base_path => $self->o('base_path'),
       release   => $self->o('release')},
     -flow_into  => { 2 => 'align' },
-    -rc_name    => 'small',
+    -rc_name    => 'default',
   },
   {
     -logic_name        => 'align',
@@ -205,7 +205,7 @@ sub pipeline_analyses {
     -parameters        => {
       base_path => $self->o('base_path')
     },
-    -rc_name           => 'large',
+    -rc_name           => '16GB_D',
     -hive_capacity     => 300,
     -analysis_capacity => 300,
     -batch_size        => 5,
@@ -222,7 +222,7 @@ sub pipeline_analyses {
       '2->A' => ['direct_xrefs', 'rnacentral_mapping'],
       'A->1' => 'mapping'
     },
-    -rc_name    => 'small',
+    -rc_name    => '1GB',
   },
   {
     -logic_name => 'direct_xrefs',
@@ -232,7 +232,7 @@ sub pipeline_analyses {
       release   => $self->o('release')
     },
     -flow_into  => { 1 => 'process_alignment' },
-    -rc_name    => 'normal',
+    -rc_name    => '1GB_D',
     -analysis_capacity => 30
   },
   {
@@ -242,7 +242,7 @@ sub pipeline_analyses {
       base_path => $self->o('base_path'),
       release   => $self->o('release')
     },
-    -rc_name    => 'normal',
+    -rc_name    => '1GB_D',
     -analysis_capacity => 30
   },
   {
@@ -253,7 +253,7 @@ sub pipeline_analyses {
       release   => $self->o('release')
     },
     -flow_into  => { 1 => 'uniparc_mapping' },
-    -rc_name    => 'normal',
+    -rc_name    => 'default',
     -hive_capacity => 300,
     -analysis_capacity => 30
   },
@@ -265,7 +265,7 @@ sub pipeline_analyses {
       release   => $self->o('release')
     },
     -flow_into  => { 1 => 'coordinate_mapping' },
-    -rc_name    => 'normal',
+    -rc_name    => '1GB',
     -hive_capacity => 300,
     -analysis_capacity => 30
   },
@@ -276,7 +276,7 @@ sub pipeline_analyses {
       base_path => $self->o('base_path'),
       release   => $self->o('release')
     },
-    -rc_name    => 'mem',
+    -rc_name    => '16GB',
     -analysis_capacity => 30
   },
   {
@@ -290,25 +290,26 @@ sub pipeline_analyses {
       '1->A' => 'RunXrefCriticalDatacheck',
       'A->1' => 'RunXrefAdvisoryDatacheck'
     },
-    -rc_name    => 'mem',
+    -rc_name    => '16GB_D',
     -analysis_capacity => 30,
   },
   {
-    -logic_name        => 'RunXrefCriticalDatacheck',
-    -module            => 'Bio::EnsEMBL::DataCheck::Pipeline::RunDataChecks',
-    -max_retry_count   => 1,
-    -analysis_capacity => 10,
-    -batch_size        => 10,
-    -parameters        => {
-      datacheck_names  => ['ForeignKeys'],
-      datacheck_groups => ['xref_mapping'],
-      datacheck_types  => ['critical'],
-      registry_file    => $self->o('registry'),
-      config_file      => $self->o('dc_config_file'),
-      history_file     => $self->o('history_file'),
-      old_server_uri   => $self->o('old_server_uri'),
-      failures_fatal   => 1,
-    },
+      -logic_name        => 'RunXrefCriticalDatacheck',
+      -module            => 'Bio::EnsEMBL::DataCheck::Pipeline::RunDataChecks',
+      -max_retry_count   => 1,
+      -analysis_capacity => 10,
+      -batch_size        => 10,
+      -parameters        => {
+          datacheck_names  => [ 'ForeignKeys' ],
+          datacheck_groups => [ 'xref_mapping' ],
+          datacheck_types  => [ 'critical' ],
+          registry_file    => $self->o('registry'),
+          config_file      => $self->o('dc_config_file'),
+          history_file     => $self->o('history_file'),
+          old_server_uri   => $self->o('old_server_uri'),
+          failures_fatal   => 1,
+      },
+      -rc_name           => '1GB',
   },
   {
     -logic_name        => 'RunXrefAdvisoryDatacheck',
@@ -325,12 +326,14 @@ sub pipeline_analyses {
       old_server_uri   => $self->o('old_server_uri'),
       failures_fatal   => 0,
     },
-    -flow_into         => { 4 => 'AdvisoryXrefReport' }
+    -flow_into         => { 4 => 'AdvisoryXrefReport' },
+    -rc_name           => '1GB',
+
   },
   {
     -logic_name => 'AdvisoryXrefReport',
     -module     => 'Bio::EnsEMBL::Production::Pipeline::Xrefs::AdvisoryXrefReport',
-    -rc_name    => 'small'
+    -rc_name    => 'default'
   },
   {
     -logic_name => 'EmailAdvisoryXrefReport',
@@ -340,7 +343,7 @@ sub pipeline_analyses {
       pipeline_name => $self->o('pipeline_name'),
       base_path => $self->o('base_path')
     },
-    -rc_name    => 'small',
+    -rc_name    => 'default',
     -flow_into  => { 1 => 'notify_by_email' }
   },
   {
@@ -350,22 +353,11 @@ sub pipeline_analyses {
       email        => $self->o('email'),
       pipeline_name => $self->o('pipeline_name')
     },
-    -rc_name    => 'small'
+    -rc_name    => 'default'
   }
   ];
 }
 
-sub resource_classes {
-  my ($self) = @_;
-
-  return {
-    %{$self->SUPER::resource_classes},
-    'small'  => { 'LSF' => '-q production -M 200 -R "rusage[mem=200]"' },
-    'normal' => { 'LSF' => '-q production -M 500 -R "rusage[mem=500]"' },
-    'mem'    => { 'LSF' => '-q production -M 3000 -R "rusage[mem=3000]"' },
-    'large'  => { 'LSF' => '-q production -M 10000 -R "rusage[mem=10000]"' },
-  }
-}
 
 sub pipeline_wide_parameters {
   my ($self) = @_;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/ScheduleSource.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/ScheduleSource.pm
@@ -126,7 +126,9 @@ sub run {
       $self->dataflow_output_id($dataflow_params, 2);
     } else {
       # Create list of files
-      my @list_files = `ls $file_name`;
+      opendir(my $dir_handle, $file_name);
+      my @list_files = readdir($dir_handle);
+      closedir($dir_handle);
       if ($preparse) { @list_files = $preparse; }
       foreach my $file (@list_files) {
         $file =~ s/\n//;


### PR DESCRIPTION
## Description

This PR fixes the failures in the Plant Xref pipeline and provide slurm support for that pipeline.

## Use case

The plants xref have db problems and fail to complete this should fix it. In addition the slurm resource classes were used over the stnandrd Infra resources

## Possible Drawbacks

It could break at some point

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ X] Have you run the entire test suite and no regression was detected?
- [ X] TravisCI passed on your branch

