### PR TITLE
Check that pepstats is there

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Production/PepStats.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Production/PepStats.pm
@@ -103,8 +103,9 @@ sub run_pepstats {
   my $attribs = {};
   my $tid;
   close(OUT);
-  foreach my $line (@lines) {
+  die("pepstats command not found ($PEPSTATS)") if ($lines[0] =~ /command not found/);
 
+  foreach my $line (@lines) {
 	if ($line =~ /PEPSTATS of ([^ ]+)/) {
 	  $tid = $1;
 	} elsif (defined $tid) {


### PR DESCRIPTION
Fix a bug where the runnable continues running and finishes silently even if the binary for pepstats is not available.

## Description

Add a simple check for when the pepstats binary is not available.

## Use case

Used in Core stats pipeline. Currently if pepstats is missing, PepStats still completes silently, then PepStats_Datachecks finds that no peptide attributes have been added to the database.

## Benefits

Prevent the runnable from silently finishing when it should fail and be restarted with a working binary path.

## Possible Drawbacks

None

## Testing

No tests added. Used this commit to run a core stats pipeline when pepstats was missing in the environment. After adding a working path to a pepstats binary and restarting the PepStats jobs, the next datachecks pass.

Dependencies
------------

None
