### PR TITLE
Add check for unvalid readdir output

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/ScheduleSource.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/ScheduleSource.pm
@@ -131,6 +131,7 @@ sub run {
       closedir($dir_handle);
       if ($preparse) { @list_files = $preparse; }
       foreach my $file (@list_files) {
+        next if ($file =~ /^\./);
         $file =~ s/\n//;
         $file = $file_name . "/" . $file;
         if (defined $release_file and $file eq $release_file) { next; }


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Adding line missed in last PR.

## Use case

When changing the use of "ls" into perl's "readdir" in the PR #865 , this check was also supposed to be added to eliminate the unneeded output of readdir. This PR should fix that.

## Benefits

Fix the corruption of file names for xref parsers.

## Possible Drawbacks

None

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
