### PR TITLE
Fix uniprot gene name + cleanup bugs

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/CleanupUniprot.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/CleanupUniprot.pm
@@ -116,7 +116,7 @@ sub run {
         $_ =~ s/\nCC\s{3}.*//g; # Remove comments
         $_ =~ s/\nCT(\s{3}.*)CAUTION: The sequence shown here is derived from an Ensembl(.*)/\nCC$1CAUTION: The sequence shown here is derived from an Ensembl$2/g; # Set temp line back to comment
 	$_ =~ s/\nFT\s{3}.*//g; # Remove feature coordinates
-        $_ =~ s/\nDR\s{3}($sources_to_remove);.*\n//g; # Remove sources skipped at processing
+        $_ =~ s/\nDR\s{3}($sources_to_remove);.*//g; # Remove sources skipped at processing
 
         # Added lines that we do need into output
         print $out_fh $_;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/Parser/UniProtDatabaseParser.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/Parser/UniProtDatabaseParser.pm
@@ -242,7 +242,7 @@ sub run {
         # Make sure these are still lines with Name or Synonyms
         if (($gn !~ /^GN/ || $gn !~ /Name=/) && $gn !~ /Synonyms=/) { last; }
 
-        if ($gn =~ / Name=([A-Za-z0-9_\-\.\s]+)/s) { #/s for multi-line entries ; is the delimiter
+        if ($gn =~ / Name=([A-Za-z0-9_\-\.\s:]+)/s) { #/s for multi-line entries ; is the delimiter
           # Example line 
           # GN   Name=ctrc {ECO:0000313|Xenbase:XB-GENE-5790348};
           my $name = $1;


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Fixing some bugs discovered during the 112 run.

## Use case

During the 112 run of xrefs, a bug in the UniProt file parser was discovered that lead to parsing gene names in a wrong way. Some gene names have a colon ":" character in them that is not captured by the regex used to parse the gene names and thus these names are corrupted. This fixes this issue, along with another minor issue in the UniProt cleanup that was keeping in some information that we don't need in the file (doesn't affect data).

## Benefits

Gene names are read correctly from the UniProt files, including all characters.

## Possible Drawbacks

None. This did not affect the 112 run since a patch was added at the time.

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
