### PR TITLE
Flag outdated taxon_ids in TaxonomyInfoCore pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/TaxonomyUpdate/QueryMetadata.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/TaxonomyUpdate/QueryMetadata.pm
@@ -82,7 +82,24 @@ sub _meta {
   $self->warning('Querying Taxonomy');
   #my $tdba =  Bio::EnsEMBL::Registry->get_DBAdaptor( "multi", "taxonomy" );
   my $taxonomy  = $self->_taxonomy( $tdba, $metadata->{'species.taxonomy_id'});
-  $metadata->{'species.classification'} = $taxonomy; 	
+
+  if (scalar(@{$taxonomy}) == 0) {
+    my $dbname = $self->param('dbname');
+    my $species = $self->param('species');
+    my $taxon_id = $metadata->{'species.taxonomy_id'};
+    my $msg = "Cannot retrieve taxonomy classification for species $species with taxonomy_id $taxon_id in database $dbname;";
+
+    my $primary_taxon_id = $self->_fetch_primary_taxon_id($tdba, $taxon_id);
+    if (defined $primary_taxon_id) {
+      $msg = $msg
+             ." taxon_id $taxon_id has been merged into primary taxon_id $primary_taxon_id."
+             ." Would you kindly set the 'species.taxonomy_id' meta entry for this species to the"
+             ." primary taxon_id and ensure the change is propagated to other relevant databases ?";
+    }
+    throw $msg;
+  }
+
+  $metadata->{'species.classification'} = $taxonomy;
   $self->warning('Updating meta');
   foreach my $key ( keys %{$metadata} ) {
     my $array = wrap_array( $metadata->{$key} );
@@ -147,6 +164,34 @@ SQL
   );
   #$self->warning( 'Classification is [%s]', join( q{, }, @{$res} ) );
   return $res;
+}
+
+
+sub _fetch_primary_taxon_id {
+  my ( $self, $tdba, $taxon_id ) = @_;
+  $self->warning('Querying taxonomy to fetch primary taxon_id');
+  my $sql            = <<'SQL';
+select taxon_id
+from ncbi_taxa_name
+where name = ?
+and name_class = 'merged_taxon_id'
+SQL
+  my $dbc = $tdba->dbc();
+  my $res = $dbc->sql_helper()->execute_simple(
+    -SQL    => $sql,
+    -PARAMS => [ $taxon_id ]
+  );
+  $self->debug( 'Result is [%s]', join( q{, }, @{$res} ) );
+  my $result_count = scalar(@{$res});
+
+  my $primary_taxon_id;
+  if ($result_count == 1) {
+    $primary_taxon_id = $res->[0];
+  } elsif ($result_count > 1) {
+    throw "Expected at most 1 primary taxon_id for $taxon_id but got $result_count";
+  }
+
+  return $primary_taxon_id;
 }
 
 


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required.
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

This PR modifies the `TaxonomyUpdate::QueryMetadata` Hive runnable used in the `TaxonomyInfoCore` pipeline to throw an exception if a species has an outdated Taxonomy ID. If that outdated Taxonomy ID has been merged into another, primary Taxonomy ID, then the error message provides the primary Taxonomy ID and asks the user to ensure that the outdated Taxonomy ID is replaced with its primary Taxonomy ID in the affected core database and other relevant databases.

## Use case

Outdated Taxonomy IDs are periodically flagged by various production processes, for example at the start of Compara production (e.g. [Fungi Compara 108 production](https://github.com/Ensembl/staging-patches/pull/545), [Protists Compara 111 production](https://github.com/Ensembl/staging-patches/pull/605)) or during the generation of taxon tree data by the Web team (e.g. in [Ensembl 110](https://ebi.enterprise.slack.com/archives/C0JBUBFRD/p1679562175503609), [Ensembl 112](https://ebi.enterprise.slack.com/archives/C0F90TQ1X/p1707909223810539)).

It would save time if outdated Taxonomy IDs were flagged at the earliest possible opportunity.

## Benefits

Assuming the `TaxonomyInfoCore` pipeline is run shortly after the `ImportNCBItaxonomy` pipeline, this change would ensure that merged Taxonomy IDs can be identified and updated to their primary Taxonomy ID as soon as possible during production.

## Possible Drawbacks

This frontloads the solution to the issue of outdated Taxonomy IDs, so any issues with outdated Taxonomy IDs would be addressed sooner rather than later.

## Testing

- [ ] Have you added/modified unit tests to test the changes? _No. The new functionality was tested using a modified version of the `TaxonomyUpdate::QueryMetadata` runnable with species `histoplasma_capsulatum_nam1_gca_000149585`._
- [ ] If so, do the tests pass? _No_
- [ ] Have you run the entire test suite and no regression was detected? _No_
- [ ] TravisCI passed on your branch _TBD_

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.

N/A