### PR TITLE
Load InterPro Family data only for canonicals

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/LoadFamily/AddFamilyMembers.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/LoadFamily/AddFamilyMembers.pm
@@ -78,11 +78,13 @@ sub run {
   # create a hash first though, which can then be processed
   # gene_id as key, then sets of protein-family pairs
   my $gene_families = {};
+  # retrieve family data for canonical translations
   my $sql = qq/select t.gene_id, t.transcript_id, pf.hit_name
 		from coord_system c
 		join seq_region s using (coord_system_id)
-		join transcript t using (seq_region_id)
-		join translation tl using (transcript_id)
+        join gene g using(seq_region_id)
+        join transcript t on t.transcript_id = g.canonical_transcript_id
+        join translation tl on tl.translation_id = t.canonical_translation_id
 		join protein_feature pf using (translation_id)
 		join analysis pfa ON (pf.analysis_id=pfa.analysis_id)
 		where pfa.logic_name in ($logic_names)
@@ -104,37 +106,52 @@ sub run {
   my $family_members     = {};
   while ( my ( $gene_id, $hits ) = each %$gene_families ) {
     my $gene = $gene_adaptor->fetch_by_dbID($gene_id);
-    # create and store gene member
-    my $gene_member =
-      Bio::EnsEMBL::Compara::GeneMember->new_from_Gene(
-        -GENE          => $gene,
-        -GENOME_DB     => $genome_db,
-        -BIOTYPE_GROUP => $gene->get_Biotype->biotype_group()
-      );
-    # If there are duplicate stable IDs, trap fatal error from compara
-    # method, so we can skip it and carry on with others.
-    eval {
-      $gene_member_dba->store($gene_member);
-    };
-    if ($@) {
-      my ($msg) = $@ =~ /MSG:\s+([^\n]+)/m;
-      $self->warning('Duplicate stable ID: '.$msg);
+
+    # retrieve or create-and-store gene_member from the current genome_db
+    my $gene_member = $gene_member_dba->fetch_by_stable_id_GenomeDB($gene->stable_id,
+                                                                    $genome_db);
+    my $existing_canonical;
+    if (defined $gene_member) {
+      $existing_canonical = $seq_member_dba->fetch_by_dbID( $gene_member->canonical_member_id );
     } else {
-      for my $hit (@$hits) {
-        my $transcript =
-          $transcript_adaptor->fetch_by_dbID( $hit->[0] );
-          my $seq_member =
-            Bio::EnsEMBL::Compara::SeqMember->new_from_Transcript(
-              -TRANSCRIPT => $transcript,
-              -TRANSLATE  => 'yes',
-              -GENOME_DB  => $genome_db
-            );
+      $gene_member =
+        Bio::EnsEMBL::Compara::GeneMember->new_from_Gene(
+          -GENE          => $gene,
+          -GENOME_DB     => $genome_db,
+          -BIOTYPE_GROUP => $gene->get_Biotype->biotype_group()
+        );
+      $gene_member_dba->store($gene_member);
+    }
+
+    for my $hit (@$hits) {
+      my $transcript =
+        $transcript_adaptor->fetch_by_dbID( $hit->[0] );
+      my $translation_stable_id = $transcript->translation->stable_id;
+
+      if (defined $existing_canonical && $translation_stable_id ne $existing_canonical->stable_id) {
+        $self->warning(sprintf('skipping translation %s because stable ID does not match canonical member %s',
+                               $translation_stable_id, $existing_canonical->stable_id));
+        next;
+      }
+
+      # retrieve or create-and-store seq_member from the current genome_db
+      my $seq_member =
+        $seq_member_dba->fetch_by_stable_id_GenomeDB($translation_stable_id,
+                                                     $genome_db);
+      if (!defined $seq_member) {
+        $seq_member =
+          Bio::EnsEMBL::Compara::SeqMember->new_from_Transcript(
+            -TRANSCRIPT => $transcript,
+            -TRANSLATE  => 'yes',
+            -GENOME_DB  => $genome_db
+          );
         # TODO store CDS too?
         $seq_member->gene_member_id( $gene_member->dbID );
         $seq_member_dba->store($seq_member);
         $seq_member_dba->_set_member_as_canonical($seq_member);
-        push @{ $family_members->{ $hit->[1] } }, $seq_member->dbID();
       }
+
+      push @{ $family_members->{ $hit->[1] } }, $seq_member->dbID();
     }
   } ## end while ( my ( $gene_id, $hits...))
   print "Saving familes for ".$dba->species()."\n";


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

With the changes in this PR:
1. InterPro Family data are loaded only for canonical members.
2. Existing MLSS and member data are reused in the `create_families` and `add_members` steps (respectively) of the `LoadFamily` pipeline.
3. The `FAMILY` method is generated with the standard Compara `method_link_id` for Family data (i.e. `301`).

## Use case

Loading of Family data for non-canonical sequences has led to discrepancies between the Compara canonical member and the Ensembl canonical translation. This has led in turn to a bug affecting the accessbility of gene-tree and homology data for some genes on the Ensembl Fungi and Protists websites.

## Benefits

1. Limiting Family data to canonical members would prevent canonical discrepancies and avoid issues accessing gene-tree/homology data for genes which also have Family data.
2. Reusing existing MLSS and member data would reduce the opportunity for introduction of inconsistencies.
3. Using a standard `method_link_id` for Family data would further enhance consistency.

## Possible Drawbacks

Because InterPro Family data would be restricted to canonicals, a somewhat reduced amount of Family data would be loaded.

## Testing

- [ ] Have you added/modified unit tests to test the changes?

No. The new functionality was tested by running the `LoadFamily` pipeline on a copy of `ensembl_compara_fungi_59_112`.

Following this, the `MemberProductionCounts` datacheck passed on the test database. (This datacheck had failed during testing of [staging patch 641](https://github.com/Ensembl/staging-patches/pull/641).)

The test database was configured in the Fungi Compara sandbox so that the successful loading of the family data could be verified there too (e.g. [SCHCODRAFT_107723](http://wp-np2-25.ebi.ac.uk:5091/Schizophyllum_commune_h4_8_gca_000143185/Gene/Gene_families?db=core;g=SCHCODRAFT_107723)).

- [ ] If so, do the tests pass?

N/A

- [ ] Have you run the entire test suite and no regression was detected?

No

- [ ] TravisCI passed on your branch

TBD

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.

N/A