### PR TITLE
Update EnsemblBlastDumps_conf.pm

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/EnsemblBlastDumps_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/EnsemblBlastDumps_conf.pm
@@ -61,7 +61,7 @@ sub default_options {
     # By default, files are not written if the parent directory
     # (which is the database name) exists.
     overwrite => 0,
-    dump_dir  => '/hps/nobackup/flicek/ensembl/production/ensembl_dumps/ftp/blast_dumps',
+    dump_dir  => undef,
   };
 }
 


### PR DESCRIPTION
It's best to force to specify the path in the init_pipeline.pl. because a default would end up some other peopel writing onto our path if not set.

## Description

Blast dump path not hard coded

## Use case

Best to have this in SOP. 

## Benefits

Usage by other team don't overwrite by default in our path. 

## Possible Drawbacks

None

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
