### PR TITLE
Make refget loader more efficient

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Refget/RefgetLoader.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Refget/RefgetLoader.pm
@@ -415,8 +415,16 @@ sub insert_raw_sequence {
     my ($self, $refget_schema, $seq_ref, $ga4gh_id) = @_;
     my $hash = ga4gh_to_trunc512($ga4gh_id);
     my $rs = $refget_schema->resultset('RawSeq');
-    my $raw_seq = $rs->find_or_create({ checksum => $hash, seq => ${$seq_ref} });
-    return $raw_seq;
+    my $row = $rs->search(
+        { checksum => $checksum },
+        { columns => [qw/ checksum /] }
+    )->single();
+    if($row) {
+        return $row;
+    }
+    my $hash = { checksum => $checksum, seq => $sequence };
+    my $raw_seq = $rs->new_result($hash);
+    return $raw_seq->insert();
 }
 
 ##### Batch checksum attribute retrieval and checking


### PR DESCRIPTION
Based on feedback from Karthick, the code now does a search for only checksum and then avoids pulling back large sequences. Otherwise we end up in a situation where we will fetch the entire sequence that's clashing

**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Based on feedback from Karthick, the code now does a search for only checksum and then avoids pulling back large sequences. Otherwise we end up in a situation where we will fetch the entire sequence that's clashing

## Use case

Refget insertions can be slow. This should speed it up

## Benefits

More speed

## Possible Drawbacks

None really. The code should be fine. But I've not run the tests sorry so I need someone to do that. I have checked this in my refget code though in refget-server-perl so I am pretty sure it's okay.

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

None
