### PR TITLE
StableID Pipeline - optimise index creation

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/StableID/sql/index.sql
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/StableID/sql/index.sql
@@ -13,5 +13,4 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-CREATE INDEX stable_id_db_type ON stable_id_lookup(stable_id, db_type, object_type);
-CREATE INDEX stable_id_object_type ON stable_id_lookup(stable_id, object_type);
+CREATE INDEX stable_id_db_type ON stable_id_lookup(stable_id, object_type, db_type);

--- a/modules/Bio/EnsEMBL/Production/Pipeline/StableID/sql/table.sql
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/StableID/sql/table.sql
@@ -14,15 +14,12 @@
 -- limitations under the License.
 
 CREATE TABLE archive_id_lookup (
-  archive_id  VARCHAR(128) NOT NULL,
+  archive_id  VARCHAR(100) NOT NULL,
   species_id  INTEGER UNSIGNED NOT NULL,
-  db_type     VARCHAR(255) NOT NULL,
-  object_type VARCHAR(255) NOT NULL,
+  db_type     VARCHAR(20) NOT NULL,
+  object_type VARCHAR(20) NOT NULL,
 
-  UNIQUE INDEX archive_id_lookup_idx (archive_id, species_id, db_type, object_type),
-  KEY archive_id_db_type (archive_id, db_type, object_type),
-  KEY archive_id_object_type (archive_id, object_type)
-
+  UNIQUE INDEX archive_id_lookup_idx (archive_id, object_type, db_type, species_id)
 ) COLLATE=latin1_swedish_ci ENGINE=MyISAM;
 
 CREATE TABLE meta (
@@ -48,9 +45,9 @@ CREATE TABLE species (
 ) COLLATE=latin1_swedish_ci ENGINE=MyISAM;
 
 CREATE TABLE stable_id_lookup (
-  stable_id   VARCHAR(128) NOT NULL,	      
+  stable_id   VARCHAR(100) NOT NULL,	      
   species_id  INTEGER UNSIGNED NOT NULL,
-  db_type     VARCHAR(255) NOT NULL,
-  object_type VARCHAR(255) NOT NULL
+  db_type     VARCHAR(20) NOT NULL,
+  object_type VARCHAR(20) NOT NULL
 
 ) COLLATE=latin1_swedish_ci ENGINE=MyISAM;


### PR DESCRIPTION
## Description

The StableID pipeline inserts stable_id's into `stable_id_lookup` and creates indices, which is the correct approach.
However, 
- It creates indices considering the full lengths of VARCHAR fields, which can be large (255)
- It creates indices , which might be made redundant

The approach here is to reduce the lengths of some fields and avoid creating un-needed indices to make the pipeline more efficient.
The reduction proposal is based on considering the actual maximum length of the strings and adding a bit of contingency to it.

## Use case

The index creation takes days in Ensembl main lifecycle.

## Benefits

Significantly speedup for index creation.

## Possible Drawbacks

The changes might not be future proof, because of the "naive" shortening of the fields in the tables.
In case of longer stable IDs, the INSERT statements in "Populate.pm" would fail, and the pipeline would stop.

A more robust approach would be to create index, by using only the leading part of column values.
However, the table `stable_id_lookup` contains records in excess of 800M, and seems reasonable to find a different solution.

## Testing

Tested by running the pipeline. The resulting DB looks bigger than the previous one, which satisfies a "natural" necessary condition for accepting it. 

Dependencies
------------

N/A
