### PR TITLE
Added handling of new Transcript attribute 'gencode_primary'

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_GFF3.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_GFF3.pm
@@ -264,6 +264,7 @@ sub Bio::EnsEMBL::Transcript::summary_as_hash {
 
   my @tags;
   push(@tags, 'basic') if $self->gencode_basic();
+  push(@tags, 'GENCODE primary') if $self->gencode_primary();
   push(@tags, 'Ensembl_canonical') if $self->is_canonical();
   
   # A transcript can have different types of MANE-related attributes (MANE_Select, MANE_Plus_Clinical)

--- a/modules/Bio/EnsEMBL/Production/Pipeline/GFF3/DumpFile.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/GFF3/DumpFile.pm
@@ -280,6 +280,7 @@ sub Bio::EnsEMBL::Transcript::summary_as_hash {
 
   my @tags;
   push(@tags, 'basic') if $self->gencode_basic();
+  push(@tags, 'GENCODE primary') if $self->gencode_primary();
   push(@tags, 'Ensembl_canonical') if $self->is_canonical();
 
   # A transcript can have different types of MANE-related attributes (MANE_Select, MANE_Plus_Clinical)


### PR DESCRIPTION
## Description

A new attribute - GENCODE Primary - for Transcript has been added to `human`.
This attribute - as it will eventually replace GENCODE Basic - must be dumped into the annotation GTF/GFF3 files, as appropriate.

Although changes in the code are species-independent, the new attribute is used only for human.

## Use case

The file dump pipelines must have the ability to add the new attribute, as appropriate.

## Benefits

Transcripts annotated as "GENCODE Primary" will be tagged as such in Ensembl GFF3/GTF files.

## Possible Drawbacks

None

## Testing

The test suite ran fine.

Dependencies
------------
These changes rely on Ensembl Perl API version 113 (new Transcript method to expose the new attribute, similarly to GENCODE Basic):
- ensembl: https://github.com/Ensembl/ensembl/pull/694
- ensembl-io: https://github.com/Ensembl/ensembl-io/pull/159