### PR TITLE
Patched gencode_primary tag for harmonisation purposes

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_GFF3.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_GFF3.pm
@@ -264,6 +264,7 @@ sub Bio::EnsEMBL::Transcript::summary_as_hash {
 
   my @tags;
   push(@tags, 'basic') if $self->gencode_basic();
+  push(@tags, 'gencode_primary') if $self->gencode_primary();
   push(@tags, 'Ensembl_canonical') if $self->is_canonical();
   
   # A transcript can have different types of MANE-related attributes (MANE_Select, MANE_Plus_Clinical)
@@ -273,9 +274,6 @@ sub Bio::EnsEMBL::Transcript::summary_as_hash {
     my $mane_type = $mane->type();
     push(@tags, $mane_type) if ($mane_type);
   }
-
-  my $gencode_primary = $self->get_all_Attributes('gencode_primary');
-  push(@tags, 'GENCODE Primary') if @{$gencode_primary};
 
   $summary{'tag'} = \@tags if @tags;
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/GFF3/DumpFile.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/GFF3/DumpFile.pm
@@ -280,6 +280,7 @@ sub Bio::EnsEMBL::Transcript::summary_as_hash {
 
   my @tags;
   push(@tags, 'basic') if $self->gencode_basic();
+  push(@tags, 'gencode_primary') if $self->gencode_primary();
   push(@tags, 'Ensembl_canonical') if $self->is_canonical();
 
   # A transcript can have different types of MANE-related attributes (MANE_Select, MANE_Plus_Clinical)
@@ -289,9 +290,6 @@ sub Bio::EnsEMBL::Transcript::summary_as_hash {
     my $mane_type = $mane->type();
     push(@tags, $mane_type) if ($mane_type);
   }
-
-  my $gencode_primary = $self->get_all_Attributes('gencode_primary');
-  push(@tags, 'GENCODE Primary') if @{$gencode_primary};
 
   $summary{'tag'} = \@tags if @tags;
 


### PR DESCRIPTION
## Description

GENCODE Primary tag must be considered in E!112 files (applicable to human).

## Use case

Patching the string to comply with the agreed standard: `gencode_primary`

## Benefits

Keep the format consistent since day 1

## Possible Drawbacks

None

## Testing

N/A - patched the string only.

Dependencies
------------

None
