### PR TITLE
Fixed gencode_primary string

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_GFF3.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_GFF3.pm
@@ -264,7 +264,7 @@ sub Bio::EnsEMBL::Transcript::summary_as_hash {
 
   my @tags;
   push(@tags, 'basic') if $self->gencode_basic();
-  push(@tags, 'GENCODE primary') if $self->gencode_primary();
+  push(@tags, 'gencode_primary') if $self->gencode_primary();
   push(@tags, 'Ensembl_canonical') if $self->is_canonical();
   
   # A transcript can have different types of MANE-related attributes (MANE_Select, MANE_Plus_Clinical)

--- a/modules/Bio/EnsEMBL/Production/Pipeline/GFF3/DumpFile.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/GFF3/DumpFile.pm
@@ -280,7 +280,7 @@ sub Bio::EnsEMBL::Transcript::summary_as_hash {
 
   my @tags;
   push(@tags, 'basic') if $self->gencode_basic();
-  push(@tags, 'GENCODE primary') if $self->gencode_primary();
+  push(@tags, 'gencode_primary') if $self->gencode_primary();
   push(@tags, 'Ensembl_canonical') if $self->is_canonical();
 
   # A transcript can have different types of MANE-related attributes (MANE_Select, MANE_Plus_Clinical)


### PR DESCRIPTION
## Description

"GENCODE Primary" tag should be `gencode_primary` also for consistency with E!112

## Use case

Patching the string to comply with the agreed standard: `gencode_primary`

## Benefits

Keep the format consistent since day 1

## Possible Drawbacks

None

## Testing

N/A - patched the string only.

Dependencies
------------

None
