### PR TITLE
Changed GENCODE Basic tag to 'gencode_basic'

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_GFF3.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_GFF3.pm
@@ -263,7 +263,7 @@ sub Bio::EnsEMBL::Transcript::summary_as_hash {
   $summary{'transcript_support_level'} = $self->tsl if $self->tsl;
 
   my @tags;
-  push(@tags, 'basic') if $self->gencode_basic();
+  push(@tags, 'gencode_basic') if $self->gencode_basic();
   push(@tags, 'gencode_primary') if $self->gencode_primary();
   push(@tags, 'Ensembl_canonical') if $self->is_canonical();
   

--- a/modules/Bio/EnsEMBL/Production/Pipeline/GFF3/DumpFile.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/GFF3/DumpFile.pm
@@ -279,7 +279,7 @@ sub Bio::EnsEMBL::Transcript::summary_as_hash {
   $summary{'transcript_support_level'} = $self->tsl if $self->tsl;
 
   my @tags;
-  push(@tags, 'basic') if $self->gencode_basic();
+  push(@tags, 'gencode_basic') if $self->gencode_basic();
   push(@tags, 'gencode_primary') if $self->gencode_primary();
   push(@tags, 'Ensembl_canonical') if $self->is_canonical();
 


### PR DESCRIPTION
## Description

Changing the "GENCODE Basic" tag (`basic`) to `gencode_basic` for harmonising it to GENCODE Primary and improved readability.

## Use case

Sister PR to #918 - this one against `main`

Changing the "GENCODE Basic" tag (`basic`) to `gencode_basic` for harmonising it to GENCODE Primary and improved readability, as per ENSINT-1885.

## Benefits

Changing the "GENCODE Basic" tag (`basic`) to `gencode_basic` for harmonising it to GENCODE Primary and improved readability.

## Possible Drawbacks

Potentially breaking downstream parsers

## Testing

N/A

Dependencies
------------

None
