### PR TITLE
Removed cds and hardmasked from dumps

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Genome_FASTA.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Genome_FASTA.pm
@@ -35,7 +35,7 @@ sub param_defaults {
   return {
     %{$self->SUPER::param_defaults},
     data_type      => 'sequence',
-    data_types     => ['unmasked', 'softmasked', 'hardmasked'],
+    data_types     => ['unmasked', 'softmasked'],
     file_type      => 'fa',
     # For BLAST generation we don't need the timestamped files to be generated
       # TODO NEED revision
@@ -64,7 +64,7 @@ sub run {
 
   my $um_filename = $$filenames{'unmasked'};
   my $sm_filename = $$filenames{'softmasked'};
-  my $hm_filename = $$filenames{'hardmasked'};
+  #my $hm_filename = $$filenames{'hardmasked'};
 
 
   #set timestamped dir for FTP dumps


### PR DESCRIPTION
This update removes cds from genset_FASTA and removes hardmasked from genome_FASTA within the file dumps. Testing with http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensadmin&host=mysql-ens-hive-prod-1&port=4575&dbname=ens2020_2020_file_dump_core_1981&passwd=xxxxx

Do not merge until all tests pass.