### PR TITLE
Updated JSON remodeler to stop Experimental push on scalar is now for…

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/JSON/JsonRemodeller.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/JSON/JsonRemodeller.pm
@@ -292,7 +292,10 @@ sub merge_xrefs {
         $obj->{$dbname} = [];
       }
       for my $ann ( @{ $subobj->{$dbname} } ) {
-        push $obj->{$dbname}, $self->copy_hash($ann);
+        if (ref($obj->{$dbname}) ne 'ARRAY') {
+          $obj->{$dbname} = [];
+        }
+        push @{ $obj->{$dbname} }, $self->copy_hash($ann);
       }
     }
   }


### PR DESCRIPTION
This simple fix just stops the perl error: Experimental push on scalar is now forbidden when running the filedumps with new perl version