### PR TITLE
Update GENCODE tag info in header

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/GTF/DumpFile.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/GTF/DumpFile.pm
@@ -383,7 +383,8 @@ feature for the position of this on the genome
 - cds_start_NF: the coding region start could not be confirmed
 - mRNA_end_NF: the mRNA end could not be confirmed
 - mRNA_start_NF: the mRNA start could not be confirmed.
-- basic: the transcript is part of the gencode basic geneset
+- gencode_basic: the transcript is part of the gencode basic geneset
+- gencode_primary: the transcript is part of the gencode primary geneset
 
 Comments
 


### PR DESCRIPTION
Related to https://github.com/Ensembl/ensembl-production/pull/918.

This PR updates the GTF header info to reflect recent changes to:

- `basic` to `gencode_basic`
- `primary` to `gencode_primary`