### PR TITLE
Xref bugfix

### DIFF
--- a/nextflow/config/xref.config
+++ b/nextflow/config/xref.config
@@ -17,6 +17,7 @@ params.reuse_db = 0
 params.skip_preparse = 1
 params.split_files_by_species = 1
 params.tax_ids_file = ''
+params.update_mode = 0
 
 params.base_path = ''
 params.clean_files = 1
@@ -70,11 +71,11 @@ profiles {
 
     withLabel: dm {
         queue = 'datamover'
-        time = '2h'
+        time = '3h'
         memory = 2.GB
     }
     withLabel:mem4GB {
-        time = '3d'
+        time = '5d'
         memory = 4.GB
     }
   }

--- a/nextflow/workflows/xrefDownload.nf
+++ b/nextflow/workflows/xrefDownload.nf
@@ -18,6 +18,7 @@ println """\
         sources_config_file       : ${params.sources_config_file}
         clean_dir                 : ${params.clean_dir}
         tax_ids_file              : ${params.tax_ids_file}
+        update_mode               : ${params.update_mode}
         """
         .stripIndent()
 
@@ -57,6 +58,9 @@ def helpMessage() {
 
     --tax_ids_file              (optional)      Path to the file containing the taxonomy IDs of the species to extract data for.
                                                 Used to update the data for the provided species.
+
+    --update_mode               (optional)      If set to 1, pipeline is in update mode, refreshing/updating its data for new taxonomy IDs.
+                                                Only used if --tax_ids_file is set. Default: 0
   """.stripIndent()
 }
 
@@ -198,7 +202,7 @@ process CleanupSplitSource {
   }
 
   """
-  perl ${params.perl_scripts_dir}/cleanup_and_split_source.pl --base_path ${params.base_path} --log_timestamp $timestamp --source_db_url ${params.source_db_url} --name $src_name --clean_dir ${params.clean_dir} --skip_download ${params.skip_download} --clean_files ${params.clean_files} $cmd_params
+  perl ${params.perl_scripts_dir}/cleanup_and_split_source.pl --base_path ${params.base_path} --log_timestamp $timestamp --source_db_url ${params.source_db_url} --name $src_name --clean_dir ${params.clean_dir} --clean_files ${params.clean_files} --update_mode ${params.update_mode} $cmd_params
   """
 }
 


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Species files were being appended to even if not in update mode.

## Use case

Under the scenario of a cleanup job failing, the script would start again and append data to existing species files, leading to duplicate data and making the files bigger. This change deletes all files at the start of a cleanup run before creating the needed ones. This happens only when the pipeline/script is not in update mode, where specific taxonomy IDs are provided.

Also, time limits were increased a bit since jobs seem to be taking more time than previously thought.

## Benefits

Files have the appropriate size.

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
