### PR TITLE
Fixed  as per ENSPROD-9493

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/AlphaFold/InsertProteinFeatures.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/AlphaFold/InsertProteinFeatures.pm
@@ -164,7 +164,7 @@ sub run {
             -db            => 'alphafold',
             -db_version    => $alpha_version,
             -db_file       => $self->param('db_dir') . '/accession_ids.csv',
-            -display_label => 'AlphaFold DB import',
+            -display_label => 'AFDB-ENSP mapping',
             -displayable   => '1',
             -description   => 'Protein features based on AlphaFold predictions, mapped with GIFTS or UniParc'
     );


### PR DESCRIPTION
## Description

Prior to 113 the alphafold loading pipeline was setting analysis_description.display_label = "AlphaFold DB import" for alphafold. The website was expecting the value "AFDB-ENSP mapping", so links in the VEP results table were not being correctly displayed.

## Benefits

Make the web site happy again

## Possible Drawbacks

None

## Testing

Test suite completed successfully

Dependencies
------------

None
