### PR TITLE
Fix use of keys on a scalar

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Ga4ghChecksum/ChecksumGenerator.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Ga4ghChecksum/ChecksumGenerator.pm
@@ -218,7 +218,7 @@ sub all_hashes {
     } ## end foreach my $slice (@slices)
 
     for my $seq_type (keys %$batch) {
-        for my $attrib_table (keys $batch->{$seq_type}) {
+        for my $attrib_table (keys %{$batch->{$seq_type}}) {
             $attribute_adaptor->store_batch_on_Object($attrib_table, $batch->{$seq_type}->{$attrib_table}, 1000);
         }
     }


### PR DESCRIPTION

## Description

There was an experimental Perl feature that allowed the use of a scalar containing a hashref in place of a hash, e.g. `keys $hashref`. That feature was deprecated, then removed in a recent update of Perl. This PR fixes such a use, converting the hashref to a hash for keys, e.g. `keys %{$hashref}`.

## Testing

Changed in the live checkout and used to initialise a pipeline.
