### PR TITLE
Xref fixes

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/XrefProcess_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/XrefProcess_conf.pm
@@ -173,6 +173,7 @@ sub pipeline_analyses {
       base_path => $self->o('base_path'),
       release   => $self->o('release')
     },
+    -max_retry_count => 0,
     -flow_into  => {
       '2->A' => 'dump_xref',
       'A->1' => 'schedule_mapping'
@@ -187,6 +188,7 @@ sub pipeline_analyses {
       release     => $self->o('release'),
       config_file => $self->o('config_file')
     },
+    -max_retry_count => 0,
     -flow_into  => { 2 => 'align_factory' },
     -rc_name    => '1GB',
   },


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Fixes for issues in 113 run.

## Use case

The Alignment module wasn't handling errors in exonerate, leading to the job displaying as successful even if exonerate fails (in this case it was failing because of memory limit). This change causes the job to fail in this case, allowing the user to change resource classes accordingly. In addition, because of the way the DumpEnsembl module is written with saving time on reruns as a priority, an error there is leading to the dump files being incomplete. To handle that, this change sets the retry value to 0, thus not allowing the retry to occur automatically. In case of failure, the job will display as failed and the user will have to manually delete the existing dump files of the species before resetting the job. This behavior was also added into DumpXref since the code is similar, even though no errors were detected in that step.

## Benefits

Proper job failures are now displayed in the alignment step.

## Possible Drawbacks

The dumping change requires manual intervention from the user. However, because of the time constraints, keeping the time saving code in there is a priority.

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
