### PR TITLE
Bugfix/pf uniparc gunzip

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProteinFeatures_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ProteinFeatures_conf.pm
@@ -75,7 +75,7 @@ sub default_options {
 
     interpro_file    => 'names.dat',
     interpro2go_file => 'interpro2go',
-    uniparc_file     => 'upidump.lis',
+    uniparc_file     => 'upidump.lis.gz',
     mapping_file     => 'idmapping_selected.tab.gz',
 
     # Files are retrieved and stored locally with the same name.

--- a/modules/Bio/EnsEMBL/Production/Pipeline/ProteinFeatures/LoadUniParc.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/ProteinFeatures/LoadUniParc.pm
@@ -53,7 +53,7 @@ sub run {
     $dbh->do($index_2) or self->throw($dbh->errstr);
 
     #delete upidump file from pipeline direcotry after loading into hive db
-    unlink  $uniparc_file or $self->throw("unable to delete $uniparc_file");
+    unlink  $uniparc_file or $self->throw("unable to delete $uniparc_file: $!");
 
   } else {
     $self->throw("Checksum file '$uniparc_file' does not exist");

--- a/modules/Bio/EnsEMBL/Production/Pipeline/ProteinFeatures/LoadUniParc.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/ProteinFeatures/LoadUniParc.pm
@@ -38,7 +38,7 @@ sub run {
         $uniparc_file_decompress =~ s/\.gz$//;
         gunzip $uniparc_file => $uniparc_file_decompress  or $self->throw("gunzip failed: $GunzipError");
         #delete compressed file .gz
-        unlink  $uniparc_file or $self->throw("unable to delete $uniparc_file");
+        unlink  $uniparc_file or $self->throw("unable to delete $uniparc_file: $!");
         $uniparc_file = $uniparc_file_decompress;
     }
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/ProteinFeatures/LoadUniParc.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/ProteinFeatures/LoadUniParc.pm
@@ -37,6 +37,8 @@ sub run {
         my $uniparc_file_decompress = $uniparc_file;
         $uniparc_file_decompress =~ s/\.gz$//;
         gunzip $uniparc_file => $uniparc_file_decompress  or $self->throw("gunzip failed: $GunzipError");
+        #delete compressed file .gz
+        unlink  $uniparc_file or $self->throw("unable to delete $uniparc_file");
         $uniparc_file = $uniparc_file_decompress;
     }
 
@@ -50,9 +52,14 @@ sub run {
     my $index_2 = 'ALTER TABLE uniparc ADD KEY md5sum_idx (md5sum) USING HASH';
     $dbh->do($index_2) or self->throw($dbh->errstr);
 
+    #delete upidump file from pipeline direcotry after loading into hive db
+    unlink  $uniparc_file or $self->throw("unable to delete $uniparc_file");
+
   } else {
     $self->throw("Checksum file '$uniparc_file' does not exist");
   }
+
+
 }
 
 1;


### PR DESCRIPTION
## Description
Download and uncompress the gzipped uniparc dump file in the protein features pipeline.

## Benefits
Handles both compressed and uncompressed file 
Deletes upidumps files from pipeline dir after loading into hive db 

## Possible Drawbacks
None

