### PR TITLE
Fixed non-existing resource class

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/AlphaDBImport_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/AlphaDBImport_conf.pm
@@ -186,7 +186,7 @@ sub pipeline_analyses {
             -parameters => {
                 datacheck_names => [ 'CheckAlphafoldEntries' ],
             },
-            -rc_name    => '200M',
+            -rc_name    => '500M',
         },
         {
             -logic_name        => 'cleanup',


### PR DESCRIPTION
## Description

The AFold pipeline fails init because of non-existing resource class (200M) in `datacheck` analysis.
Grabbed the minimum available (500M) to make it work.

## Use case

Needed to instantiate the AFold pipeline, which turned out not being feasible.

## Benefits

Instantiate and run the pipeline.

## Possible Drawbacks

Minimal suboptimal use of resources (RAM).

## Testing

Manually and successfully instantiated the pipeline.

Dependencies
------------

Base_conf.pm in the same repo, which defines the available resource classes.