### PR TITLE
Minor bugfixes and updates for the XrefDownload pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/Base_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/Base_conf.pm
@@ -74,6 +74,7 @@ sub resource_classes {
     );
 
     my %memory = (
+        '100M'           => '100',
         '500M'           => '500',
         '1GB'            => '1000',
         '2GB'            => '2000',

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/XrefDownload_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/XrefDownload_conf.pm
@@ -128,7 +128,7 @@ sub pipeline_analyses {
       -rc_name    => 'default'
     },
     {
-      -logic_name => 'checksum_W',
+      -logic_name => 'checksum',
       -module     => 'Bio::EnsEMBL::Production::Pipeline::Xrefs::Checksum',
       -comment    => 'Adds all checksum files into a single file and loads it into the checksum_xref table.',
       -parameters => {

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/gencode_sources.json
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/gencode_sources.json
@@ -16,7 +16,7 @@
     {
       "name" : "UniParc",
       "parser" : "ChecksumParser",
-      "file" : "https://ftp.ebi.ac.uk/pub/contrib/uniparc/upidump.lis",
+      "file" : "https://ftp.ebi.ac.uk/pub/contrib/uniparc/upidump.lis.gz",
       "db" : "checksum",
       "priority" : 1
     },

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_all_sources.json
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_all_sources.json
@@ -9,7 +9,7 @@
     {
       "name" : "UniParc",
       "parser" : "ChecksumParser",
-      "file" : "https://ftp.ebi.ac.uk/pub/contrib/uniparc/upidump.lis",
+      "file" : "https://ftp.ebi.ac.uk/pub/contrib/uniparc/upidump.lis.gz",
       "db" : "checksum",
       "priority" : 1
     },

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_sources.json
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_sources.json
@@ -16,7 +16,7 @@
     {
       "name" : "UniParc",
       "parser" : "ChecksumParser",
-      "file" : "https://ftp.ebi.ac.uk/pub/contrib/uniparc/upidump.lis",
+      "file" : "https://ftp.ebi.ac.uk/pub/contrib/uniparc/upidump.lis.gz",
       "db" : "checksum",
       "priority" : 1
     },

--- a/src/python/ensembl/production/xrefs/config/xref_all_sources.json
+++ b/src/python/ensembl/production/xrefs/config/xref_all_sources.json
@@ -16,7 +16,7 @@
     {
       "name" : "UniParc",
       "parser" : "ChecksumParser",
-      "file" : "https://ftp.ebi.ac.uk/pub/contrib/uniparc/upidump.lis",
+      "file" : "https://ftp.ebi.ac.uk/pub/contrib/uniparc/upidump.lis.gz",
       "db" : "checksum",
       "priority" : 1
     },


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

-Updated analysis name from 'checksum_W' to 'checksum' in the XrefDownload configuration, since it didn't match the name used in the data flow.
-Added resource class 100M since it was required by analysis 'checksum' (100M_W) and 'cleanup_refseq_dna' (100M_D).
-Updated the file name for UniParc data download: the unidump.lis file is gzipped now.

## Use case



## Benefits

The XrefDownload eHive pipeline will fail to intialise or stop without these fixes.
The UniParc URL will probably affect the XrefDownload nextflow pipeline too.

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._

## Testing

- [ ] Have you added/modified unit tests to test the changes?
No
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
