### PR TITLE
fix delete group param in dbcopy pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DbCopy_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DbCopy_conf.pm
@@ -39,6 +39,7 @@ sub default_options {
     # Database type factory
     groups => 1,
     group  => [],
+    delete_group => [], 
 
     # Named database factory
     dbname => [],
@@ -200,7 +201,7 @@ sub pipeline_analyses {
       -max_retry_count => 1,
       -parameters      => {
                             ensembl_release => $self->o('delete_release'),
-                            group           => $self->o('delete_group'),
+                            group           => (ref($self->o('delete_group')) eq 'ARRAY' && @{$self->o('delete_group')}) ? $self->o('delete_group') : $self->o('group'),
                             groups          => $self->o('groups'),
                           },
       -flow_into       => {

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DbCopy_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DbCopy_conf.pm
@@ -59,7 +59,6 @@ sub default_options {
     # Drop databases from target, by default the same set that will be copied
     delete_db          => 0,
     delete_release     => $self->o('ensembl_release'),
-    delete_group       => $self->o('group'),
     delete_dbname      => $self->o('dbname'),
     delete_marts       => $self->o('marts'),
     delete_compara     => $self->o('compara'),


### PR DESCRIPTION
fix error :  Can't use string ("variation") as an ARRAY  in dbcopy pipeline 
