### PR TITLE
Analyze and optimize after gene-tree highlighting

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/Base_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/Base_conf.pm
@@ -24,7 +24,7 @@ use warnings;
 use base ('Bio::EnsEMBL::Hive::PipeConfig::EnsemblGeneric_conf');
 
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
-use Bio::EnsEMBL::Hive::Version 2.5;
+use Bio::EnsEMBL::Hive::Version v2.5;
 
 use File::Spec::Functions qw(catdir);
 


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

This PR addresses slow queries involving the `member_xref` table following the loading of GO and InterPro xrefs in the gene-tree highlighting pipeline.

With these changes, tables `external_db` and `member_xref` are analysed and optimised after xrefs have been loaded, and before running the `MemberXrefAccessTime` datacheck.

In addition, to ensure eHive versions can be correctly compared, `use Bio::EnsEMBL::Hive::Version` statements have been changed so that versions are v-strings.

## Use case

Previous releases have seen slow queries on the `member_xref` table. In release 109 this issue ([ENSWEB-6789](https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6789)) was not identified until very close to the release date, resulting in unavailability of Metazoa gene-tree views for several days after release.

In subsequent releases, the `MemberXrefAccessTime` datacheck pinpointed the gene-tree pipeline as the most appropriate opportunity to address these slow query times.

## Benefits

Assuming it is successful, this should save time when running the gene-tree highlighting pipeline by reducing the failure rate of the `MemberXrefAccessTime` datacheck, and eliminate one possible source of issues with non-vertebrate gene-tree views.

## Possible Drawbacks

No drawbacks anticipated.

## Testing

A test run of the `GeneTreeHighlighting` pipeline has completed successfully.

For info on the testing pipeline, see Compara ticket [ENSCOMPARASW-8019](https://www.ebi.ac.uk/panda/jira/browse/ENSCOMPARASW-8019).

- [ ] Have you added/modified unit tests to test the changes?
  No unit tests have been added/modified.
- [ ] If so, do the tests pass?
  N/A
- [ ] Have you run the entire test suite and no regression was detected?
  N/A
- [ ] TravisCI passed on your branch
   TBD

Dependencies
------------

The updated pipeline makes use of the runnable `Bio::EnsEMBL::Compara::RunnableDB::FunnelCheck`, which is a module of the existing dependency, [ensembl-compara](https://github.com/Ensembl/ensembl-compara).
