### PR TITLE
set principle isoform score to 1

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/AttributeAnnotation/LoadAppris.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/AttributeAnnotation/LoadAppris.pm
@@ -103,11 +103,14 @@ sub load_file {
 
   my $file = $self->param_required('file');
 
-  my $label2code = { 'PRINCIPAL:1'   => [ 'appris', 'principal1' ],
+  my $label2code = { 
+                     'PRINCIPAL:0'   => [ 'appris', 'principal1' ], 
+                     'PRINCIPAL:1'   => [ 'appris', 'principal1' ],
                      'PRINCIPAL:2'   => [ 'appris', 'principal2' ],
                      'PRINCIPAL:3'   => [ 'appris', 'principal3' ],
                      'PRINCIPAL:4'   => [ 'appris', 'principal4' ],
                      'PRINCIPAL:5'   => [ 'appris', 'principal5' ],
+                     'ALTERNATIVE:0' => [ 'appris', 'alternative1' ],
                      'ALTERNATIVE:1' => [ 'appris', 'alternative1' ],
                      'ALTERNATIVE:2' => [ 'appris', 'alternative2' ], };
 


### PR DESCRIPTION
 Noticed discrepancies regarding principle isoform scoring in appris data. According to the help 
 documentation(https://appris.bioinfo.cnio.es/#/help/scores), principal isoforms are typically scored from 1 to 5. 
However, for some human entries, we observe a score of 0 for the "PRINCIPAL" designation and also for "ALTERNATIVE" isoforms, as seen in this example:
ENSG00000117501 ENST00000367759 PRINCIPAL:0

## Fix
The resultant records  are manual overrides when  APPRIS is not picking up the correct coding transcript, these should be considered as scores with 1 


