### PR TITLE
Feature/blast header

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_FASTA.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_FASTA.pm
@@ -195,8 +195,8 @@ sub header {
   if ($self->param_is_defined('fasta_header_prefix')){
     
     $prefix = $self->param('fasta_header_prefix');
+
     #add addition attributes version & is_canonical for fata header only 
-    
     if ($seq_type eq 'cdna' || $seq_type eq 'cds') {
       push @attributes, 'version:'.$transcript->version;
       push @attributes, 'is_canonical:'.$transcript->is_canonical();

--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_FASTA.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_FASTA.pm
@@ -198,10 +198,10 @@ sub header {
     #add addition attributes version & is_canonical for fata header only 
     
     if ($seq_type eq 'cdna' || $seq_type eq 'cds') {
-      push @attributes, 'version:'.$transcript->stable_id_version;
+      push @attributes, 'version:'.$transcript->version;
       push @attributes, 'is_canonical:'.$transcript->is_canonical();
     } elsif ($seq_type eq 'pep') {
-      push @attributes, 'version:'.$transcript->translation->stable_id_version;
+      push @attributes, 'version:'.$transcript->translation->version;
       push @attributes, 'is_canonical:'.$transcript->is_canonical;
     }
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_FASTA.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_FASTA.pm
@@ -193,7 +193,18 @@ sub header {
   my $prefix = '';
 
   if ($self->param_is_defined('fasta_header_prefix')){
+    
     $prefix = $self->param('fasta_header_prefix');
+    #add addition attributes version & is_canonical for fata header only 
+    
+    if ($seq_type eq 'cdna' || $seq_type eq 'cds') {
+      push @attributes, 'version:'.$transcript->stable_id_version;
+      push @attributes, 'is_canonical:'.$transcript->is_canonical();
+    } elsif ($seq_type eq 'pep') {
+      push @attributes, 'version:'.$transcript->translation->stable_id_version;
+      push @attributes, 'is_canonical:'.$transcript->is_canonical;
+    }
+
   }
 
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Genome_FASTA.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Genome_FASTA.pm
@@ -75,7 +75,7 @@ sub run {
   #   $self->print_to_file([@$chr, @$non_chr], undef, $sm_filename, '>', $repeat_analyses);
   # }
   if($self->param('unmasked')){
-      $self->unmask($sm_filename, $um_filename);
+      $self->unmask($sm_filename, $um_filename); 
   }
   if($self->param('hardmasked')){
     $self->hardmask($sm_filename, $hm_filename);

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/BlastFileDump_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/BlastFileDump_conf.pm
@@ -80,7 +80,8 @@ sub default_options {
 
         #blast param for new site
         'hardmasked'          => 1,
-        'cds'                 => 1,   
+        'cds'                 => 1, 
+        'unmasked'            => 1,  
         'fasta_header_prefix' => 'ENSEMBL:',
         #genome factory params
       	'dataset_status' => 'Submitted', #fetch genomes with dataset status submitted
@@ -173,7 +174,8 @@ sub pipeline_analyses {
                 blast_index    => 0,
                 blastdb_exe    => $self->o('blastdb_exe'),
                 per_chromosome => $self->o('dna_per_chromosome'),
-                hardmasked  => $self->o('hardmasked'),
+                unmasked       => $self->o('unmasked'),
+                hardmasked     => $self->o('hardmasked'),
                 fasta_header_prefix => $self->o('fasta_header_prefix'),
                 
             },
@@ -207,6 +209,7 @@ sub pipeline_analyses {
                 blast_index    => $self->o('blast_index'),
                 blastdb_exe    => $self->o('blastdb_exe'),
                 per_chromosome => $self->o('dna_per_chromosome'),
+                unmasked       => $self->o('unmasked'),
                 hardmasked     => $self->o('hardmasked'),
                 overwrite      => 1,
                 fasta_header_prefix => $self->o('fasta_header_prefix'),


### PR DESCRIPTION
## Description

Added new attributes (is_canonical, stable Id version ) in the blast fasta header for cds and pep files .
Add unmasked flag to geneset fata module to dump unmasked fasta files  

## Benefits

- Having  version  and is_canonical attributes in fasta header for blast  

## Possible Drawbacks

None

## Testing

No changes. Test suite could run successfully

