### PR TITLE
Fixed bulk update, removed hash type, put limit on concurrent jobs

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ChecksumGenerator_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ChecksumGenerator_conf.pm
@@ -155,7 +155,6 @@ sub pipeline_analyses {
             -language        => 'python3',
             -max_retry_count => 1,
             -parameters      => {
-                hash_type => $self->o('hash_type'),
                 metadata_uri   => $self->o('metadata_uri'),
             },
         },

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ChecksumLoader_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/ChecksumLoader_conf.pm
@@ -114,8 +114,8 @@ sub pipeline_analyses {
             -module            => 'ensembl.production.hive.ensembl_genome_metadata.ChecksumTransfer',
             -language        => 'python3',
             -max_retry_count   => 1,
+            -analysis_capacity => 1,
             -parameters        => {
-                hash_type => $self->o('hash_type'),
                 metadata_uri   => $self->o('metadata_uri'),
             },
             -rc_name           => 'default',

--- a/src/python/ensembl/production/hive/ensembl_genome_metadata/ChecksumTransfer.py
+++ b/src/python/ensembl/production/hive/ensembl_genome_metadata/ChecksumTransfer.py
@@ -81,7 +81,6 @@ class ChecksumTransfer(BaseProdRunnable):
                     AssemblySequence.name.in_(seq_regions.keys())
                 ).all()
 
-                # Map AssemblySequence records to their names for easy access
                 assembly_seq_dict = {seq.name: seq for seq in assembly_seqs}
 
                 # Check Seq_region exists in metadata database but not in our dictionary
@@ -96,19 +95,17 @@ class ChecksumTransfer(BaseProdRunnable):
                         raise ValueError(
                             f"AssemblySequence with name {seq_name} not found in metadata database for assembly {assembly_acc}")
 
-                    # Prepare the update data (EXCLUDE assembly_sequence_id from SET values)
                     update_data = {}
                     if 'md5' in checksums:
                         update_data['md5'] = checksums['md5']
                     if 'sha512t24u' in checksums:
                         update_data['sha512t24u'] = checksums['sha512t24u']
 
-                    if update_data:  # Ensure there's something to update
-                        # Rename bindparam key for primary key to avoid conflict
+                    if update_data:
                         update_data["pk_assembly_sequence_id"] = assembly_seq.assembly_sequence_id
                         updates.append(update_data)
 
-            # Perform the bulk update using the correct syntax
+            # Perform the bulk update
             if updates:
                 stmt = update(AssemblySequence).where(
                     AssemblySequence.assembly_sequence_id == bindparam("pk_assembly_sequence_id")


### PR DESCRIPTION
Fixed the checksum bulk updater to work with sqlalchemy 2.0
Improvements: Faster, no chance of error.
Drawbacks: Will overload the database if too many are ran at once. Concurrent jobs are set to one currently (200 genomes were tested and loaded sequentially in less than an hour)
Removed the params for hash_type in the metadata loader. We should always load both (don't look at who put it in originally) 
Tested and functional.