### PR TITLE
[main] Update xref_all_sources.json

### DIFF
--- a/src/python/ensembl/production/xrefs/config/xref_all_sources.json
+++ b/src/python/ensembl/production/xrefs/config/xref_all_sources.json
@@ -214,7 +214,7 @@
     {
       "name" : "ZFIN_desc",
       "parser" : "ZFINDescParser",
-      "file" : "ftp://zfin.org/pub/transfer/MEOW/zfin_genes.txt",
+      "file" : "https://zfin.org/downloads/genetic_markers.txt",
       "priority" : 1
     },
     {
@@ -226,7 +226,7 @@
     {
       "name" : "Xenbase",
       "parser" : "XenopusJamboreeParser",
-      "file" : "http://ftp.xenbase.org/pub/GenePageReports/GenePageEnsemblModelMapping.txt",
+      "file" : "https://ftp.xenbase.org/pub/GenePageReports/GenePageEnsemblModelMapping_4.1.txt",
       "priority" : 1
     },
     {


### PR DESCRIPTION
In 115, two xref source file locations have changed and have required updates. This is the duplicate PR to #995, where here the changes are for the `main` branch.

1. The FTP for ZFIN became inaccessible, leading to a new source file become required.

2. An updated file from Xenbase is available and should be used.