### PR TITLE
Update to metazoa species to latest assemblies

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpOrtholog_eg_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/DumpOrtholog_eg_conf.pm
@@ -100,7 +100,7 @@ sub default_options {
                     'drosophila_pseudoobscura_gca009870125v2rs',
                     'drosophila_sechellia_gca004382195v2rs',
                     'drosophila_simulans_gca016746395v2rs',
-                    'drosophila_virilis_gca003285735v2rs',
+                    'drosophila_virilis_gca030788295v1rs',
                     'drosophila_willistoni_gca018902025v2rs',
                     'drosophila_yakuba_gca016746365v2rs'
                   ],


### PR DESCRIPTION
## Description

This is a file Metazoa tends to forget it exists until something fails. For e115 _D. virilis_ was updated and we forgot to update it here, so its file is missing in `/nfs/ftp/public/databases/ensembl/projections/ensemblmetazoa` (we have a cron job that alerts us of this).

This PR fixes the issue, once the ortholog projection dump is generated.

_Note:_ I assume the files there are from e115, but let me know if these are still e114 and I will change the PR.
