### PR TITLE
Access canonical only if defined, allow more time

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/LoadFamily/AddFamilyMembers.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/LoadFamily/AddFamilyMembers.pm
@@ -112,7 +112,7 @@ sub run {
                                                                     $genome_db);
     my $existing_canonical;
     if (defined $gene_member) {
-      $existing_canonical = $seq_member_dba->fetch_by_dbID( $gene_member->canonical_member_id );
+      $existing_canonical = $seq_member_dba->fetch_by_dbID( $gene_member->canonical_member_id ) if defined $gene_member->canonical_member_id;
     } else {
       $gene_member =
         Bio::EnsEMBL::Compara::GeneMember->new_from_Gene(

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/LoadFamily_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/LoadFamily_conf.pm
@@ -73,6 +73,7 @@ sub pipeline_analyses {
                       logic_names => $self->o('logic_names')
                      },
       -analysis_capacity => 20,
+      -rc_name    => '1GB_D',
     },
     @{ Bio::EnsEMBL::Compara::PipeConfig::Parts::GeneMemberHomologyStats::pipeline_analyses_fam_stats($self) },
   ];


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

This PR would:
- add an extra check in `AddFamilyMembers` to require that `$gene_member->canonical_member_id` is defined before attempting to fetch an existing canonical member;
- bump up the `add_members` resource class to `1GB_D` in `LoadFamily` pipeline, to allow more time for its jobs to complete.

## Use case

Errors have been encountered while running the InterPro family pipeline on Fungi.

A possible reason for these errors is an attempt to fetch a `SeqMember` by an undefined `canonical_member_id` of an existing `GeneMember` (e.g. gene with stable ID `BP5553_08638` in genome `venustampulla_echinocandica_gca_003357145`).

This may have been brought about in turn by some `add_members` jobs encountering their `RUNLIMIT`.

## Benefits

This PR attempts to address the latter by bumping up the runlimit, and the former by checking that
`$gene_member->canonical_member_id` is defined before using it.

## Possible Drawbacks

The queue time of `add_members` jobs may potentially be increased somewhat by the higher requested runlimit.

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
