### PR TITLE
Remove support for non-indexed vep folder

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FileDumpVEP_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FileDumpVEP_conf.pm
@@ -96,7 +96,6 @@ sub pipeline_analyses {
       -parameters        => {
                               cmd =>
                                 'mkdir -p #target_dir#/#division_name#/variation ;'.
-                                'rsync -avW #pipeline_dir#/#division_name#/dumps/production/ #target_dir#/#division_name#/variation/vep ;'.
                                 'rsync -avW #pipeline_dir#/#division_name#/dumps/web/ #target_dir#/#division_name#/variation/indexed_vep_cache ;',
                               ,
                               target_dir => $self->o('target_dir'),


### PR DESCRIPTION
## Description

From `release/114`, non-indexed vep cache directory is not supported via FTP dumps. This PR implements it through the VEP file dumping pipeline. It affects variation dumps for vertebrates and non-vertebrates.