### PR TITLE
[116] Add new attribute tag to file dumps

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_GFF3.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_GFF3.pm
@@ -266,6 +266,7 @@ sub Bio::EnsEMBL::Transcript::summary_as_hash {
   push(@tags, 'gencode_basic') if $self->gencode_basic();
   push(@tags, 'gencode_primary') if $self->gencode_primary();
   push(@tags, 'Ensembl_canonical') if $self->is_canonical();
+  push(@tags, 'ens_canon_extended') if $self->ens_canon_extended();
   
   # A transcript can have different types of MANE-related attributes (MANE_Select, MANE_Plus_Clinical)
   # We depend on the Bio::EnsEMBL::MANE object to get the specific type

--- a/modules/Bio/EnsEMBL/Production/Pipeline/GFF3/DumpFile.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/GFF3/DumpFile.pm
@@ -282,6 +282,7 @@ sub Bio::EnsEMBL::Transcript::summary_as_hash {
   push(@tags, 'gencode_basic') if $self->gencode_basic();
   push(@tags, 'gencode_primary') if $self->gencode_primary();
   push(@tags, 'Ensembl_canonical') if $self->is_canonical();
+  push(@tags, 'ens_canon_extended') if $self->ens_canon_extended();
 
   # A transcript can have different types of MANE-related attributes (MANE_Select, MANE_Plus_Clinical)
   # We depend on the Bio::EnsEMBL::MANE object to get the specific type


### PR DESCRIPTION
## Description

Havana has requested a new attribute to be added to file dumps (GTF/GFF3) for Release 116.

## Use case

For use in human (and mouse?) as of Release 116. This transcript attribute tag will be printed out in file dumps wherever applicable.

## Benefits

Extra annotation

## Possible Drawbacks

None

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.

Related PRs have been made in these repos:
- https://github.com/Ensembl/ensembl-io/pull/175
- https://github.com/Ensembl/ensembl/pull/738
