### PR TITLE
[116] Add support to add readthrough transcript attrib to GTF/GFF3

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_GFF3.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/FileDump/Geneset_GFF3.pm
@@ -267,6 +267,7 @@ sub Bio::EnsEMBL::Transcript::summary_as_hash {
   push(@tags, 'gencode_primary') if $self->gencode_primary();
   push(@tags, 'Ensembl_canonical') if $self->is_canonical();
   push(@tags, 'ens_canon_extended') if $self->ens_canon_extended();
+  push(@tags, 'readthrough_transcript') if $self->readthrough_transcript();
   
   # A transcript can have different types of MANE-related attributes (MANE_Select, MANE_Plus_Clinical)
   # We depend on the Bio::EnsEMBL::MANE object to get the specific type

--- a/modules/Bio/EnsEMBL/Production/Pipeline/GFF3/DumpFile.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/GFF3/DumpFile.pm
@@ -283,6 +283,7 @@ sub Bio::EnsEMBL::Transcript::summary_as_hash {
   push(@tags, 'gencode_primary') if $self->gencode_primary();
   push(@tags, 'Ensembl_canonical') if $self->is_canonical();
   push(@tags, 'ens_canon_extended') if $self->ens_canon_extended();
+  push(@tags, 'readthrough_transcript') if $self->readthrough_transcript();
 
   # A transcript can have different types of MANE-related attributes (MANE_Select, MANE_Plus_Clinical)
   # We depend on the Bio::EnsEMBL::MANE object to get the specific type

--- a/modules/Bio/EnsEMBL/Production/Pipeline/GTF/DumpFile.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/GTF/DumpFile.pm
@@ -386,6 +386,7 @@ feature for the position of this on the genome
 - gencode_basic: the transcript is part of the gencode basic geneset
 - gencode_primary: the transcript is part of the gencode primary geneset
 - ens_canon_extended: the transcript is part of the Ensembl Canonical Extended set
+- readthrough_transcript: a HAVANA readthrough transcript
 
 Comments
 


### PR DESCRIPTION
## Description

Add the HAVANA readthrough transcript attribute to GTF and GFF file dumps.

## Use case

Users will be able to find the transcript attribute in file dumps.

## Benefits

Users will be able to find the transcript attribute in file dumps.

## Possible Drawbacks

None

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
