### PR TITLE
Update database library

### DIFF
--- a/nextflow/nf-py-scripts/generate_track_api_csv.py
+++ b/nextflow/nf-py-scripts/generate_track_api_csv.py
@@ -28,7 +28,7 @@ import logging
 import os
 import csv
 from sqlalchemy import func, select
-from ensembl.database import DBConnection
+from ensembl.utils.database import DBConnection
 from ensembl.production.metadata.api.models.dataset import DatasetType, Dataset, DatasetSource, DatasetStatus
 from ensembl.production.metadata.api.models.genome import Genome, GenomeDataset
 from ensembl.production.metadata.api.models.organism import Organism, OrganismGroup, OrganismGroupMember

--- a/nextflow/nf-py-scripts/genesearch_solr.py
+++ b/nextflow/nf-py-scripts/genesearch_solr.py
@@ -27,7 +27,7 @@ import ijson
 import logging
 import os
 from sqlalchemy import func
-from ensembl.database import DBConnection
+from ensembl.utils.database import DBConnection
 from sqlalchemy import select, text
 from ensembl.core.models import Gene, Xref, SeqRegion, Analysis, AnalysisDescription, Biotype, AttribType, CoordSystem, \
     SeqRegionAttrib, Transcript, ExternalSynonym, Meta

--- a/nextflow/nf-py-scripts/track_api_loading.py
+++ b/nextflow/nf-py-scripts/track_api_loading.py
@@ -9,7 +9,7 @@ import os
 import requests
 
 from sqlalchemy import func, select
-from ensembl.database import DBConnection
+from ensembl.utils.database import DBConnection
 from ensembl.production.metadata.api.models.dataset import (
     DatasetType,
     Dataset,


### PR DESCRIPTION
Instead of ensembl.database we need to use ensembl.utils.database for due to changes in metadata api.