### PR TITLE
Relax data validation for alphafold data

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/AlphaFold/CreateAlphaDB.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/AlphaFold/CreateAlphaDB.pm
@@ -104,7 +104,7 @@ sub run {
         # A0A2I1PIX0,1,200,AF-A0A2I1PIX0-F1,4
         # Currently, all entries in this file have a unique uniprot accession and
         # have a hit starting at 1
-        unless ($line =~ /^\w+,\d+,\d+,[\w_-]+,\d+$/) {
+        unless ($line =~ /^[\w_-]+,\d+,\d+,[\w_-]+,\d+$/) {
             die "Data error. Line is not what we expect: '$line'";
         }
         my @x = split(",", $line, 2);


### PR DESCRIPTION
The file containing the alphafold data, accession_ids.csv, now has uniprot accessions with a dash. Adapt code that validates this.