### PR TITLE
Set file Name parameter of IO::Compress::Gzip::gzip

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Common/Gzip.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Common/Gzip.pm
@@ -33,6 +33,7 @@ package Bio::EnsEMBL::Production::Pipeline::Common::Gzip;;
 use strict;
 use warnings;
 use base qw/Bio::EnsEMBL::Production::Pipeline::Common::Base/;
+use File::Basename qw(fileparse);
 use IO::Compress::Gzip qw(gzip $GzipError) ;
 
 sub fetch_input {
@@ -49,10 +50,11 @@ sub run {
         push(@compress, $self->param_required('compress'))
     }
     foreach my $file (@compress) {
+        my ($file_name) = fileparse($file);
         my $output_file = $file.'.gz';
         eval {
             local $SIG{PIPE} = sub { die "gzip interrupted by SIGPIPE\n" };
-            gzip $file => $output_file
+            gzip $file => $output_file, Name => $file_name
                 or die "gzip failed: $GzipError\n";
             unlink $file;
         };


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

This PR would fix an issue whereby a gzip-compressed homology annotation TSV file that is decompressed in a Windows or Ubuntu GUI recreates the absolute file path of the original file in the decompression output, requiring the user to navigate through about a  dozen directories to access the decompressed file.

This issue does not affect all homology annotation TSV files.

For example, it affects the `2023_04` Mouse reference homology annotation TSV file ( [Mus_musculus-GCA_000001635.9-2023_04-homology.tsv.gz](https://ftp.ebi.ac.uk/pub/ensemblorganisms/Mus_musculus/GCA_000001635.9/ensembl/homology/2023_04/Mus_musculus-GCA_000001635.9-2023_04-homology.tsv.gz) ) but not the `2024_11` Mouse reference homology annotation file ( [Mus_musculus-GCA_000001635.9-2024_11-homology.tsv.gz](https://ftp.ebi.ac.uk/pub/ensemblorganisms/Mus_musculus/GCA_000001635.9/ensembl/homology/2024_11/Mus_musculus-GCA_000001635.9-2024_11-homology.tsv.gz) ). The issue manifests even in very recently generated homology annotation TSV files (e.g. [Amanita_rubescens-GCA_965266945.1-2025_11-homology.tsv.gz](https://ftp.ebi.ac.uk/pub/ensemblorganisms/Amanita_rubescens/GCA_965266945.1/ensembl/homology/2025_11/Amanita_rubescens-GCA_965266945.1-2025_11-homology.tsv.gz) ).

The issue may be manifesting inconsistently because different pipelines may have been used to compress homology annotation files destined for the Ensembl Beta FTP. Some pipelines are configured to use `Bio::EnsEMBL::Production::Pipeline::Common::Gzip` (e.g. [FileDump](https://github.com/Ensembl/ensembl-production/blob/18804493153cfafd11ee84a68dcb93075d1170b6/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FileDump_conf.pm#L265) and [FileDumpHomologyStatsMVP](https://github.com/Ensembl/ensembl-production/blob/18804493153cfafd11ee84a68dcb93075d1170b6/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/FileDumpHomologyStatsMVP_conf.pm#L193)), while others are configured to use the `gzip` command-line tool (e.g. [HomologyAnnotation](https://github.com/Ensembl/ensembl-compara/blob/a4150f7a2ca7340533133f0e024e8581a6133558/modules/Bio/EnsEMBL/Compara/PipeConfig/Parts/PerSpeciesCopyFactory.pm#L136)).

Having tested both, it appears that the issue affects the `Bio::EnsEMBL::Production::Pipeline::Common::Gzip` runnable.

This PR would address the issue by updating the runnable to set the `Name` parameter to the basename of the input `$file` to be compressed.

## Use case

This would benefit users who download homology annotation TSV files from the Ensembl Beta FTP site via the GUI of Windows or Ubuntu on a laptop/desktop.

## Benefits

This would make homology annotation TSV files easier to access for Windows and Ubuntu users.

## Possible Drawbacks

None expected.

## Testing

- [ ] Have you added/modified unit tests to test the changes?
       I have not updated the unit test for runnable `Bio::EnsEMBL::Production::Pipeline::Common::Gzip` as I have been unable to find it.
- [ ] If so, do the tests pass?
- [x] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

The change has been tested by downloading `Mus_musculus-GCA_000001635.9-2023_04-homology.tsv.gz`, decompressing it and recompressing it using the updated `Bio::EnsEMBL::Production::Pipeline::Common::Gzip` module:
```bash
wget https://ftp.ebi.ac.uk/pub/ensemblorganisms/Mus_musculus/GCA_000001635.9/ensembl/homology/2023_04/Mus_musculus-GCA_000001635.9-2023_04-homology.tsv.gz

gunzip Mus_musculus-GCA_000001635.9-2023_04-homology.tsv.gz

standaloneJob.pl Bio::EnsEMBL::Production::Pipeline::Common::Gzip \
    -compress /hps/nobackup/flicek/ensembl/compara/twalsh/Mus_musculus-GCA_000001635.9-2023_04-homology.tsv
```

When decompressing the resulting gzip file in the GUI of both Windows and Ubuntu devices, it was immediately accessible.


Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.

The updated `Bio::EnsEMBL::Production::Pipeline::Common::Gzip` runnable makes use of the `File::Basename` package, which is already in use within other `Bio::EnsEMBL::Production` modules.