### PR TITLE
Set Name param of IO::Compress::Gzip::gzip

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Common/Gzip.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Common/Gzip.pm
@@ -33,6 +33,7 @@ package Bio::EnsEMBL::Production::Pipeline::Common::Gzip;;
 use strict;
 use warnings;
 use base qw/Bio::EnsEMBL::Production::Pipeline::Common::Base/;
+use File::Basename qw(fileparse);
 use IO::Compress::Gzip qw(gzip $GzipError) ;
 
 sub fetch_input {
@@ -49,10 +50,11 @@ sub run {
         push(@compress, $self->param_required('compress'))
     }
     foreach my $file (@compress) {
+        my ($file_name) = fileparse($file);
         my $output_file = $file.'.gz';
         eval {
             local $SIG{PIPE} = sub { die "gzip interrupted by SIGPIPE\n" };
-            gzip $file => $output_file
+            gzip $file => $output_file, Name => $file_name
                 or die "gzip failed: $GzipError\n";
             unlink $file;
         };


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

This PR would fix an issue whereby a gzip-compressed homology annotation TSV file that is decompressed in a Windows or Ubuntu GUI recreates the absolute file path of the original file in the decompression output, requiring the user to navigate through multiple directories to access the decompressed file.

It would address the issue by updating the runnable to set the `Name` parameter to the basename of the input `$file` to be compressed.

## Use case

This would benefit users who download gzip-compressed files from the Ensembl FTP via the GUI of Windows or Ubuntu on a laptop/desktop.

## Benefits

This would make affected files easier to access for Windows and Ubuntu users.

## Possible Drawbacks

None expected.

## Testing

- [ ] Have you added/modified unit tests to test the changes?
       I have not updated the unit test for runnable `Bio::EnsEMBL::Production::Pipeline::Common::Gzip` as I have been unable to find it.
- [ ] If so, do the tests pass?
- [x] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

The change has been tested by downloading `Mus_musculus-GCA_000001635.9-2023_04-homology.tsv.gz`, decompressing it and recompressing it using the updated `Bio::EnsEMBL::Production::Pipeline::Common::Gzip` module:
```bash
wget https://ftp.ebi.ac.uk/pub/ensemblorganisms/Mus_musculus/GCA_000001635.9/ensembl/homology/2023_04/Mus_musculus-GCA_000001635.9-2023_04-homology.tsv.gz

gunzip Mus_musculus-GCA_000001635.9-2023_04-homology.tsv.gz

standaloneJob.pl Bio::EnsEMBL::Production::Pipeline::Common::Gzip \
    -compress /hps/nobackup/flicek/ensembl/compara/twalsh/Mus_musculus-GCA_000001635.9-2023_04-homology.tsv
```

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.

The updated `Bio::EnsEMBL::Production::Pipeline::Common::Gzip` runnable makes use of the `File::Basename` package, which is already in use within other `Bio::EnsEMBL::Production` modules.