### PR TITLE
Add transcript attrib to JSON output 

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/JSON/JsonRemodeller.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/JSON/JsonRemodeller.pm
@@ -104,7 +104,7 @@ sub remodel_gene {
     my $new_transcript =
       $self->copy_hash(
         $transcript,
-        qw/id name description biotype seq_region_name start end strand/
+        qw/id name description biotype seq_region_name start end strand attrib/
       );
     $self->collate_xrefs( $transcript, $new_transcript );
     # process translations

--- a/modules/Bio/EnsEMBL/Production/Pipeline/JSON/genes_schema.json
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/JSON/genes_schema.json
@@ -212,7 +212,7 @@
                     "start",
                     "strand",
                     "xrefs",
-		    "attrib"
+		            "attrib"
                 ],
                 "type": "object",
                 "properties": {
@@ -236,8 +236,17 @@
                         },
                         "TSL": {
                           "type": "string"
+                        },
+                        "gencode_primary": {
+                          "type": "string"
+                        },
+                        "gencode_basic": {
+                          "type": "string"
+                        },
+                        "ens_canon_extended": {
+                          "type": "string"
                         }
-                      }
+                        }
                     },			
                     "exons": {
                         "items": {

--- a/modules/Bio/EnsEMBL/Production/Pipeline/JSON/genes_schema.json
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/JSON/genes_schema.json
@@ -224,6 +224,18 @@
                       "properties": {
                         "is_canonical": {
                           "type": "boolean"
+                        },
+                        "MANE_Select": {
+                          "type": "string"
+                        },
+                        "MANE_Plus_Clinical": {
+                          "type": "string"
+                        },
+                        "apprisq": {
+                          "type": "string"
+                        },
+                        "TSL": {
+                          "type": "string"
                         }
                       }
                     },			


### PR DESCRIPTION

Extend genes JSON transcripts to include an attrib object 
Update genes_schema.json to require attrib (with is_canonical) and allow MANE_Select, MANE_Plus_Clinical, apprisq, TSL.
